### PR TITLE
Added the ability for the extension to inject an install marker on frames

### DIFF
--- a/src/scripts/constants.ts
+++ b/src/scripts/constants.ts
@@ -85,6 +85,9 @@ export module Constants {
 		export var userDropdownArrow = "userDropdownArrow";
 		export var userSettingsContainer = "userSettingsContainer";
 
+		// install marker
+		export var installMarker = "oneNoteWebClipperIsInstalledOnThisBrowser";
+
 		// loadingPanel
 		export var clipperLoadingContainer = "clipperLoadingContainer";
 

--- a/src/scripts/extensions/safari/safariInject.ts
+++ b/src/scripts/extensions/safari/safariInject.ts
@@ -13,7 +13,16 @@ declare var safari;
  * to execute the code
  */
 
-// This is injected into every page loaded (including frames), but we only want to set the listener on the main document
+// This is injected into every page loaded (including frames)
+
+if (!document.getElementById(Constants.Ids.installMarker)) {
+	let marker = document.createElement("DIV");
+	marker.id = Constants.Ids.installMarker;
+	marker.style.display = "none";
+	document.body.appendChild(marker);
+}
+
+// We only want to set the listener on the main document
 if (window.top === window) {
 	safari.self.addEventListener("message", (event) => {
 		if (event.name === Constants.FunctionKeys.invokeClipper) {

--- a/src/scripts/extensions/webExtensionBase/webExtension.ts
+++ b/src/scripts/extensions/webExtensionBase/webExtension.ts
@@ -44,6 +44,24 @@ export class WebExtension extends ExtensionBase<WebExtensionWorker, W3CTab, numb
 		this.registerContextMenuItems();
 		this.registerInstallListener();
 		this.registerTabRemoveListener();
+		this.registerAppendInstalledMarkerOnNav();
+	}
+
+	private registerAppendInstalledMarkerOnNav() {
+		WebExtension.browser.webNavigation.onCompleted.addListener((details) => {
+			let code = [
+				"if (!document.getElementById('" + Constants.Ids.installMarker + "')) {",
+					"var marker = document.createElement('DIV');",
+					"marker.id = '" + Constants.Ids.installMarker + "';",
+					"marker.style.display = 'none';",
+					"document.body.appendChild(marker);",
+				"}"
+			].join("\n");
+			WebExtension.browser.tabs.executeScript(details.tabId, {
+				code: code,
+				allFrames: true
+			});
+		});
 	}
 
 	public static getExtensionVersion(): string {


### PR DESCRIPTION
We need a way for our sites to reliably check if the Web Clipper is installed in a browser agnostic manner. On navigates, we inject an empty, hidden div onto the page and its frames which we can then check for.
