### PR TITLE
Fix api not being included in extension build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -594,6 +594,7 @@ function exportChromeJS() {
 
 	var chromeExtensionTask = gulp.src([
 		targetDir + "logManager.js",
+		targetDir + "oneNoteApi.js",
 		PATHS.BUNDLEROOT + "chromeExtension.js"
 	]).pipe(concat("chromeExtension.js")).pipe(gulp.dest(targetDir));
 
@@ -648,8 +649,9 @@ function exportEdgeJS() {
 	var commonTask = exportCommonJS(targetDir);
 
 	var edgeExtensionTask = gulp.src([
-			targetDir + "logManager.js",
-			PATHS.BUNDLEROOT + "edgeExtension.js"
+		targetDir + "logManager.js",
+		targetDir + "oneNoteApi.js",
+		PATHS.BUNDLEROOT + "edgeExtension.js"
 	]).pipe(concat("edgeExtension.js")).pipe(gulp.dest(targetDir));
 
 	var edgeDebugLoggingInjectTask = gulp.src([
@@ -726,6 +728,7 @@ function exportFirefoxJS() {
 
 	var firefoxExtensionTask = gulp.src([
 		targetDir + "logManager.js",
+		targetDir + "oneNoteApi.js",
 		PATHS.BUNDLEROOT + "firefoxExtension.js"
 	]).pipe(concat("firefoxExtension.js")).pipe(gulp.dest(targetDir));
 
@@ -780,8 +783,9 @@ function exportSafariJS() {
 	var commonTask = exportCommonJS(targetDir);
 
 	var safariExtensionTask = gulp.src([
-			targetDir + "logManager.js",
-			PATHS.BUNDLEROOT + "safariExtension.js"
+		targetDir + "logManager.js",
+		targetDir + "oneNoteApi.js",
+		PATHS.BUNDLEROOT + "safariExtension.js"
 	]).pipe(concat("safariExtension.js")).pipe(gulp.dest(targetDir));
 
 	var safariDebugLoggingInjectTask = gulp.src([


### PR DESCRIPTION
Include API in build for each extension's background code. In the case of bookmarklet, the extension lives in clipper.html where oneNoteApi.js is already included as another file.

This has been manually verified to exist in all the extension output files.