### PR TITLE
(Firefox) Fix textHighlighter.js not being included in the output extension

### DIFF
--- a/src/clipper.html
+++ b/src/clipper.html
@@ -18,7 +18,7 @@
 	</div>
 
 	<script type="text/javascript" src="pdf.combined.js"></script>
-	<script type="text/javascript" src="TextHighlighter.js"></script>
+	<script type="text/javascript" src="textHighlighter.js"></script>
 	<script type="text/javascript" src="URI.min.js"></script>
 	<script type="text/javascript" src="velocity.min.js"></script>
 	<script type="text/javascript" src="mithril.min.js"></script>


### PR DESCRIPTION
Looks like script srcs in Firefox are case-sensitive ...

Fixes #460 