### PR TITLE
Reimplement Firefox onInstall logic

### DIFF
--- a/src/scripts/extensions/webExtensionBase/webExtension.ts
+++ b/src/scripts/extensions/webExtensionBase/webExtension.ts
@@ -74,7 +74,11 @@ export class WebExtension extends ExtensionBase<WebExtensionWorker, W3CTab, numb
 	}
 
 	protected onFirstRun() {
-		// Don't do anything since we're using the onInstalled functionality instead
+		// Don't do anything since we're using the onInstalled functionality instead, unless it's not available
+		// then we use our 'missing-clipperId' heuristic
+		if (!this.onInstalledSupported()) {
+			this.onInstalled();
+		}
 	}
 
 	protected checkIfTabMatchesATooltipType(tab: W3CTab, tooltipType: TooltipType): boolean {
@@ -158,7 +162,7 @@ export class WebExtension extends ExtensionBase<WebExtensionWorker, W3CTab, numb
 
 	private registerInstallListener() {
 		// onInstalled is undefined as of Firefox 48
-		if (WebExtension.browser.runtime.onInstalled) {
+		if (this.onInstalledSupported()) {
 			WebExtension.browser.runtime.onInstalled.addListener(details => {
 				if (details.reason === "install") {
 					this.onInstalled();
@@ -174,5 +178,9 @@ export class WebExtension extends ExtensionBase<WebExtensionWorker, W3CTab, numb
 				this.removeWorker(worker);
 			}
 		});
+	}
+
+	private onInstalledSupported(): boolean {
+		return !!WebExtension.browser.runtime.onInstalled;
 	}
 }


### PR DESCRIPTION
Firefox's implementation of WebExtensions currently does not include onInstall() (i.e., the method is undefined). We have some logic for FRE where if the user does not have a clipperId, we assume it's a new user. WebExtensions does not use this as we use onInstall instead (which does not work for Firefox). Ported Firefox onInstall logic back to this old way of doing it. Fixes #14 
