### PR TITLE
No-op instead of attempting to alert from the background in Firefox

### DIFF
--- a/src/scripts/extensions/webExtensionBase/webExtensionWorker.ts
+++ b/src/scripts/extensions/webExtensionBase/webExtensionWorker.ts
@@ -94,7 +94,10 @@ export class WebExtensionWorker extends ExtensionWorkerBase<W3CTab, number> {
 						},
 						clientInfo: this.clientInfo
 					});
-					InjectHelper.alertUserOfUnclippablePage();
+					// In Firefox, alert() is not callable from the background, so it looks like we have to no-op here
+					if (this.clientInfo.get().clipperType !== ClientType.FirefoxExtension) {
+						InjectHelper.alertUserOfUnclippablePage();
+					}
 					resolve(false);
 				} else {
 					WebExtension.browser.tabs.executeScript(this.tab.id, { file: this.injectUrls.webClipperInjectUrl });


### PR DESCRIPTION
Since we can't inject anything into the page to alert the user of a no-op, we would have to actually no-op here. 

Fixes #450