### PR TITLE
Rename Region mode to 'Image' in Edge

### DIFF
--- a/src/scripts/clipperUI/components/modeButtonSelector.tsx
+++ b/src/scripts/clipperUI/components/modeButtonSelector.tsx
@@ -1,3 +1,4 @@
+import {ClientType} from "../../clientType";
 import {Experiments} from "../../experiments";
 import {Utils} from "../../utils";
 
@@ -50,10 +51,20 @@ class ModeButtonSelectorClass extends ComponentBase<{}, ClipperStateProp> {
 		}
 
 		return <ModeButton imgSrc={Utils.getImageResourceUrl("region.png") }
-			label={Localization.getLocalizedString("WebClipper.ClipType.Region.Button")}
+			label={Localization.getLocalizedString(this.getRegionModeButtonLabel())}
 			myMode={ClipMode.Region} tabIndex={41} selected={currentMode === ClipMode.Region}
 			onModeSelected={this.onModeSelected.bind(this) }
 			tooltipText={Localization.getLocalizedString("WebClipper.ClipType.MultipleRegions.Button.Tooltip")}/>;
+	}
+
+	private getRegionModeButtonLabel(): string {
+		// As of 09/13/16, Edge does not support grabbing the viewport screenshot, so this mode only surfaces
+		// when the user selects an image through the context menu. In this scenario, it's best that we call it
+		// 'Image' instead of 'Region' mode. 
+		if (this.props.clipperState.clientInfo.clipperType === ClientType.EdgeExtension) {
+			return "WebClipper.ClipType.Image.Button";
+		}
+		return "WebClipper.ClipType.Region.Button";
 	}
 
 	private getSelectionModeButton(currentMode: ClipMode) {

--- a/src/strings.json
+++ b/src/strings.json
@@ -17,6 +17,7 @@
 	"WebClipper.ClipType.Bookmark.Button.Tooltip": "Clip just the title, thumbnail, synopsis, and link.",
 	"WebClipper.ClipType.Bookmark.ProgressLabel": "Clipping Bookmark",
 	"WebClipper.ClipType.Button.Tooltip": "Clip just the {0} in an easy-to-read format.",
+	"WebClipper.ClipType.Image.Button": "Image",
 	"WebClipper.ClipType.ImageSnippet.Button": "Image Snippet",
 	"WebClipper.ClipType.MultipleRegions.Button.Tooltip": "Take screenshots of parts of the page you\u0027ll select.",
 	"WebClipper.ClipType.Pdf.Button": "PDF File",

--- a/src/tests/clipperUI/components/modeButtonSelector_tests.tsx
+++ b/src/tests/clipperUI/components/modeButtonSelector_tests.tsx
@@ -11,8 +11,12 @@ import {SmartValue} from "../../../scripts/communicator/smartValue";
 
 import {InvokeMode} from "../../../scripts/extensions/invokeOptions";
 
+import {ClientType} from "../../../scripts/clientType";
+
 import {HelperFunctions} from "../../helperFunctions";
 
+// These are not available in constants.ts as we currently dynamically generate them
+// at runtime
 export module TestConstants {
 	export module Classes {
 		export var icon = "icon";
@@ -29,6 +33,9 @@ export module TestConstants {
 		export var bookmarkButton = "bookmarkButton";
 	}
 }
+
+declare function require(name: string);
+let stringsJson = require("../../../strings.json");
 
 let defaultComponent;
 QUnit.module("modeButtonSelector", {
@@ -81,6 +88,53 @@ test("The region clipping button should appear when enableRegionClipping is inje
 	strictEqual(buttonElements[1].id, TestConstants.Ids.regionButton, "The second button should be the region button");
 	strictEqual(buttonElements[2].id, TestConstants.Ids.augmentationButton, "The third button should be the augmentation button");
 	strictEqual(buttonElements[3].id, TestConstants.Ids.bookmarkButton, "The fourth button should be the bookmark button");
+});
+
+test("The region button should be labeled 'Region' in non-Edge browsers", () => {
+	let startingState = HelperFunctions.getMockClipperState();
+	startingState.clientInfo.clipperType = ClientType.ChromeExtension;
+	HelperFunctions.mountToFixture(
+		<ModeButtonSelector clipperState={ startingState } />);
+
+	let modeButtonSelector = HelperFunctions.getFixture().firstElementChild;
+	let buttonElements = modeButtonSelector.getElementsByClassName(TestConstants.Classes.modeButton);
+	let regionButton = buttonElements[1];
+	let label = regionButton.getElementsByClassName(TestConstants.Classes.label)[0] as Node;
+	strictEqual(label.textContent, stringsJson["WebClipper.ClipType.Region.Button"]);
+});
+
+test("The region button should be labeled 'Region' in non-Edge browsers and an image was selected", () => {
+	let startingState = HelperFunctions.getMockClipperState();
+	startingState.clientInfo.clipperType = ClientType.FirefoxExtension;
+	startingState.invokeOptions = {
+		invokeMode: InvokeMode.ContextImage,
+		invokeDataForMode: "dummy-img"
+	};
+	HelperFunctions.mountToFixture(
+		<ModeButtonSelector clipperState={ startingState } />);
+
+	let modeButtonSelector = HelperFunctions.getFixture().firstElementChild;
+	let buttonElements = modeButtonSelector.getElementsByClassName(TestConstants.Classes.modeButton);
+	let regionButton = buttonElements[1];
+	let label = regionButton.getElementsByClassName(TestConstants.Classes.label)[0] as Node;
+	strictEqual(label.textContent, stringsJson["WebClipper.ClipType.Region.Button"]);
+});
+
+test("The region button should be labeled 'Image' in Edge and an image was selected", () => {
+	let startingState = HelperFunctions.getMockClipperState();
+	startingState.clientInfo.clipperType = ClientType.EdgeExtension;
+	startingState.invokeOptions = {
+		invokeMode: InvokeMode.ContextImage,
+		invokeDataForMode: "dummy-img"
+	};
+	HelperFunctions.mountToFixture(
+		<ModeButtonSelector clipperState={ startingState } />);
+
+	let modeButtonSelector = HelperFunctions.getFixture().firstElementChild;
+	let buttonElements = modeButtonSelector.getElementsByClassName(TestConstants.Classes.modeButton);
+	let imageButton = buttonElements[1];
+	let label = imageButton.getElementsByClassName(TestConstants.Classes.label)[0] as Node;
+	strictEqual(label.textContent, stringsJson["WebClipper.ClipType.Image.Button"]);
 });
 
 test("The selection button should appear when invokeMode is set to selection", () => {
@@ -245,7 +299,7 @@ test("The augmentation button should be labeled as 'Article' by default", () => 
 	let buttonElements = modeButtonSelector.getElementsByClassName(TestConstants.Classes.modeButton);
 	let augmentationButton = buttonElements[2];
 	let label = augmentationButton.getElementsByClassName(TestConstants.Classes.label)[0] as Node;
-	strictEqual(label.textContent, "Article");
+	strictEqual(label.textContent, stringsJson["WebClipper.ClipType.Article.Button"]);
 });
 
 test("The augmentation button should be labeled according to the content model of the augmentation result", () => {
@@ -269,7 +323,7 @@ test("The augmentation button should be labeled according to the content model o
 	let buttonElements = modeButtonSelector.getElementsByClassName(TestConstants.Classes.modeButton);
 	let augmentationButton = buttonElements[2];
 	let label = augmentationButton.getElementsByClassName(TestConstants.Classes.label)[0] as Node;
-	strictEqual(label.textContent, "Recipe");
+	strictEqual(label.textContent, stringsJson["WebClipper.ClipType.Recipe.Button"]);
 });
 
 test("The augmentation button should have its image set to the article icon by default", () => {


### PR DESCRIPTION
This is to be checked in when the matching string has been localized.

Fixes #7.
