### PR TITLE
[Bug] Change logic of when tooltip shows + clean up a bit of the logic

### DIFF
--- a/src/scripts/constants.ts
+++ b/src/scripts/constants.ts
@@ -323,7 +323,8 @@ export module Constants {
 	}
 
 	export module Settings {
-		export var timeBetweenTooltips = 1000 * 60 * 60 * 24 * 7 * 3; // 21 days
+		export var timeBetweenDifferentTooltips = 1000 * 60 * 60 * 24 * 7 * 3; // 21 days
+		export var timeBetweenSameTooltip = 1000 * 60 * 60 * 24 * 7 * 1; // 7 days
 		export var maximumNumberOfTimesToShowTooltips = 3;
 		export var noOpTrackerTimeoutDuration = 20 * 1000; // 20 seconds
 		export var maximumFontSize = 72;

--- a/src/scripts/constants.ts
+++ b/src/scripts/constants.ts
@@ -324,7 +324,7 @@ export module Constants {
 
 	export module Settings {
 		export var timeBetweenTooltips = 1000 * 60 * 60 * 24 * 7 * 3; // 21 days
-		export var maximumNumberOfTimesToShowTooltips = 4;
+		export var maximumNumberOfTimesToShowTooltips = 3;
 		export var noOpTrackerTimeoutDuration = 20 * 1000; // 20 seconds
 		export var maximumFontSize = 72;
 		export var minimumFontSize = 8;

--- a/src/scripts/constants.ts
+++ b/src/scripts/constants.ts
@@ -324,6 +324,7 @@ export module Constants {
 
 	export module Settings {
 		export var timeBetweenTooltips = 1000 * 60 * 60 * 24 * 7 * 3; // 21 days
+		export var maximumNumberOfTimesToShowTooltips = 4;
 		export var noOpTrackerTimeoutDuration = 20 * 1000; // 20 seconds
 		export var maximumFontSize = 72;
 		export var minimumFontSize = 8;

--- a/src/scripts/constants.ts
+++ b/src/scripts/constants.ts
@@ -323,8 +323,8 @@ export module Constants {
 	}
 
 	export module Settings {
-		export var timeBetweenDifferentTooltips = 1000 * 60 * 60 * 24 * 7 * 3; // 21 days
-		export var timeBetweenSameTooltip = 1000 * 60 * 60 * 24 * 7 * 1; // 7 days
+		export var timeBetweenDifferentTooltips = 1000 * 60 * 60 * 24 * 7 * 1; // 21 days
+		export var timeBetweenSameTooltip = 1000 * 60 * 60 * 24 * 7 * 3; // 7 days
 		export var maximumNumberOfTimesToShowTooltips = 3;
 		export var noOpTrackerTimeoutDuration = 20 * 1000; // 20 seconds
 		export var maximumFontSize = 72;

--- a/src/scripts/constants.ts
+++ b/src/scripts/constants.ts
@@ -323,8 +323,8 @@ export module Constants {
 	}
 
 	export module Settings {
-		export var timeBetweenDifferentTooltips = 1000 * 60 * 60 * 24 * 7 * 1; // 21 days
-		export var timeBetweenSameTooltip = 1000 * 60 * 60 * 24 * 7 * 3; // 7 days
+		export var timeBetweenDifferentTooltips = 1000 * 60 * 60 * 24 * 7 * 1; // 1 week
+		export var timeBetweenSameTooltip = 1000 * 60 * 60 * 24 * 7 * 3; // 3 weeks
 		export var maximumNumberOfTimesToShowTooltips = 3;
 		export var noOpTrackerTimeoutDuration = 20 * 1000; // 20 seconds
 		export var maximumFontSize = 72;

--- a/src/scripts/extensions/bookmarklet/inlineExtension.ts
+++ b/src/scripts/extensions/bookmarklet/inlineExtension.ts
@@ -48,8 +48,8 @@ export class InlineExtension extends ExtensionBase<InlineWorker, any, any> {
 	protected addPageNavListener(callback: (tab: any) => void) {
 	}
 
-	protected checkIfTabMatchesATooltipType(tab: SafariBrowserTab, tooltipType: TooltipType): boolean {
-		return false;
+	protected checkIfTabMatchesATooltipType(tab: SafariBrowserTab, tooltipTypes: TooltipType[]): TooltipType {
+		return undefined;
 	}
 
 	protected checkIfTabIsAVideoDomain(tab: SafariBrowserTab): boolean {

--- a/src/scripts/extensions/extensionBase.ts
+++ b/src/scripts/extensions/extensionBase.ts
@@ -274,16 +274,26 @@ export abstract class ExtensionBase<TWorker extends ExtensionWorkerBase<TTab, TT
 		});
 	}
 
-	private shouldShowTooltip(tab: TTab, tooltipType: TooltipType): boolean {
-		if (this.tooltip.tooltipDelayIsOver(tooltipType, Date.now()) && this.checkIfTabMatchesATooltipType(tab, tooltipType)) {
-			return true;
+	private shouldShowTooltip(tab: TTab, tooltipTypes: TooltipType[]): TooltipType {
+		let type = this.checkIfTabMatchesATooltipType(tab, tooltipTypes);
+
+		// If the tab doesn't match any of the given tooltipTypes, then return
+		if (!type) {
+			return;
 		}
+
+		if (!this.tooltip.tooltipDelayIsOver(type, Date.now())) {
+			return;
+		}
+
+		return type;
 	}
 
 	private shouldShowVideoTooltip(tab: TTab): boolean {
-		if (this.tooltip.tooltipDelayIsOver(TooltipType.Video, Date.now()) && this.checkIfTabIsAVideoDomain(tab)) {
+		if (this.checkIfTabIsAVideoDomain(tab) && this.tooltip.tooltipDelayIsOver(TooltipType.Video, Date.now())) {
 			return true;
 		}
+		return false;
 	}
 
 	private showTooltip(tab: TTab, tooltipType: TooltipType): void {
@@ -359,11 +369,9 @@ export abstract class ExtensionBase<TWorker extends ExtensionWorkerBase<TTab, TT
 			let extensionVersion = new Version(ExtensionBase.getExtensionVersion());
 
 			let tooltips = [TooltipType.Pdf, TooltipType.Product, TooltipType.Recipe];
-			for (let i = 0; i < tooltips.length; ++i) {
-				if (this.shouldShowTooltip(tab, tooltips[i])) {
-					this.showTooltip(tab, tooltips[i]);
-					return;
-				}
+			let typeToShow = this.shouldShowTooltip(tab, tooltips);
+			if (typeToShow) {
+				this.showTooltip(tab, typeToShow);
 			}
 
 			if (this.shouldShowVideoTooltip(tab)) {
@@ -405,7 +413,7 @@ export abstract class ExtensionBase<TWorker extends ExtensionWorkerBase<TTab, TT
 	/**
 	 * Returns True if the Extension determines the tab is a Product, Recipe, or PDF. False otherwise
 	 */
-	protected abstract checkIfTabMatchesATooltipType(tab: TTab, tooltipType: TooltipType): boolean;
+	protected abstract checkIfTabMatchesATooltipType(tab: TTab, tooltipTypes: TooltipType[]): TooltipType;
 
 	/**
 	 * Returns True if the Extension determines the tab is a Video, false otherwise

--- a/src/scripts/extensions/extensionBase.ts
+++ b/src/scripts/extensions/extensionBase.ts
@@ -369,12 +369,11 @@ export abstract class ExtensionBase<TWorker extends ExtensionWorkerBase<TTab, TT
 			let extensionVersion = new Version(ExtensionBase.getExtensionVersion());
 
 			let tooltips = [TooltipType.Pdf, TooltipType.Product, TooltipType.Recipe];
-			if (!this.tooltip.hasAnyTooltipBeenSeenInLastTimePeriod(Date.now(), tooltips, Constants.Settings.timeBetweenDifferentTooltips)) {
-				let typeToShow = this.shouldShowTooltip(tab, tooltips);
-				if (typeToShow) {
-					this.showTooltip(tab, typeToShow);
-					return;
-				}
+			// Returns the Type of tooltip to show IF the delay is over and the tab has the correct content type
+			let typeToShow = this.shouldShowTooltip(tab, tooltips);
+			if (typeToShow) {
+				this.showTooltip(tab, typeToShow);
+				return;
 			}
 
 			if (this.shouldShowVideoTooltip(tab)) {

--- a/src/scripts/extensions/extensionBase.ts
+++ b/src/scripts/extensions/extensionBase.ts
@@ -277,7 +277,6 @@ export abstract class ExtensionBase<TWorker extends ExtensionWorkerBase<TTab, TT
 	private shouldShowTooltip(tab: TTab, tooltipTypes: TooltipType[]): TooltipType {
 		let type = this.checkIfTabMatchesATooltipType(tab, tooltipTypes);
 
-		// If the tab doesn't match any of the given tooltipTypes, then return
 		if (!type) {
 			return;
 		}

--- a/src/scripts/extensions/extensionBase.ts
+++ b/src/scripts/extensions/extensionBase.ts
@@ -369,9 +369,12 @@ export abstract class ExtensionBase<TWorker extends ExtensionWorkerBase<TTab, TT
 			let extensionVersion = new Version(ExtensionBase.getExtensionVersion());
 
 			let tooltips = [TooltipType.Pdf, TooltipType.Product, TooltipType.Recipe];
-			let typeToShow = this.shouldShowTooltip(tab, tooltips);
-			if (typeToShow) {
-				this.showTooltip(tab, typeToShow);
+			if (!this.tooltip.hasAnyTooltipBeenSeenInLastTimePeriod(Date.now(), tooltips, Constants.Settings.timeBetweenDifferentTooltips)) {
+				let typeToShow = this.shouldShowTooltip(tab, tooltips);
+				if (typeToShow) {
+					this.showTooltip(tab, typeToShow);
+					return;
+				}
 			}
 
 			if (this.shouldShowVideoTooltip(tab)) {

--- a/src/scripts/extensions/safari/safariExtension.ts
+++ b/src/scripts/extensions/safari/safariExtension.ts
@@ -86,8 +86,8 @@ export class SafariExtension extends ExtensionBase<SafariWorker, SafariBrowserTa
 		safari.application.activeBrowserWindow.activeTab.url = installUrl;
 	}
 
-	protected checkIfTabMatchesATooltipType(tab: SafariBrowserTab, tooltipType: TooltipType): boolean {
-		return Utils.checkIfUrlMatchesAContentType(tab.url, tooltipType);
+	protected checkIfTabMatchesATooltipType(tab: SafariBrowserTab, tooltipTypes: TooltipType[]): TooltipType {
+		return Utils.checkIfUrlMatchesAContentType(tab.url, tooltipTypes);
 	}
 
 	protected checkIfTabIsAVideoDomain(tab: SafariBrowserTab): boolean {

--- a/src/scripts/extensions/tooltipHelper.ts
+++ b/src/scripts/extensions/tooltipHelper.ts
@@ -65,7 +65,6 @@ export class TooltipHelper {
 		if (this.hasAnyTooltipBeenSeenInLastTimePeriod(curTime, tooltipsWithoutCurrentType, Constants.Settings.timeBetweenDifferentTooltips)) {
 			return false;
 		}
-		
 		return true;
 	}
 

--- a/src/scripts/extensions/tooltipHelper.ts
+++ b/src/scripts/extensions/tooltipHelper.ts
@@ -54,13 +54,6 @@ export class TooltipHelper {
 			return false;
 		}
 
-		let timeBetweenTooltips = Constants.Settings.timeBetweenTooltips;
-
-		// If the user has seen any of the tooltips in the last timeBetweenTooltips
-		if (this.hasAnyTooltipBeenSeenInLastTimePeriod(time, this.validTypes, Constants.Settings.timeBetweenTooltips)) {
-			return false;
-		}
-
 		return true;
 	}
 

--- a/src/scripts/extensions/tooltipHelper.ts
+++ b/src/scripts/extensions/tooltipHelper.ts
@@ -40,26 +40,26 @@ export class TooltipHelper {
 			throw new Error("Invalid argument passed to tooltipDelayIsOver");
 		}
 
-		let numTimesTooltipHasBeenSeen = this.getTooltipInformation(ClipperStorageKeys.numTimesTooltipHasBeenSeenBase, tooltipType);
-		let lastSeenTooltipTime = this.getTooltipInformation(ClipperStorageKeys.lastSeenTooltipTimeBase, tooltipType);
-		let lastClipTime = this.getTooltipInformation(ClipperStorageKeys.lastClippedTooltipTimeBase, tooltipType);
 
 		// If the user has clipped this content type
+		let lastClipTime = this.getTooltipInformation(ClipperStorageKeys.lastClippedTooltipTimeBase, tooltipType);		
 		if (lastClipTime !== 0) {
 			return false;
 		}
 
 		// If the user has seen enough of our tooltips :P 
+		let numTimesTooltipHasBeenSeen = this.getTooltipInformation(ClipperStorageKeys.numTimesTooltipHasBeenSeenBase, tooltipType);		
 		if (numTimesTooltipHasBeenSeen >= Constants.Settings.maximumNumberOfTimesToShowTooltips) {
 			return false;
 		}
 
-		// If it has been less than 3 weeks since the user saw this specific tooltip, return false
+		// If not enough time has passed since the user saw this specific tooltip, return false
+		let lastSeenTooltipTime = this.getTooltipInformation(ClipperStorageKeys.lastSeenTooltipTimeBase, tooltipType);		
 		if (this.tooltipHasBeenSeenInLastTimePeriod(tooltipType, curTime, Constants.Settings.timeBetweenSameTooltip)) {
 			return false;
 		}
 
-		// If it has been less than 7 days since the user saw any tooltip, then return false
+		// If not enought time has been since the user saw ANY OTHER tooltip, then return false
 		let indexOfThisTooltip = this.validTypes.indexOf(tooltipType);
 		let validTypesWithCurrentTypeRemoved = this.validTypes.slice();
 		validTypesWithCurrentTypeRemoved.splice(indexOfThisTooltip, 1);

--- a/src/scripts/extensions/tooltipHelper.ts
+++ b/src/scripts/extensions/tooltipHelper.ts
@@ -40,21 +40,20 @@ export class TooltipHelper {
 			throw new Error("Invalid argument passed to tooltipDelayIsOver");
 		}
 
-
 		// If the user has clipped this content type
-		let lastClipTime = this.getTooltipInformation(ClipperStorageKeys.lastClippedTooltipTimeBase, tooltipType);		
+		let lastClipTime = this.getTooltipInformation(ClipperStorageKeys.lastClippedTooltipTimeBase, tooltipType);
 		if (lastClipTime !== 0) {
 			return false;
 		}
 
 		// If the user has seen enough of our tooltips :P 
-		let numTimesTooltipHasBeenSeen = this.getTooltipInformation(ClipperStorageKeys.numTimesTooltipHasBeenSeenBase, tooltipType);		
+		let numTimesTooltipHasBeenSeen = this.getTooltipInformation(ClipperStorageKeys.numTimesTooltipHasBeenSeenBase, tooltipType);
 		if (numTimesTooltipHasBeenSeen >= Constants.Settings.maximumNumberOfTimesToShowTooltips) {
 			return false;
 		}
 
 		// If not enough time has passed since the user saw this specific tooltip, return false
-		let lastSeenTooltipTime = this.getTooltipInformation(ClipperStorageKeys.lastSeenTooltipTimeBase, tooltipType);		
+		let lastSeenTooltipTime = this.getTooltipInformation(ClipperStorageKeys.lastSeenTooltipTimeBase, tooltipType);
 		if (this.tooltipHasBeenSeenInLastTimePeriod(tooltipType, curTime, Constants.Settings.timeBetweenSameTooltip)) {
 			return false;
 		}

--- a/src/scripts/extensions/tooltipHelper.ts
+++ b/src/scripts/extensions/tooltipHelper.ts
@@ -35,15 +35,6 @@ export class TooltipHelper {
 		this.storage.setValue(storageKey, value);
 	}
 
-	/**
-	 *  Returns false if:
-	 *	- A user has clipped the content type we are trying to upsell
-	 *  - The user has seen this tooltip more than maxTooltipsShown times
-	 *  - They've seen any of the tooltips in the last timeBetweenTooltips time period
-	 *  - They have set a preference to stop showing tooltips
-	 *
-	 *  Returns true otherwise
-	 */
 	public tooltipDelayIsOver(tooltipType: TooltipType, time: number): boolean {
 		if (Utils.isNullOrUndefined(tooltipType) || Utils.isNullOrUndefined(time)) {
 			throw new Error("Invalid argument passed to tooltipDelayIsOver");
@@ -55,13 +46,11 @@ export class TooltipHelper {
 
 		// If the user has clipped this content type
 		if (lastClipTime !== 0) {
-			console.log("returned false");			
 			return false;
 		}
 
 		// If the user has seen enough of our tooltips :P 
 		if (numTimesTooltipHasBeenSeen >= Constants.Settings.maximumNumberOfTimesToShowTooltips) {
-			console.log("returned false");			
 			return false;
 		}
 
@@ -69,11 +58,9 @@ export class TooltipHelper {
 
 		// If the user has seen any of the tooltips in the last timeBetweenTooltips
 		if (this.hasAnyTooltipBeenSeenInLastTimePeriod(time, this.validTypes, Constants.Settings.timeBetweenTooltips)) {
-			console.log("returned false");
 			return false;
 		}
 
-		console.log("returned true");
 		return true;
 	}
 
@@ -88,11 +75,9 @@ export class TooltipHelper {
 	public tooltipHasBeenSeenInLastTimePeriod(tooltipType: TooltipType, curTime: number, timePeriod: number): boolean {
 		let lastSeenTooltipTime = this.getTooltipInformation(ClipperStorageKeys.lastSeenTooltipTimeBase, tooltipType);
 		if (lastSeenTooltipTime === 0) {
-			console.log("time did not exist in storage");
 			return false;
 		}
 
-		console.log("curTime: " + curTime + ", lastSeenTooltipTime: " + lastSeenTooltipTime + ", timePeriod: " + timePeriod);
 		return (curTime - lastSeenTooltipTime) < timePeriod;
 	}
 
@@ -102,7 +87,6 @@ export class TooltipHelper {
 	public hasAnyTooltipBeenSeenInLastTimePeriod(curTime: number, typesToCheck: TooltipType[], timePeriod): boolean {
 		return this.validTypes.some((tooltipType) => {
 			let tooltipWasSeen = this.tooltipHasBeenSeenInLastTimePeriod(tooltipType, curTime, timePeriod);
-			console.log("[" + TooltipType[tooltipType] + "] " + tooltipWasSeen);
 			return tooltipWasSeen;
 		});
 	}

--- a/src/scripts/extensions/tooltipHelper.ts
+++ b/src/scripts/extensions/tooltipHelper.ts
@@ -61,8 +61,9 @@ export class TooltipHelper {
 
 		// If it has been less than 7 days since the user saw any tooltip, then return false
 		let indexOfThisTooltip = this.validTypes.indexOf(tooltipType);
-		let tooltipsWithoutCurrentType = this.validTypes.splice(indexOfThisTooltip, 1);
-		if (this.hasAnyTooltipBeenSeenInLastTimePeriod(curTime, tooltipsWithoutCurrentType, Constants.Settings.timeBetweenDifferentTooltips)) {
+		let validTypesWithCurrentTypeRemoved = this.validTypes.slice();
+		validTypesWithCurrentTypeRemoved.splice(indexOfThisTooltip, 1);
+		if (this.hasAnyTooltipBeenSeenInLastTimePeriod(curTime, validTypesWithCurrentTypeRemoved, Constants.Settings.timeBetweenDifferentTooltips)) {
 			return false;
 		}
 		return true;
@@ -92,7 +93,7 @@ export class TooltipHelper {
 	 * Returns true if any of the @tooltipTypesToCheck have been seen in the last @timePeriod, given the current @time
 	 */
 	public hasAnyTooltipBeenSeenInLastTimePeriod(curTime: number, typesToCheck: TooltipType[], timePeriod: number): boolean {
-		return this.validTypes.some((tooltipType) => {
+		return typesToCheck.some((tooltipType) => {
 			let tooltipWasSeen = this.tooltipHasBeenSeenInLastTimePeriod(tooltipType, curTime, timePeriod);
 			return tooltipWasSeen;
 		});

--- a/src/scripts/extensions/tooltipHelper.ts
+++ b/src/scripts/extensions/tooltipHelper.ts
@@ -8,9 +8,11 @@ import {Storage} from "../storage/storage";
 
 export class TooltipHelper {
 	private storage: Storage;
+	private validTypes: TooltipType[];
 
 	constructor(storage: Storage) {
 		this.storage = storage;
+		this.validTypes = [TooltipType.Pdf, TooltipType.Product, TooltipType.Recipe, TooltipType.Video];
 	}
 
 	public getTooltipInformation(storageKeyBase: string, tooltipType: TooltipType): number {
@@ -33,22 +35,46 @@ export class TooltipHelper {
 		this.storage.setValue(storageKey, value);
 	}
 
-	public tooltipDelayIsOver(tooltipType: TooltipType, time: number) {
+	/**
+	 *  Returns false if:
+	 *	- A user has clipped the content type we are trying to upsell
+	 *  - The user has seen this tooltip more than maxTooltipsShown times
+	 *  - They've seen any of the tooltips in the last timeBetweenTooltips time period
+	 *  - They have set a preference to stop showing tooltips
+	 *
+	 *  Returns true otherwise
+	 */
+	public tooltipDelayIsOver(tooltipType: TooltipType, time: number): boolean {
 		if (Utils.isNullOrUndefined(tooltipType) || Utils.isNullOrUndefined(time)) {
 			throw new Error("Invalid argument passed to tooltipDelayIsOver");
 		}
 
+		let numTimesTooltipHasBeenSeen = this.getTooltipInformation(ClipperStorageKeys.numTimesTooltipHasBeenSeenBase, tooltipType);
 		let lastSeenTooltipTime = this.getTooltipInformation(ClipperStorageKeys.lastSeenTooltipTimeBase, tooltipType);
-		let lastSeenClipTime = this.getTooltipInformation(ClipperStorageKeys.lastClippedTooltipTimeBase, tooltipType);
+		let lastClipTime = this.getTooltipInformation(ClipperStorageKeys.lastClippedTooltipTimeBase, tooltipType);
+
+		// If the user has clipped this content type
+		if (lastClipTime !== 0) {
+			console.log("returned false");			
+			return false;
+		}
+
+		// If the user has seen enough of our tooltips :P 
+		if (numTimesTooltipHasBeenSeen >= Constants.Settings.maximumNumberOfTimesToShowTooltips) {
+			console.log("returned false");			
+			return false;
+		}
 
 		let timeBetweenTooltips = Constants.Settings.timeBetweenTooltips;
 
-		let isTooltipShownDelayOver = (time - lastSeenTooltipTime) >= timeBetweenTooltips;
-		let isClipDelayOver = (time - lastSeenClipTime) >= timeBetweenTooltips;
+		// If the user has seen any of the tooltips in the last timeBetweenTooltips
+		if (this.hasAnyTooltipBeenSeenInLastTimePeriod(time, this.validTypes, Constants.Settings.timeBetweenTooltips)) {
+			console.log("returned false");
+			return false;
+		}
 
-		// Only shows if it has been >= 3 weeks since the User saw a tooltip AND it has been >= 3 weeks
-		// since their last Clip of this specific TooltipType
-		return isTooltipShownDelayOver && isClipDelayOver;
+		console.log("returned true");
+		return true;
 	}
 
 	public static getStorageKeyForTooltip(storageKeyBase: string, tooltipType: TooltipType): string {
@@ -57,5 +83,27 @@ export class TooltipHelper {
 		}
 
 		return storageKeyBase + TooltipType[tooltipType];
+	}
+
+	public tooltipHasBeenSeenInLastTimePeriod(tooltipType: TooltipType, curTime: number, timePeriod: number): boolean {
+		let lastSeenTooltipTime = this.getTooltipInformation(ClipperStorageKeys.lastSeenTooltipTimeBase, tooltipType);
+		if (lastSeenTooltipTime === 0) {
+			console.log("time did not exist in storage");
+			return false;
+		}
+
+		console.log("curTime: " + curTime + ", lastSeenTooltipTime: " + lastSeenTooltipTime + ", timePeriod: " + timePeriod);
+		return (curTime - lastSeenTooltipTime) < timePeriod;
+	}
+
+	/**
+	 * Returns true if any of the @tooltipTypesToCheck have been seen in the last @timePeriod, given the current @time
+	 */
+	public hasAnyTooltipBeenSeenInLastTimePeriod(curTime: number, typesToCheck: TooltipType[], timePeriod): boolean {
+		return this.validTypes.some((tooltipType) => {
+			let tooltipWasSeen = this.tooltipHasBeenSeenInLastTimePeriod(tooltipType, curTime, timePeriod);
+			console.log("[" + TooltipType[tooltipType] + "] " + tooltipWasSeen);
+			return tooltipWasSeen;
+		});
 	}
 }

--- a/src/scripts/extensions/webExtensionBase/webExtension.ts
+++ b/src/scripts/extensions/webExtensionBase/webExtension.ts
@@ -89,7 +89,7 @@ export class WebExtension extends ExtensionBase<WebExtensionWorker, W3CTab, numb
 
 	protected checkIfTabIsAVideoDomain(tab: W3CTab): boolean {
 		let domain = VideoUtils.videoDomainIfSupported(tab.url);
-		return domain ? true : false;
+		return !!domain;
 	}
 
 	private invokeClipperInTab(tab: W3CTab, invokeInfo: InvokeInfo, options: InvokeOptions) {

--- a/src/scripts/extensions/webExtensionBase/webExtension.ts
+++ b/src/scripts/extensions/webExtensionBase/webExtension.ts
@@ -83,8 +83,8 @@ export class WebExtension extends ExtensionBase<WebExtensionWorker, W3CTab, numb
 		}
 	}
 
-	protected checkIfTabMatchesATooltipType(tab: W3CTab, tooltipType: TooltipType): boolean {
-		return Utils.checkIfUrlMatchesAContentType(tab.url, tooltipType);
+	protected checkIfTabMatchesATooltipType(tab: W3CTab, tooltipTypes: TooltipType[]): TooltipType {
+		return Utils.checkIfUrlMatchesAContentType(tab.url, tooltipTypes);
 	}
 
 	protected checkIfTabIsAVideoDomain(tab: W3CTab): boolean {

--- a/src/scripts/utils.ts
+++ b/src/scripts/utils.ts
@@ -136,14 +136,18 @@ export module Utils {
 		return this.ensureLeadingForwardSlash(urlPathName);
 	}
 
-	export function checkIfUrlMatchesAContentType(url: string, tooltipType: TooltipType) {
-		let contentTypeAsString = TooltipType[tooltipType];
-		let contentTypeRegexes = Settings.getSetting(contentTypeAsString + "Domains");
-		if (!contentTypeRegexes) {
-			return false;
+	export function checkIfUrlMatchesAContentType(url: string, tooltipTypes: TooltipType[]): TooltipType {
+		for (let i = 0; i < tooltipTypes.length; ++i) {
+			let tooltipType = tooltipTypes[i];
+			let contentTypeAsString = TooltipType[tooltipType];
+			let contentTypeRegexes = Settings.getSetting(contentTypeAsString + "Domains");
+			let concatenatedRegExes = new RegExp(contentTypeRegexes.join("|"), "i");
+			if (concatenatedRegExes.test(url)) {
+				return tooltipType;
+			}
 		}
-		let concatenatedRegExes = new RegExp(contentTypeRegexes.join("|"), "i");
-		return concatenatedRegExes.test(url);
+
+		return;
 	}
 
 	export function ensureLeadingForwardSlash(url: string): string {

--- a/src/tests/extensions/tooltipHelper_tests.ts
+++ b/src/tests/extensions/tooltipHelper_tests.ts
@@ -124,9 +124,9 @@ function setSeenTimeWithinRange(tooltipType: TooltipType, timePeriod: number) {
 	tooltipHelper.setTooltipInformation(ClipperStorageKeys.lastSeenTooltipTimeBase, tooltipType, timeToSet.toString());
 }
 
-function setSeenTimeOutsideOfRange() {
-	let timeToSet = baseTime - Constants.Settings.timeBetweenSameTooltip - 5000;
-	tooltipHelper.setTooltipInformation(ClipperStorageKeys.lastSeenTooltipTimeBase, testType, timeToSet.toString());
+function setSeenTimeOutsideOfRange(tooltipType: TooltipType, timePeriod: number) {
+	let timeToSet = baseTime - timePeriod - 5000;
+	tooltipHelper.setTooltipInformation(ClipperStorageKeys.lastSeenTooltipTimeBase, tooltipType, timeToSet.toString());
 }
 
 function setNumTimesTooltipHasBeenSeen(times: number) {
@@ -138,13 +138,8 @@ test("tooltipHasBeenSeenInLastTimePeriod should return FALSE when nothing is in 
 });
 
 test("tooltipHasBeenSeenInLastTimePeriod should return FALSE when a value is in storage but it is outside the time period", () => {
-	setSeenTimeOutsideOfRange();
+	setSeenTimeOutsideOfRange(testType, Constants.Settings.timeBetweenSameTooltip);
 	ok(!tooltipHelper.tooltipHasBeenSeenInLastTimePeriod(baseTime, testType, Constants.Settings.timeBetweenSameTooltip));
-});
-
-test("tooltipHasBeenSeenInLastTimePeriod should return TRUE when a value is in storage and is within the time period for non-production values", () => {
-	tooltipHelper.setTooltipInformation(ClipperStorageKeys.lastSeenTooltipTimeBase, testType, "15");
-	ok(tooltipHelper.tooltipHasBeenSeenInLastTimePeriod(testType, 25, 11));
 });
 
 test("tooltipHasBeenSeenInLastTimePeriod should return TRUE when a value is in storage and is within the time period", () => {
@@ -152,17 +147,12 @@ test("tooltipHasBeenSeenInLastTimePeriod should return TRUE when a value is in s
 	ok(tooltipHelper.tooltipHasBeenSeenInLastTimePeriod(testType, baseTime, Constants.Settings.timeBetweenSameTooltip));
 });
 
-test("tooltipHasBeenSeenInLastTimePeriod should return FALSE when a value is in storage, but it outside the time period #2", () => {
-	setSeenTimeWithinRange(testType, Constants.Settings.timeBetweenDifferentTooltips);
-	ok(!tooltipHelper.tooltipHasBeenSeenInLastTimePeriod(testType, baseTime, Constants.Settings.timeBetweenSameTooltip));
-});
-
 test("hasAnyTooltipBeenSeenInLastTimerPeriod should return FALSE when nothing is in storage", () => {
 	ok(!tooltipHelper.hasAnyTooltipBeenSeenInLastTimePeriod(baseTime, validTypes, Constants.Settings.timeBetweenDifferentTooltips));
 });
 
 test("hasAnyTooltipBeenSeenInLastTimePeriod should return TRUE if at least one of the tooltips has a lastSeenTooltipTime in Storage within the time period", () => {
-	setSeenTimeWithinRange(Constants.Settings.timeBetweenDifferentTooltips);
+	setSeenTimeWithinRange(testType, Constants.Settings.timeBetweenDifferentTooltips);
 	ok(tooltipHelper.hasAnyTooltipBeenSeenInLastTimePeriod(baseTime, validTypes, Constants.Settings.timeBetweenDifferentTooltips));
 });
 
@@ -180,14 +170,18 @@ test("tooltipDelayIsOver should return FALSE when the user has clipped this cont
 
 // Have they seen ANY content? If so, return FALSE
 test("tooltipDelayIsOver should return FALSE when they have seen a tooltip in the last 21 days", () => {
-	setSeenTimeWithinRange();
+	setSeenTimeWithinRange(testType, Constants.Settings.timeBetweenSameTooltip);
 	ok(!tooltipHelper.tooltipDelayIsOver(testType, baseTime));
 });
 
-test("tooltipDelayIsOver should return FALSE when they have seen a tooltip (not the same one) in the last 21 days", () => {
-	let timeToSet = baseTime - Constants.Settings.timeBetweenTooltips + 5000;
-	tooltipHelper.setTooltipInformation(ClipperStorageKeys.lastSeenTooltipTimeBase, TooltipType.Video, timeToSet.toString());
+test("tooltipDelayIsOver should return FALSE when they have seen a tooltip (not the same one) in the last 7 days", () => {
+	setSeenTimeWithinRange(TooltipType.Video, Constants.Settings.timeBetweenDifferentTooltips);
 	ok(!tooltipHelper.tooltipDelayIsOver(testType, baseTime));
+});
+
+test("tooltipDelayIsOver should return TRUE if they have NOT seen a different tooltip in the last 7 days", () => {
+	setSeenTimeOutsideOfRange(TooltipType.Video, Constants.Settings.timeBetweenDifferentTooltips);
+	ok(tooltipHelper.tooltipDelayIsOver(testType, baseTime));
 });
 
 // Has the user has seen the tooltip more than maxTooltipsShown times? If so, return FALSE
@@ -197,12 +191,12 @@ test("tooltipDelayIsOVer should return FALSE when the user has seen this tooltip
 });
 
 test("tooltipDelayIsOver should return TRUE when the user hasn't seen a tooltip in a while, they've never clipped this content, and they haven't gone over the max number of times to see the tooltip", () => {
-	setSeenTimeOutsideOfRange();
+	setSeenTimeOutsideOfRange(testType, Constants.Settings.timeBetweenSameTooltip);
 	ok(tooltipHelper.tooltipDelayIsOver(testType, baseTime));
 });
 
 test("tooltipDelayIsOver should return FALSE when the user has seen a tooltip in the last 21 days, no matter the value of lastClippedTime", () => {
-	setSeenTimeWithinRange();
+	setSeenTimeWithinRange(testType, Constants.Settings.timeBetweenSameTooltip);
 	ok(!tooltipHelper.tooltipDelayIsOver(testType, baseTime));
 
 	setClipTimeOutsideOfRange();
@@ -216,9 +210,9 @@ test("tooltipDelayIsOver should return FALSE when the user has clipped a tooltip
 	setClipTimeWithinRange();
 	ok(!tooltipHelper.tooltipDelayIsOver(testType, baseTime));
 
-	setSeenTimeOutsideOfRange();
+	setSeenTimeOutsideOfRange(testType, Constants.Settings.timeBetweenSameTooltip);
 	ok(!tooltipHelper.tooltipDelayIsOver(testType, baseTime));
 
-	setSeenTimeWithinRange();
+	setSeenTimeWithinRange(testType, Constants.Settings.timeBetweenSameTooltip);
 	ok(!tooltipHelper.tooltipDelayIsOver(testType, baseTime));
 });

--- a/src/tests/extensions/tooltipHelper_tests.ts
+++ b/src/tests/extensions/tooltipHelper_tests.ts
@@ -175,12 +175,12 @@ test("tooltipDelayIsOver should return FALSE when they have seen a tooltip in th
 });
 
 test("tooltipDelayIsOver should return FALSE when they have seen a tooltip (not the same one) in the last 7 days", () => {
-	setSeenTimeWithinRange(TooltipType.Video, Constants.Settings.timeBetweenDifferentTooltips);
-	ok(!tooltipHelper.tooltipDelayIsOver(testType, baseTime));
+	setSeenTimeWithinRange(TooltipType.Pdf, Constants.Settings.timeBetweenDifferentTooltips);
+	ok(!tooltipHelper.tooltipDelayIsOver(TooltipType.Product, baseTime));
 });
 
 test("tooltipDelayIsOver should return TRUE if they have NOT seen a different tooltip in the last 7 days", () => {
-	setSeenTimeOutsideOfRange(TooltipType.Video, Constants.Settings.timeBetweenDifferentTooltips);
+	setSeenTimeOutsideOfRange(TooltipType.Product, Constants.Settings.timeBetweenDifferentTooltips);
 	ok(tooltipHelper.tooltipDelayIsOver(testType, baseTime));
 });
 

--- a/src/tests/extensions/tooltipHelper_tests.ts
+++ b/src/tests/extensions/tooltipHelper_tests.ts
@@ -12,7 +12,8 @@ import {MockStorage} from "../storage/mockStorage";
 let tooltipHelper: TooltipHelper;
 let mockStorage: Storage;
 let testType = TooltipType.Pdf;
-let baseDate = new Date("09/27/1993 09:27:00 PM");
+let validTypes = [TooltipType.Pdf, TooltipType.Product, TooltipType.Recipe, TooltipType.Video];
+let baseTime = new Date("09/27/2016 00:00:00 PM").getTime();
 
 QUnit.module("tooltipHelper", {
 	beforeEach: () => {
@@ -109,63 +110,100 @@ test("Null or undefined passed to tooltipDelayIsOver should throw an Error", () 
 });
 
 function setClipTimeWithinRange() {
-	let timeToSet = baseDate.getTime() - Constants.Settings.timeBetweenTooltips + 5000;
+	let timeToSet = baseTime - Constants.Settings.timeBetweenTooltips + 5000;
 	tooltipHelper.setTooltipInformation(ClipperStorageKeys.lastClippedTooltipTimeBase, testType, timeToSet.toString());
 }
 
 function setClipTimeOutsideOfRange() {
-	let timeToSet = baseDate.getTime() - Constants.Settings.timeBetweenTooltips - 5000;
+	let timeToSet = baseTime - Constants.Settings.timeBetweenTooltips - 5000;
 	tooltipHelper.setTooltipInformation(ClipperStorageKeys.lastClippedTooltipTimeBase, testType, timeToSet.toString());
 }
 
 function setSeenTimeWithinRange() {
-	let timeToSet = baseDate.getTime() - Constants.Settings.timeBetweenTooltips + 5000;
+	let timeToSet = baseTime - Constants.Settings.timeBetweenTooltips + 5000;
 	tooltipHelper.setTooltipInformation(ClipperStorageKeys.lastSeenTooltipTimeBase, testType, timeToSet.toString());
 }
 
 function setSeenTimeOutsideOfRange() {
-	let timeToSet = baseDate.getTime() - Constants.Settings.timeBetweenTooltips - 5000;
+	let timeToSet = baseTime - Constants.Settings.timeBetweenTooltips - 5000;
 	tooltipHelper.setTooltipInformation(ClipperStorageKeys.lastSeenTooltipTimeBase, testType, timeToSet.toString());
 }
 
-test("tooltipDelayIsOver should return true when nothing in in storage", () => {
-	strictEqual(tooltipHelper.tooltipDelayIsOver(testType, Date.now()), true);
+function setNumTimesTooltipHasBeenSeen(times: number) {
+	tooltipHelper.setTooltipInformation(ClipperStorageKeys.numTimesTooltipHasBeenSeenBase, testType, times.toString());
+}
+
+test("tooltipHasBeenSeenInLastTimePeriod should return FALSE when nothing is in storage", () => {
+	ok(!tooltipHelper.tooltipHasBeenSeenInLastTimePeriod(baseTime, testType, Constants.Settings.timeBetweenTooltips));
 });
 
-test("tooltipDelayIsOver should return true when they haven't seen a tooltip in 21 days and the key for lastClippedTime is empty", () => {
+test("tooltipHasBeenSeenInLastTimePeriod should return FALSE when a value is in storage but it is outside the time period", () => {
 	setSeenTimeOutsideOfRange();
-	strictEqual(tooltipHelper.tooltipDelayIsOver(testType, baseDate.getTime()), true);
+	ok(!tooltipHelper.tooltipHasBeenSeenInLastTimePeriod(baseTime, testType, Constants.Settings.timeBetweenTooltips));
 });
 
-test("tooltipDelayIsOver should return true when they haven't clipped in 21 days and the key for lastSeenTime is empty", () => {
-	setClipTimeOutsideOfRange();
-	strictEqual(tooltipHelper.tooltipDelayIsOver(testType, baseDate.getTime()), true);
+test("tooltipHasBeenSeenInLastTimePeriod should return TRUE when a value is in storage and is within the time period", () => {
+	tooltipHelper.setTooltipInformation(ClipperStorageKeys.lastSeenTooltipTimeBase, testType, "15");
+	ok(tooltipHelper.tooltipHasBeenSeenInLastTimePeriod(testType, 25, 11));
 });
 
-test("tooltipDelayIsOver should return true when the user hasn't clipped in 21 days and hasn't seen a tooltip in 21 days", () => {
-	setClipTimeOutsideOfRange();
-	setSeenTimeOutsideOfRange();
-	strictEqual(tooltipHelper.tooltipDelayIsOver(testType, baseDate.getTime()), true);
+test("hasAnyTooltipBeenSeenInLastTimerPeriod should return FALSE when nothing is in storage", () => {
+	ok(!tooltipHelper.hasAnyTooltipBeenSeenInLastTimePeriod(baseTime, validTypes, Constants.Settings.timeBetweenTooltips));
 });
 
-test("tooltipDelayIsOver should return false when the user has seen a tooltip in the last 21 days, no matter the value of lastClippedTime", () => {
+test("hasAnyTooltipBeenSeenInLastTimePeriod should return TRUE if at least one of the tooltips has a lastSeenTooltipTime in Storage within the time period", () => {
 	setSeenTimeWithinRange();
-	strictEqual(tooltipHelper.tooltipDelayIsOver(testType, baseDate.getTime()), false);
+	ok(tooltipHelper.hasAnyTooltipBeenSeenInLastTimePeriod(baseTime, validTypes, Constants.Settings.timeBetweenTooltips));
+});
+
+test("tooltipDelayIsOver should return TRUE when nothing in in storage", () => {
+	ok(tooltipHelper.tooltipDelayIsOver(testType, baseTime));
+});
+
+// Have they clipped this content? If so, return FALSE
+test("tooltipDelayIsOver should return FALSE when the user has clipped this content type regardless of when they Clipped it and the rest of the values in storage", () => {
+	setClipTimeWithinRange();
+	ok(!tooltipHelper.tooltipDelayIsOver(testType, baseTime));
+	setClipTimeOutsideOfRange();
+	ok(!tooltipHelper.tooltipDelayIsOver(testType, baseTime));
+
+});
+
+// Have they seen ANY content? If so, return FALSE
+test("tooltipDelayIsOver should return TRUE when they haven't seen a tooltip in 21 days and the key for lastClippedTime is empty", () => {
+	setSeenTimeWithinRange();
+	ok(!tooltipHelper.tooltipDelayIsOver(testType, baseTime));
+});
+
+// Has the user has seen the tooltip more than maxTooltipsShown times? If so, return FALSE
+test("tooltipDelayIsOVer should return FALSE when the user has seen this tooltip more than maxTooltipsShown times", () => {
+	setNumTimesTooltipHasBeenSeen(Constants.Settings.maximumNumberOfTimesToShowTooltips);
+	ok(!tooltipHelper.tooltipDelayIsOver(testType, baseTime));
+});
+
+test("tooltipDelayIsOver should return TRUE when the user hasn't seen a tooltip in a while, they've never clipped this content, and they haven't gone over the max number of times to see the tooltip", () => {
+	setSeenTimeOutsideOfRange();
+	ok(tooltipHelper.tooltipDelayIsOver(testType, baseTime));
+});
+
+test("tooltipDelayIsOver should return FALSE when the user has seen a tooltip in the last 21 days, no matter the value of lastClippedTime", () => {
+	setSeenTimeWithinRange();
+	strictEqual(tooltipHelper.tooltipDelayIsOver(testType, baseTime), false);
 
 	setClipTimeOutsideOfRange();
-	strictEqual(tooltipHelper.tooltipDelayIsOver(testType, baseDate.getTime()), false);
+	strictEqual(tooltipHelper.tooltipDelayIsOver(testType, baseTime), false);
 
 	setClipTimeWithinRange();
-	strictEqual(tooltipHelper.tooltipDelayIsOver(testType, baseDate.getTime()), false);
+	strictEqual(tooltipHelper.tooltipDelayIsOver(testType, baseTime), false);
 });
 
-test("tooltipDelayIsOver should return false when the user has clipped a tooltip in the last 21 days, no matter the value of lastSeenTime", () => {
+test("tooltipDelayIsOver should return FALSE when the user has clipped a tooltip, no matter the value of lastSeenTime", () => {
 	setClipTimeWithinRange();
-	strictEqual(tooltipHelper.tooltipDelayIsOver(testType, baseDate.getTime()), false);
+	strictEqual(tooltipHelper.tooltipDelayIsOver(testType, baseTime), false);
 
 	setSeenTimeOutsideOfRange();
-	strictEqual(tooltipHelper.tooltipDelayIsOver(testType, baseDate.getTime()), false);
+	strictEqual(tooltipHelper.tooltipDelayIsOver(testType, baseTime), false);
 
 	setSeenTimeWithinRange();
-	strictEqual(tooltipHelper.tooltipDelayIsOver(testType, baseDate.getTime()), false);
+	strictEqual(tooltipHelper.tooltipDelayIsOver(testType, baseTime), false);
 });

--- a/src/tests/extensions/tooltipHelper_tests.ts
+++ b/src/tests/extensions/tooltipHelper_tests.ts
@@ -166,12 +166,17 @@ test("tooltipDelayIsOver should return FALSE when the user has clipped this cont
 	ok(!tooltipHelper.tooltipDelayIsOver(testType, baseTime));
 	setClipTimeOutsideOfRange();
 	ok(!tooltipHelper.tooltipDelayIsOver(testType, baseTime));
-
 });
 
 // Have they seen ANY content? If so, return FALSE
-test("tooltipDelayIsOver should return TRUE when they haven't seen a tooltip in 21 days and the key for lastClippedTime is empty", () => {
+test("tooltipDelayIsOver should return FALSE when they have seen a tooltip in the last 21 days", () => {
 	setSeenTimeWithinRange();
+	ok(!tooltipHelper.tooltipDelayIsOver(testType, baseTime));
+});
+
+test("tooltipDelayIsOver should return FALSE when they have seen a tooltip (not the same one) in the last 21 days", () => {
+	let timeToSet = baseTime - Constants.Settings.timeBetweenTooltips + 5000;
+	tooltipHelper.setTooltipInformation(ClipperStorageKeys.lastSeenTooltipTimeBase, TooltipType.Video, timeToSet.toString());
 	ok(!tooltipHelper.tooltipDelayIsOver(testType, baseTime));
 });
 
@@ -188,22 +193,22 @@ test("tooltipDelayIsOver should return TRUE when the user hasn't seen a tooltip 
 
 test("tooltipDelayIsOver should return FALSE when the user has seen a tooltip in the last 21 days, no matter the value of lastClippedTime", () => {
 	setSeenTimeWithinRange();
-	strictEqual(tooltipHelper.tooltipDelayIsOver(testType, baseTime), false);
+	ok(!tooltipHelper.tooltipDelayIsOver(testType, baseTime));
 
 	setClipTimeOutsideOfRange();
-	strictEqual(tooltipHelper.tooltipDelayIsOver(testType, baseTime), false);
+	ok(!tooltipHelper.tooltipDelayIsOver(testType, baseTime));
 
 	setClipTimeWithinRange();
-	strictEqual(tooltipHelper.tooltipDelayIsOver(testType, baseTime), false);
+	ok(!tooltipHelper.tooltipDelayIsOver(testType, baseTime));
 });
 
 test("tooltipDelayIsOver should return FALSE when the user has clipped a tooltip, no matter the value of lastSeenTime", () => {
 	setClipTimeWithinRange();
-	strictEqual(tooltipHelper.tooltipDelayIsOver(testType, baseTime), false);
+	ok(!tooltipHelper.tooltipDelayIsOver(testType, baseTime));
 
 	setSeenTimeOutsideOfRange();
-	strictEqual(tooltipHelper.tooltipDelayIsOver(testType, baseTime), false);
+	ok(!tooltipHelper.tooltipDelayIsOver(testType, baseTime));
 
 	setSeenTimeWithinRange();
-	strictEqual(tooltipHelper.tooltipDelayIsOver(testType, baseTime), false);
+	ok(!tooltipHelper.tooltipDelayIsOver(testType, baseTime));
 });

--- a/src/tests/extensions/tooltipHelper_tests.ts
+++ b/src/tests/extensions/tooltipHelper_tests.ts
@@ -147,7 +147,7 @@ test("tooltipHasBeenSeenInLastTimePeriod should return TRUE when a value is in s
 	ok(tooltipHelper.tooltipHasBeenSeenInLastTimePeriod(testType, baseTime, Constants.Settings.timeBetweenSameTooltip));
 });
 
-test("hasAnyTooltipBeenSeenInLastTimerPeriod should return FALSE when nothing is in storage", () => {
+test("hasAnyTooltipBeenSeenInLastTimePeriod should return FALSE when nothing is in storage", () => {
 	ok(!tooltipHelper.hasAnyTooltipBeenSeenInLastTimePeriod(baseTime, validTypes, Constants.Settings.timeBetweenDifferentTooltips));
 });
 
@@ -169,17 +169,17 @@ test("tooltipDelayIsOver should return FALSE when the user has clipped this cont
 });
 
 // Have they seen ANY content? If so, return FALSE
-test("tooltipDelayIsOver should return FALSE when they have seen a tooltip in the last 21 days", () => {
+test("tooltipDelayIsOver should return FALSE when they have seen a tooltip in the last Constants.Settings.timeBetweenSameTooltip period", () => {
 	setSeenTimeWithinRange(testType, Constants.Settings.timeBetweenSameTooltip);
 	ok(!tooltipHelper.tooltipDelayIsOver(testType, baseTime));
 });
 
-test("tooltipDelayIsOver should return FALSE when they have seen a tooltip (not the same one) in the last 7 days", () => {
+test("tooltipDelayIsOver should return FALSE when they have seen a tooltip (not the same one) in the last Constants.Settings.timeBetweenDifferentTooltipsPeriod", () => {
 	setSeenTimeWithinRange(TooltipType.Pdf, Constants.Settings.timeBetweenDifferentTooltips);
 	ok(!tooltipHelper.tooltipDelayIsOver(TooltipType.Product, baseTime));
 });
 
-test("tooltipDelayIsOver should return TRUE if they have NOT seen a different tooltip in the last 7 days", () => {
+test("tooltipDelayIsOver should return TRUE if they have NOT seen a different tooltip in the last Constants.Settings.timeBetweenDifferentTooltipsPeriod", () => {
 	setSeenTimeOutsideOfRange(TooltipType.Product, Constants.Settings.timeBetweenDifferentTooltips);
 	ok(tooltipHelper.tooltipDelayIsOver(testType, baseTime));
 });
@@ -195,7 +195,7 @@ test("tooltipDelayIsOver should return TRUE when the user hasn't seen a tooltip 
 	ok(tooltipHelper.tooltipDelayIsOver(testType, baseTime));
 });
 
-test("tooltipDelayIsOver should return FALSE when the user has seen a tooltip in the last 21 days, no matter the value of lastClippedTime", () => {
+test("tooltipDelayIsOver should return FALSE when the user has seen a tooltip in the last Constants.Settings.timeBetweenSameTooltip period, no matter the value of lastClippedTime", () => {
 	setSeenTimeWithinRange(testType, Constants.Settings.timeBetweenSameTooltip);
 	ok(!tooltipHelper.tooltipDelayIsOver(testType, baseTime));
 

--- a/src/tests/extensions/tooltipHelper_tests.ts
+++ b/src/tests/extensions/tooltipHelper_tests.ts
@@ -110,22 +110,22 @@ test("Null or undefined passed to tooltipDelayIsOver should throw an Error", () 
 });
 
 function setClipTimeWithinRange() {
-	let timeToSet = baseTime - Constants.Settings.timeBetweenTooltips + 5000;
+	let timeToSet = baseTime - Constants.Settings.timeBetweenSameTooltip + 5000;
 	tooltipHelper.setTooltipInformation(ClipperStorageKeys.lastClippedTooltipTimeBase, testType, timeToSet.toString());
 }
 
 function setClipTimeOutsideOfRange() {
-	let timeToSet = baseTime - Constants.Settings.timeBetweenTooltips - 5000;
+	let timeToSet = baseTime - Constants.Settings.timeBetweenSameTooltip - 5000;
 	tooltipHelper.setTooltipInformation(ClipperStorageKeys.lastClippedTooltipTimeBase, testType, timeToSet.toString());
 }
 
-function setSeenTimeWithinRange() {
-	let timeToSet = baseTime - Constants.Settings.timeBetweenTooltips + 5000;
-	tooltipHelper.setTooltipInformation(ClipperStorageKeys.lastSeenTooltipTimeBase, testType, timeToSet.toString());
+function setSeenTimeWithinRange(tooltipType: TooltipType, timePeriod: number) {
+	let timeToSet = baseTime - timePeriod + 5000;
+	tooltipHelper.setTooltipInformation(ClipperStorageKeys.lastSeenTooltipTimeBase, tooltipType, timeToSet.toString());
 }
 
 function setSeenTimeOutsideOfRange() {
-	let timeToSet = baseTime - Constants.Settings.timeBetweenTooltips - 5000;
+	let timeToSet = baseTime - Constants.Settings.timeBetweenSameTooltip - 5000;
 	tooltipHelper.setTooltipInformation(ClipperStorageKeys.lastSeenTooltipTimeBase, testType, timeToSet.toString());
 }
 
@@ -134,26 +134,36 @@ function setNumTimesTooltipHasBeenSeen(times: number) {
 }
 
 test("tooltipHasBeenSeenInLastTimePeriod should return FALSE when nothing is in storage", () => {
-	ok(!tooltipHelper.tooltipHasBeenSeenInLastTimePeriod(baseTime, testType, Constants.Settings.timeBetweenTooltips));
+	ok(!tooltipHelper.tooltipHasBeenSeenInLastTimePeriod(baseTime, testType, Constants.Settings.timeBetweenSameTooltip));
 });
 
 test("tooltipHasBeenSeenInLastTimePeriod should return FALSE when a value is in storage but it is outside the time period", () => {
 	setSeenTimeOutsideOfRange();
-	ok(!tooltipHelper.tooltipHasBeenSeenInLastTimePeriod(baseTime, testType, Constants.Settings.timeBetweenTooltips));
+	ok(!tooltipHelper.tooltipHasBeenSeenInLastTimePeriod(baseTime, testType, Constants.Settings.timeBetweenSameTooltip));
 });
 
-test("tooltipHasBeenSeenInLastTimePeriod should return TRUE when a value is in storage and is within the time period", () => {
+test("tooltipHasBeenSeenInLastTimePeriod should return TRUE when a value is in storage and is within the time period for non-production values", () => {
 	tooltipHelper.setTooltipInformation(ClipperStorageKeys.lastSeenTooltipTimeBase, testType, "15");
 	ok(tooltipHelper.tooltipHasBeenSeenInLastTimePeriod(testType, 25, 11));
 });
 
+test("tooltipHasBeenSeenInLastTimePeriod should return TRUE when a value is in storage and is within the time period", () => {
+	setSeenTimeWithinRange(testType, Constants.Settings.timeBetweenSameTooltip);
+	ok(tooltipHelper.tooltipHasBeenSeenInLastTimePeriod(testType, baseTime, Constants.Settings.timeBetweenSameTooltip));
+});
+
+test("tooltipHasBeenSeenInLastTimePeriod should return FALSE when a value is in storage, but it outside the time period #2", () => {
+	setSeenTimeWithinRange(testType, Constants.Settings.timeBetweenDifferentTooltips);
+	ok(!tooltipHelper.tooltipHasBeenSeenInLastTimePeriod(testType, baseTime, Constants.Settings.timeBetweenSameTooltip));
+});
+
 test("hasAnyTooltipBeenSeenInLastTimerPeriod should return FALSE when nothing is in storage", () => {
-	ok(!tooltipHelper.hasAnyTooltipBeenSeenInLastTimePeriod(baseTime, validTypes, Constants.Settings.timeBetweenTooltips));
+	ok(!tooltipHelper.hasAnyTooltipBeenSeenInLastTimePeriod(baseTime, validTypes, Constants.Settings.timeBetweenDifferentTooltips));
 });
 
 test("hasAnyTooltipBeenSeenInLastTimePeriod should return TRUE if at least one of the tooltips has a lastSeenTooltipTime in Storage within the time period", () => {
-	setSeenTimeWithinRange();
-	ok(tooltipHelper.hasAnyTooltipBeenSeenInLastTimePeriod(baseTime, validTypes, Constants.Settings.timeBetweenTooltips));
+	setSeenTimeWithinRange(Constants.Settings.timeBetweenDifferentTooltips);
+	ok(tooltipHelper.hasAnyTooltipBeenSeenInLastTimePeriod(baseTime, validTypes, Constants.Settings.timeBetweenDifferentTooltips));
 });
 
 test("tooltipDelayIsOver should return TRUE when nothing in in storage", () => {

--- a/src/tests/utils_tests.ts
+++ b/src/tests/utils_tests.ts
@@ -342,42 +342,39 @@ test("getPathName should return a valid path given a valid URL", () => {
 	ok(Utils.getPathname("https://www.youtube.com"), "/");
 });
 
-test("checkIfUrlMatchesAContentType should return false for an undefined, null, or empty URL", () => {
-	let tooltipsToTest = [TooltipType.Pdf, TooltipType.Product, TooltipType.Recipe];
-
-	tooltipsToTest.forEach((tooltip) => {
-		ok(!Utils.checkIfUrlMatchesAContentType(undefined, tooltip));
-		/* tslint:disable:no-null-keyword */
-		ok(!Utils.checkIfUrlMatchesAContentType(null, tooltip));
-		/* tslint:enable:no-null-keyword */
-		ok(!Utils.checkIfUrlMatchesAContentType("", tooltip));
-	});
+let tooltipsToTest = [TooltipType.Pdf, TooltipType.Product, TooltipType.Recipe];
+test("checkIfUrlMatchesAContentType should return UNDEFINED for an undefined, null, or empty URL", () => {
+	ok(!Utils.checkIfUrlMatchesAContentType(undefined, tooltipsToTest));
+	/* tslint:disable:no-null-keyword */
+	ok(!Utils.checkIfUrlMatchesAContentType(null, tooltipsToTest));
+	/* tslint:enable:no-null-keyword */
+	ok(!Utils.checkIfUrlMatchesAContentType("", tooltipsToTest));
 });
 
-test("checkIfUrlMatchesAContentType for PDF should return false for a valid URL without .pdf at the end", () => {
-	ok(!Utils.checkIfUrlMatchesAContentType("https://www.fistbump.reviews", TooltipType.Pdf));
-	ok(!Utils.checkIfUrlMatchesAContentType("https://fistbumppdfs.reviews", TooltipType.Pdf));
+test("checkIfUrlMatchesAContentType for PDF should return UNDEFINED for a valid URL without .pdf at the end", () => {
+	ok(!Utils.checkIfUrlMatchesAContentType("https://www.fistbump.reviews", tooltipsToTest));
+	ok(!Utils.checkIfUrlMatchesAContentType("https://fistbumppdfs.reviews", tooltipsToTest));
 });
 
-test("checkIfUrlMatchesAContentType for PDF should return true for a valid URL with .pdf at the end, case insensitive", () => {
-	ok(Utils.checkIfUrlMatchesAContentType("https://wwww.wen.jen/shipItFresh.pdf", TooltipType.Pdf));
-	ok(Utils.checkIfUrlMatchesAContentType("http://www.orimi.com/pdf-test.PDF", TooltipType.Pdf));
+test("checkIfUrlMatchesAContentType for PDF should return PDF for a valid URL with .pdf at the end, case insensitive", () => {
+	strictEqual(Utils.checkIfUrlMatchesAContentType("https://wwww.wen.jen/shipItFresh.pdf", tooltipsToTest), TooltipType.Pdf);
+	strictEqual(Utils.checkIfUrlMatchesAContentType("http://www.orimi.com/pdf-test.PDF", tooltipsToTest), TooltipType.Pdf);
 });
 
-test("checkIfUrlMatchesAContentType for Product should return false for an invalid url", () => {
-	ok(!Utils.checkIfUrlMatchesAContentType("https://www.onenote.com/clipper", TooltipType.Product));
+test("checkIfUrlMatchesAContentType for Product should return UNDEFINED for an invalid url", () => {
+	ok(!Utils.checkIfUrlMatchesAContentType("https://www.onenote.com/clipper", tooltipsToTest));
 });
 
-test("checkIfUrlMatchesAContentType for Product should return true for a valid Wal-mart URL", () => {
-	ok(Utils.checkIfUrlMatchesAContentType("http://www.walmart.com/ip/49424374", TooltipType.Product));
+test("checkIfUrlMatchesAContentType for Product should return Product for a valid Wal-mart URL", () => {
+	strictEqual(Utils.checkIfUrlMatchesAContentType("http://www.walmart.com/ip/49424374", tooltipsToTest), TooltipType.Product);
 });
 
-test("checkIfUrlMatchesAContentType for Recipe should return false for a valid url that isnt in the regex match", () => {
-	ok(!Utils.checkIfUrlMatchesAContentType("https://www.onenote.com/clipper", TooltipType.Recipe));
+test("checkIfUrlMatchesAContentType for Recipe should return UNDEFINED for a valid url that isnt in the regex match", () => {
+	ok(!Utils.checkIfUrlMatchesAContentType("https://www.onenote.com/clipper", tooltipsToTest));
 });
 
-test("checkIfUrlMatchesAContentType for Recipe should return true for a valid URL", () => {
-	ok(Utils.checkIfUrlMatchesAContentType("http://www.chowhound.com/recipes/easy-grilled-cheese-31834", TooltipType.Recipe));
+test("checkIfUrlMatchesAContentType for Recipe should return RECIPE for a valid URL", () => {
+	strictEqual(Utils.checkIfUrlMatchesAContentType("http://www.chowhound.com/recipes/easy-grilled-cheese-31834", tooltipsToTest), TooltipType.Recipe);
 });
 
 test("ensureLeadingForwardSlash should return a valid path given different browser return values.", () => {


### PR DESCRIPTION
Changed logic to:
1. If a user has ever clipped this content type, do not show the tooltip
2. If a user has seen this tooltip in the last 21 days, do not show the tooltip
3. If a user has seen ANY OTHER tooltip in the last 7 days, do not show the tooltip (to prevent seeing 4 tooltips when hopping page to page)
4. If a user has seen a tooltip 3 or more times, never show the tooltip

There will be another PR when design gets back to us about letting users turn it off.

Resolves #39 

As for logic cleanup, now instead of iterating through each `TooltipType` and checking against all the regexes and delays, if a page matches a content type and the delay is over `shouldShowTooltip(...)` returns that `TooltipType` and then we show it. 
