### PR TITLE
Check if onInstalled is undefined

### DIFF
--- a/src/scripts/extensions/webExtensionBase/webExtension.ts
+++ b/src/scripts/extensions/webExtensionBase/webExtension.ts
@@ -157,11 +157,14 @@ export class WebExtension extends ExtensionBase<WebExtensionWorker, W3CTab, numb
 	}
 
 	private registerInstallListener() {
-		WebExtension.browser.runtime.onInstalled.addListener(details => {
-			if (details.reason === "install") {
-				this.onInstalled();
-			}
-		});
+		// onInstalled is undefined as of Firefox 48
+		if (WebExtension.browser.runtime.onInstalled) {
+			WebExtension.browser.runtime.onInstalled.addListener(details => {
+				if (details.reason === "install") {
+					this.onInstalled();
+				}
+			});
+		}
 	}
 
 	private registerTabRemoveListener() {


### PR DESCRIPTION
This is undefined in firefox. Currently in prod, we simply don't get the after install page. Everything else works fine though. This will quieten the error spikes we see.