### PR TITLE
Prevent highlighting in non-editable modes

### DIFF
--- a/src/scripts/clipperUI/components/previewViewer/augmentationPreview.tsx
+++ b/src/scripts/clipperUI/components/previewViewer/augmentationPreview.tsx
@@ -13,7 +13,7 @@ import {SpriteAnimation} from "../../components/spriteAnimation";
 import {EditorPreviewComponentBase, EditorPreviewState} from "./editorPreviewComponentBase";
 
 class AugmentationPreview extends EditorPreviewComponentBase<EditorPreviewState, ClipperStateProp> {
-	protected getContentBodyForCurrentStatus(): any[] {
+	protected getHighlightableContentBodyForCurrentStatus(): any[] {
 		let state = this.props.clipperState;
 		return this.convertAugmentationResultToContentData(state.augmentationResult);
 	}
@@ -50,25 +50,22 @@ class AugmentationPreview extends EditorPreviewComponentBase<EditorPreviewState,
 		});
 	}
 
-	private convertAugmentationResultToContentData(result: DataResult<AugmentationResult>): any[] {
-		let contentBody = [];
-
+	private convertAugmentationResultToContentData(result: DataResult<AugmentationResult>): any {
 		switch (result.status) {
 			case Status.Succeeded:
 				if (this.props.clipperState.augmentationResult.data && this.props.clipperState.augmentationResult.data.ContentModel !== AugmentationModel.None) {
-					contentBody.push(m.trust(this.props.clipperState.augmentationPreviewInfo.previewBodyHtml));
+					return m.trust(this.props.clipperState.augmentationPreviewInfo.previewBodyHtml);
 				}
 				break;
 			case Status.NotStarted:
 			case Status.InProgress:
-				contentBody.push(this.getSpinner());
-				break;
+				return this.getSpinner();
 			default:
 			case Status.Failed:
 				break;
 		}
 
-		return contentBody;
+		return undefined;
 	}
 
 	private getSpinner(): any {

--- a/src/scripts/clipperUI/components/previewViewer/editorPreviewComponentBase.tsx
+++ b/src/scripts/clipperUI/components/previewViewer/editorPreviewComponentBase.tsx
@@ -17,7 +17,9 @@ export interface EditorPreviewState {
 
 /**
  * Child components will inherit the editor header where users can make rich edits to their content, such as highlighting
- * and font changes.
+ * and font changes. Within the preview body element, this component renders a highlightable preview body element underneath
+ * it that the highlighter is attached to. Highlighting logic can only take place within this element, and this prevents
+ * other types of preview bodies from accidentally providing highlighting functionality.
  */
 export abstract class EditorPreviewComponentBase<TState extends EditorPreviewState, TProps extends ClipperStateProp>
 	extends PreviewComponentBase<TState, TProps> {

--- a/src/scripts/clipperUI/components/previewViewer/editorPreviewComponentBase.tsx
+++ b/src/scripts/clipperUI/components/previewViewer/editorPreviewComponentBase.tsx
@@ -40,6 +40,14 @@ export abstract class EditorPreviewComponentBase<TState extends EditorPreviewSta
 	}
 
 	protected abstract handleBodyChange(newBodyHtml: string);
+	protected abstract getHighlightableContentBodyForCurrentStatus(): any;
+
+	// Override
+	protected getContentBodyForCurrentStatus() {
+		return [
+			<div id={Constants.Ids.highlightablePreviewBody}>{this.getHighlightableContentBodyForCurrentStatus()}</div>
+		];
+	}
 
 	// Override
 	protected getPreviewBodyConfig() {
@@ -95,7 +103,7 @@ export abstract class EditorPreviewComponentBase<TState extends EditorPreviewSta
 	}
 
 	private deleteHighlight(timestamp: number) {
-		let previewBody = document.getElementById(Constants.Ids.previewBody);
+		let previewBody = document.getElementById(Constants.Ids.highlightablePreviewBody);
 		let highlightedElements = previewBody.querySelectorAll("span.highlighted[data-timestamp='" + timestamp + "']");
 		for (let i = 0; i < highlightedElements.length; i++) {
 			let current = highlightedElements[i] as HTMLSpanElement;
@@ -121,7 +129,7 @@ export abstract class EditorPreviewComponentBase<TState extends EditorPreviewSta
 	private setHighlighter() {
 		let addDeleteButton = (range: Range, normalizedHighlights: HTMLSpanElement[]) => {
 			if (normalizedHighlights && normalizedHighlights.length > 0) {
-				let previewBody = document.getElementById(Constants.Ids.previewBody);
+				let previewBody = document.getElementById(Constants.Ids.highlightablePreviewBody);
 
 				// We need to get the latest timestamp for normalizing all encompassed highlights later
 				let timestamps = normalizedHighlights.map((span: HTMLSpanElement) => parseInt(span.getAttribute("data-timestamp"), 10 /* radix */));
@@ -158,7 +166,7 @@ export abstract class EditorPreviewComponentBase<TState extends EditorPreviewSta
 			}
 		};
 
-		let textHighlighter = Highlighter.reconstructInstance(document.getElementById(Constants.Ids.previewBody), {
+		let textHighlighter = Highlighter.reconstructInstance(document.getElementById(Constants.Ids.highlightablePreviewBody), {
 			color: Constants.Styles.Colors.oneNoteHighlightColor,
 			contextClass: Constants.Classes.highlightable,
 			onAfterHighlight: addDeleteButton
@@ -187,7 +195,7 @@ export abstract class EditorPreviewComponentBase<TState extends EditorPreviewSta
 
 	// Similarly adopted from: http://stackoverflow.com/questions/8339857/how-to-know-if-selected-text-is-inside-a-specific-div
 	private selectionIsInPreviewBody() {
-		let previewBody = document.getElementById(Constants.Ids.previewBody);
+		let previewBody = document.getElementById(Constants.Ids.highlightablePreviewBody);
 		if (!previewBody) {
 			return false;
 		}

--- a/src/scripts/clipperUI/components/previewViewer/editorPreviewComponentBase.tsx
+++ b/src/scripts/clipperUI/components/previewViewer/editorPreviewComponentBase.tsx
@@ -103,15 +103,15 @@ export abstract class EditorPreviewComponentBase<TState extends EditorPreviewSta
 	}
 
 	private deleteHighlight(timestamp: number) {
-		let previewBody = document.getElementById(Constants.Ids.highlightablePreviewBody);
-		let highlightedElements = previewBody.querySelectorAll("span.highlighted[data-timestamp='" + timestamp + "']");
+		let highlightablePreviewBody = document.getElementById(Constants.Ids.highlightablePreviewBody);
+		let highlightedElements = highlightablePreviewBody.querySelectorAll("span.highlighted[data-timestamp='" + timestamp + "']");
 		for (let i = 0; i < highlightedElements.length; i++) {
 			let current = highlightedElements[i] as HTMLSpanElement;
 			let parent = current.parentNode;
 			parent.insertBefore(document.createTextNode(current.innerText), current);
 			parent.removeChild(current);
 		}
-		this.handleBodyChange(previewBody.innerHTML);
+		this.handleBodyChange(highlightablePreviewBody.innerHTML);
 	}
 
 	private handleClick(event: Event) {
@@ -129,7 +129,7 @@ export abstract class EditorPreviewComponentBase<TState extends EditorPreviewSta
 	private setHighlighter() {
 		let addDeleteButton = (range: Range, normalizedHighlights: HTMLSpanElement[]) => {
 			if (normalizedHighlights && normalizedHighlights.length > 0) {
-				let previewBody = document.getElementById(Constants.Ids.highlightablePreviewBody);
+				let highlightablePreviewBody = document.getElementById(Constants.Ids.highlightablePreviewBody);
 
 				// We need to get the latest timestamp for normalizing all encompassed highlights later
 				let timestamps = normalizedHighlights.map((span: HTMLSpanElement) => parseInt(span.getAttribute("data-timestamp"), 10 /* radix */));
@@ -139,7 +139,7 @@ export abstract class EditorPreviewComponentBase<TState extends EditorPreviewSta
 				for (let i = 0; i < normalizedHighlights.length; i++) {
 					// ... so we should delete their old delete buttons, and normalize them to the same timestamp
 					let oldHighlightTimestamp = normalizedHighlights[i].getAttribute("data-timestamp");
-					let oldHighlights = previewBody.querySelectorAll("span." + Constants.Classes.highlighted + "[data-timestamp='" + oldHighlightTimestamp + "']");
+					let oldHighlights = highlightablePreviewBody.querySelectorAll("span." + Constants.Classes.highlighted + "[data-timestamp='" + oldHighlightTimestamp + "']");
 					for (let j = 0; j < oldHighlights.length; j++) {
 						// Delete old delete buttons
 						let oldButtons = oldHighlights[j].querySelectorAll("img." + Constants.Classes.deleteHighlightButton);
@@ -153,7 +153,7 @@ export abstract class EditorPreviewComponentBase<TState extends EditorPreviewSta
 				}
 
 				// Find the first instance of the highlight and add the delete button
-				let firstHighlighted = previewBody.querySelector("span.highlighted[data-timestamp='" + timestamp + "']");
+				let firstHighlighted = highlightablePreviewBody.querySelector("span.highlighted[data-timestamp='" + timestamp + "']");
 				if (firstHighlighted) {
 					let deleteHighlight = document.createElement("IMG") as HTMLImageElement;
 					deleteHighlight.src = Utils.getImageResourceUrl("editoroptions/delete_button.png");
@@ -162,7 +162,7 @@ export abstract class EditorPreviewComponentBase<TState extends EditorPreviewSta
 					firstHighlighted.insertBefore(deleteHighlight, firstHighlighted.childNodes[0]);
 				}
 
-				this.handleBodyChange(previewBody.innerHTML);
+				this.handleBodyChange(highlightablePreviewBody.innerHTML);
 			}
 		};
 

--- a/src/scripts/clipperUI/components/previewViewer/selectionPreview.tsx
+++ b/src/scripts/clipperUI/components/previewViewer/selectionPreview.tsx
@@ -13,8 +13,8 @@ import {SpriteAnimation} from "../../components/spriteAnimation";
 import {EditorPreviewComponentBase, EditorPreviewState} from "./editorPreviewComponentBase";
 
 class SelectionPreview extends EditorPreviewComponentBase<EditorPreviewState, ClipperStateProp> {
-	protected getContentBodyForCurrentStatus(): any[] {
-		return [m.trust(this.props.clipperState.selectionPreviewInfo.previewBodyHtml)];
+	protected getHighlightableContentBodyForCurrentStatus(): any {
+		return m.trust(this.props.clipperState.selectionPreviewInfo.previewBodyHtml);
 	}
 
 	protected getStatus(): Status {

--- a/src/scripts/constants.ts
+++ b/src/scripts/constants.ts
@@ -62,6 +62,9 @@ export module Constants {
 		export var dialogMessage = "dialogMessage";
 		export var dialogTryAgainButton = "dialogTryAgainButton";
 
+		// editorPreviewComponentBase
+		export var highlightablePreviewBody = "highlightablePreviewBody";
+
 		// failurePanel
 		export var apiErrorMessage = "apiErrorMessage";
 		export var backToHomeButton = "backToHomeButton";

--- a/src/styles/previewStyles.less
+++ b/src/styles/previewStyles.less
@@ -393,13 +393,15 @@
 						position: relative;
 					}
 
-					&.highlightable {
-						// We need to adjust the 'hotspot' of the cursor to be aligned to middle of the "I" symbol
-						cursor: url('./images/editoroptions/highlight_cursor.cur'), text; // Hotspots are built into cur files, which IE/Edge interprets
-						cursor: url('./images/editoroptions/highlight_cursor.cur') 16 16, text; // Other browsers need you to specify the hotspot in the css file
+					#highlightablePreviewBody {
+						&.highlightable {
+							// We need to adjust the 'hotspot' of the cursor to be aligned to middle of the "I" symbol
+							cursor: url('./images/editoroptions/highlight_cursor.cur'), text; // Hotspots are built into cur files, which IE/Edge interprets
+							cursor: url('./images/editoroptions/highlight_cursor.cur') 16 16, text; // Other browsers need you to specify the hotspot in the css file
 
-						* ::selection {
-							background: @OneNoteHighlightColor;
+							* ::selection {
+								background: @OneNoteHighlightColor;
+							}
 						}
 					}
 

--- a/src/tests/clipperUI/components/previewViewer/augmentationPreview_tests.tsx
+++ b/src/tests/clipperUI/components/previewViewer/augmentationPreview_tests.tsx
@@ -94,9 +94,9 @@ test("The augmented content of the page should be displayed in preview body in A
 	let defaultComponent = <AugmentationPreview clipperState={mockClipperState} />;
 	HelperFunctions.mountToFixture(defaultComponent);
 
-	strictEqual(document.getElementById(Constants.Ids.previewBody).innerText,
+	strictEqual(document.getElementById(Constants.Ids.highlightablePreviewBody).innerHTML,
 		mockClipperState.augmentationPreviewInfo.previewBodyHtml,
-		"The editable augmentation result content is displayed in the preview body");
+		"The editable augmentation result content is displayed in the preview body's highlightable portion");
 });
 
 test("When the augmentation successfully completes, but no data is returned, the preview should indicate no content was found in Augmentation mode", () => {
@@ -371,8 +371,8 @@ test("If the user selects something in the preview body, then clicks the highlig
 	let paragraphId = "para";
 	paragraph.id = paragraphId;
 	let innerText = "Test";
-	paragraph.innerText = innerText;
-	document.getElementById(Constants.Ids.previewBody).appendChild(paragraph);
+	paragraph.innerHTML = innerText;
+	document.getElementById(Constants.Ids.highlightablePreviewBody).appendChild(paragraph);
 
 	let highlightButton = document.getElementById(Constants.Ids.highlightButton);
 
@@ -406,7 +406,7 @@ test("If the user selects something outside the preview body, then clicks the hi
 	let paragraphId = "para";
 	paragraph.id = paragraphId;
 	let innerText = "Test";
-	paragraph.innerText = innerText;
+	paragraph.innerHTML = innerText;
 
 	// Note this is outside the preview body
 	HelperFunctions.getFixture().appendChild(paragraph);

--- a/src/tests/clipperUI/components/previewViewer/augmentationPreview_tests.tsx
+++ b/src/tests/clipperUI/components/previewViewer/augmentationPreview_tests.tsx
@@ -89,7 +89,7 @@ test("The editable title of the page should be displayed in the preview title in
 	ok(!previewHeaderInput.readOnly);
 });
 
-test("The augmented content of the page should be displayed in preview body in Augmentation Mode", () => {
+test("The augmented content of the page should be displayed in the highlightable preview body in Augmentation Mode", () => {
 	let mockClipperState = getMockAugmentationModeState();
 	let defaultComponent = <AugmentationPreview clipperState={mockClipperState} />;
 	HelperFunctions.mountToFixture(defaultComponent);
@@ -361,7 +361,7 @@ test("If the user clicks the highlight button, the internal state should show th
 	notStrictEqual(highlightButton.className.indexOf("active"), -1, "The active class should be applied to the highlight button");
 });
 
-test("If the user selects something in the preview body, then clicks the highlight button, the internal state should show that 'Highlighting' is disabled in Augmentation mode, and the item should be highlighted", () => {
+test("If the user selects something in the highlightable preview body, then clicks the highlight button, the internal state should show that 'Highlighting' is disabled in Augmentation mode, and the item should be highlighted", () => {
 	let mockClipperState = getMockAugmentationModeState();
 	let defaultComponent = <AugmentationPreview clipperState={mockClipperState} />;
 	let augmentationPreview = HelperFunctions.mountToFixture(defaultComponent);
@@ -396,7 +396,7 @@ test("If the user selects something in the preview body, then clicks the highlig
 		"The highlighted element should be the inner text of the paragraph");
 });
 
-test("If the user selects something outside the preview body, then clicks the highlight button, the internal state should show that 'Highlighting' is enabled in Augmentation mode, and nothing should be highlighted", () => {
+test("If the user selects something outside the highlightable preview body, then clicks the highlight button, the internal state should show that 'Highlighting' is enabled in Augmentation mode, and nothing should be highlighted", () => {
 	let mockClipperState = getMockAugmentationModeState();
 	let defaultComponent = <AugmentationPreview clipperState={mockClipperState} />;
 	let augmentationPreview = HelperFunctions.mountToFixture(defaultComponent);

--- a/src/tests/clipperUI/components/previewViewer/selectionPreview_tests.tsx
+++ b/src/tests/clipperUI/components/previewViewer/selectionPreview_tests.tsx
@@ -31,11 +31,12 @@ QUnit.module("selectionPreview", {
 test("The selection preview should render the content", () => {
 	HelperFunctions.mountToFixture(defaultComponent);
 
-	strictEqual(document.getElementById(Constants.Ids.previewBody).innerText,
+	let highlightablePreviewBody = document.getElementById(Constants.Ids.highlightablePreviewBody);
+	strictEqual(highlightablePreviewBody.innerText,
 		mockClipperState.selectionPreviewInfo.previewBodyHtml,
 		"The editable selection result content is displayed in the preview body");
 
-	strictEqual(document.getElementById(Constants.Ids.previewBody).innerHTML,
+	strictEqual(highlightablePreviewBody.innerHTML,
 		mockClipperState.selectionPreviewInfo.previewBodyHtml,
 		"Only the editable selection result content is displayed in the preview body");
 });
@@ -45,13 +46,13 @@ test("The selection preview should render the content as HTML, not purely text",
 	defaultComponent = <SelectionPreview clipperState={mockClipperState} />;
 	HelperFunctions.mountToFixture(defaultComponent);
 
-	let previewBody = document.getElementById(Constants.Ids.previewBody);
+	let highlightablePreviewBody = document.getElementById(Constants.Ids.highlightablePreviewBody);
 
-	strictEqual(previewBody.innerHTML, mockClipperState.selectionPreviewInfo.previewBodyHtml,
+	strictEqual(highlightablePreviewBody.innerHTML, mockClipperState.selectionPreviewInfo.previewBodyHtml,
 		"Only the editable selection result content is displayed in the preview body");
-	strictEqual(previewBody.childElementCount, 1, "There should be one child");
+	strictEqual(highlightablePreviewBody.childElementCount, 1, "There should be one child");
 
-	let child = previewBody.firstElementChild as HTMLElement;
+	let child = highlightablePreviewBody.firstElementChild as HTMLElement;
 	strictEqual(child.outerHTML, mockClipperState.selectionPreviewInfo.previewBodyHtml,
 		"The child's outer HTML should be the preview body html");
 	strictEqual(child.innerHTML, "The selection",

--- a/src/tests/clipperUI/components/previewViewer/selectionPreview_tests.tsx
+++ b/src/tests/clipperUI/components/previewViewer/selectionPreview_tests.tsx
@@ -28,7 +28,7 @@ QUnit.module("selectionPreview", {
 	}
 });
 
-test("The selection preview should render the content", () => {
+test("The selection's highlightable preview body should render the content", () => {
 	HelperFunctions.mountToFixture(defaultComponent);
 
 	let highlightablePreviewBody = document.getElementById(Constants.Ids.highlightablePreviewBody);
@@ -41,7 +41,7 @@ test("The selection preview should render the content", () => {
 		"Only the editable selection result content is displayed in the preview body");
 });
 
-test("The selection preview should render the content as HTML, not purely text", () => {
+test("The selection preview's highlightable preview body should render the content as HTML, not purely text", () => {
 	mockClipperState.selectionPreviewInfo.previewBodyHtml = "<div>The selection</div>";
 	defaultComponent = <SelectionPreview clipperState={mockClipperState} />;
 	HelperFunctions.mountToFixture(defaultComponent);


### PR DESCRIPTION
This should fix the root cause of the present and past highlighting issues we've had.

Currently, we attach the highlighter to the previewBody element, which happens to be present across all preview modes. This is an issue because it's possible to get into weird states where you can highlight things in other modes, which again leads to even stranger behavior. For 'editable' previews, i.e., selection and augmentation, the highlighter will now be attached to the highlightablePreviewBody element, which is ONLY rendered in these modes.

i.e.,

``` html
<div id="previewBody ...>
  <div id="highlightablePreviewBody ...>
    {previewContent}
  </div>
</div>
```

As opposed to non editable modes:

``` html
<div id="previewBody ...>
  {previewContent}
</div>
```

Fixes #38.
