### PR TITLE
Fix the Safari first run issue

### DIFF
--- a/src/scripts/extensions/extensionBase.ts
+++ b/src/scripts/extensions/extensionBase.ts
@@ -48,15 +48,17 @@ export abstract class ExtensionBase<TWorker extends ExtensionWorkerBase<TTab, TT
 		this.auth = new AuthenticationHelper(this.storage, this.logger);
 		this.tooltip = new TooltipHelper(this.storage);
 
+		let clipperFirstRun = false;
+
 		let clipperId = this.storage.getValue(Constants.StorageKeys.clipperId);
 		if (!clipperId) {
 			// New install
+			clipperFirstRun = true;
 			clipperId = ExtensionBase.generateClipperId();
 			this.storage.setValue(Constants.StorageKeys.clipperId, clipperId);
 
 			// Ensure fresh installs don't trigger thats What's New experience
 			this.updateLastSeenVersionInStorageToCurrent();
-			this.onFirstRun();
 		}
 
 		this.clientInfo = new SmartValue<ClientInfo>({
@@ -64,6 +66,10 @@ export abstract class ExtensionBase<TWorker extends ExtensionWorkerBase<TTab, TT
 			clipperVersion: ExtensionBase.getExtensionVersion(),
 			clipperId: clipperId
 		});
+
+		if (clipperFirstRun) {
+			this.onFirstRun();
+		}
 
 		this.initializeUserFlighting();
 

--- a/src/scripts/extensions/safari/safariExtension.ts
+++ b/src/scripts/extensions/safari/safariExtension.ts
@@ -30,20 +30,26 @@ export class SafariExtension extends ExtensionBase<SafariWorker, SafariBrowserTa
 
 		// Listen for the Toolbar button it be invoked
 		safari.application.addEventListener("command", (event: SafariValidateEvent) => {
-			// Defined in "Info.plist"
-			if (event.command === "ClipperInvoker") {
-				this.invokeClipperInCurrentTab({ invokeSource: InvokeSource.ExtensionButton }, { invokeMode: InvokeMode.Default });
-			} else if (event.command === "ContextClipperInvoker") {
-				this.invokeClipperInCurrentTab({ invokeSource: InvokeSource.ContextMenu }, { invokeMode: InvokeMode.Default });
-			} else if (event.command === "ContextClipperInvokerWithImage") {
-				this.invokeClipperInCurrentTab({ invokeSource: InvokeSource.ContextMenu }, {
-					invokeDataForMode: this.currentContextItemParameter.parameters.src,
-					invokeMode: InvokeMode.ContextImage
-				});
-			} else if (event.command === "ContextClipperInvokerWithSelection") {
-				this.invokeClipperInCurrentTab({ invokeSource: InvokeSource.ContextMenu }, {
-					invokeMode: InvokeMode.ContextTextSelection
-				});
+			switch (event.command) {
+				case "ClipperInvoker":
+					this.invokeClipperInCurrentTab({ invokeSource: InvokeSource.ExtensionButton }, { invokeMode: InvokeMode.Default });
+					break;
+				case "ContextClipperInvoker":
+					this.invokeClipperInCurrentTab({ invokeSource: InvokeSource.ContextMenu }, { invokeMode: InvokeMode.Default });
+					break;
+				case "ContextClipperInvokerWithImage":
+					this.invokeClipperInCurrentTab({ invokeSource: InvokeSource.ContextMenu }, {
+						invokeDataForMode: this.currentContextItemParameter.parameters.src,
+						invokeMode: InvokeMode.ContextImage
+					});
+					break;
+				case "ContextClipperInvokerWithSelection":
+					this.invokeClipperInCurrentTab({ invokeSource: InvokeSource.ContextMenu }, {
+						invokeMode: InvokeMode.ContextTextSelection
+					});
+					break;
+				default:
+					break;
 			}
 		}, false);
 
@@ -74,18 +80,8 @@ export class SafariExtension extends ExtensionBase<SafariWorker, SafariBrowserTa
 
 	protected onFirstRun() {
 		// Send users to our installed page (redirect if they're already on our page, else open a new tab)
-		let activeWindow = safari.application.activeBrowserWindow;
-		let isInlineInstall: boolean = ExtensionBase.isOnOneNoteDomain(activeWindow.activeTab.url);
-		let installUrl = this.getClipperInstalledPageUrl(this.clientInfo.get().clipperId, this.clientInfo.get().clipperType, isInlineInstall);
-		if (activeWindow) {
-			if (isInlineInstall) {
-				activeWindow.activeTab.url = installUrl;
-			} else {
-				activeWindow.openTab().url = installUrl;
-			}
-		} else {
-			safari.application.openBrowserWindow().activeTab.url = installUrl;
-		}
+		let installUrl = this.getClipperInstalledPageUrl(this.clientInfo.get().clipperId, this.clientInfo.get().clipperType, false);
+		safari.application.activeBrowserWindow.activeTab.url = installUrl;
 	}
 
 	protected checkIfTabMatchesATooltipType(tab: SafariBrowserTab, tooltipType: TooltipType): boolean {


### PR DESCRIPTION
When the extension is first installed, we want to open up the post-install page on onenote.com.  In Safari, the logic was broken such that the page was not able to be loaded.  One of the side-effects of this was that the first impression of the extension was that it didn't seem to work (the page that was currently loaded didn't yet have the injected code).

Fixing the first run logic won't take care of the refresh issue, but it will certainly give a better first impression (and is inline with the other extensions at this point).

Misc notes on the change:
- I removed the inline install logic for Safari because there is no inline install.  The extension is always installed by navigating to Safari's extensions web page.
- The change in SafariExtension.ts is strictly about cleanup.  Technically it has nothing to do with the fix.

Fixes #1 
