### PR TITLE
(Fix for xhtml sites) Enforce the use of lowercase when creating or querying for html elements

### DIFF
--- a/src/scripts/clipperUI/components/previewViewer/editorPreviewComponentBase.tsx
+++ b/src/scripts/clipperUI/components/previewViewer/editorPreviewComponentBase.tsx
@@ -157,7 +157,7 @@ export abstract class EditorPreviewComponentBase<TState extends EditorPreviewSta
 				// Find the first instance of the highlight and add the delete button
 				let firstHighlighted = highlightablePreviewBody.querySelector("span.highlighted[data-timestamp='" + timestamp + "']");
 				if (firstHighlighted) {
-					let deleteHighlight = document.createElement("IMG") as HTMLImageElement;
+					let deleteHighlight = document.createElement("img") as HTMLImageElement;
 					deleteHighlight.src = Utils.getImageResourceUrl("editoroptions/delete_button.png");
 					deleteHighlight.className = Constants.Classes.deleteHighlightButton;
 					deleteHighlight.setAttribute("data-timestamp", "" + timestamp);

--- a/src/scripts/clipperUI/regionSelector.tsx
+++ b/src/scripts/clipperUI/regionSelector.tsx
@@ -271,7 +271,7 @@ class RegionSelectorClass extends ComponentBase<RegionSelectorState, ClipperStat
 				let sourceWidth = (xMax - xMin) * this.devicePixelRatio;
 				let sourceHeight = (yMax - yMin) * this.devicePixelRatio;
 
-				let canvas: HTMLCanvasElement = document.createElement("CANVAS") as HTMLCanvasElement;
+				let canvas: HTMLCanvasElement = document.createElement("canvas") as HTMLCanvasElement;
 				canvas.width = width;
 				canvas.height = height;
 				let ctx: CanvasRenderingContext2D = canvas.getContext("2d");

--- a/src/scripts/clipperUI/saveToOneNote.ts
+++ b/src/scripts/clipperUI/saveToOneNote.ts
@@ -65,7 +65,7 @@ export class SaveToOneNote {
 		pageModificationsEvent.setCustomProperty(Log.PropertyName.Custom.IsSerif, isAugmentationMode ? clipperState.previewGlobalInfo.serif : notApplicableText);
 
 		if (isAugmentationMode) {
-			let container = document.createElement("DIV");
+			let container = document.createElement("div");
 			container.innerHTML = clipperState.augmentationPreviewInfo.previewBodyHtml;
 			let highlightedList = container.getElementsByClassName(Constants.Classes.highlighted);
 			pageModificationsEvent.setCustomProperty(Log.PropertyName.Custom.ContainsAtLeastOneHighlight, highlightedList && highlightedList.length > 0);
@@ -153,7 +153,7 @@ export class SaveToOneNote {
 
 	private static createPostProcessessedHtml(html: string): HTMLElement {
 		// Wrap the preview in in-line styling to persist the styling through the OneNote API
-		let newPreviewBody = document.createElement("DIV");
+		let newPreviewBody = document.createElement("div");
 		newPreviewBody.innerHTML = html;
 
 		let fontSize = this.clipperState.previewGlobalInfo.fontSize.toString() + "px";

--- a/src/scripts/contentCapture/pdfScreenshotHelper.ts
+++ b/src/scripts/contentCapture/pdfScreenshotHelper.ts
@@ -81,7 +81,7 @@ export class PdfScreenshotHelper {
 				// Pages start at index 1
 				pdf.getPage(i + 1).then((page) => {
 					let viewport = page.getViewport(1 /* scale */);
-					let canvas = document.createElement("CANVAS") as HTMLCanvasElement;
+					let canvas = document.createElement("canvas") as HTMLCanvasElement;
 					let context = canvas.getContext("2d");
 					canvas.height = viewport.height;
 					canvas.width = viewport.width;

--- a/src/scripts/domParsers/domUtils.ts
+++ b/src/scripts/domParsers/domUtils.ts
@@ -69,7 +69,7 @@ export module DomUtils {
 
 		// ... and for everything else, we replace them with an equivalent, preserving the inner HTML
 		domReplacer(doc, Tags.center, (node: HTMLElement) => {
-			let div = document.createElement("DIV");
+			let div = document.createElement("div");
 			div.innerHTML = node.innerHTML;
 			return div;
 		});
@@ -385,7 +385,7 @@ export module DomUtils {
 			return false;
 		}
 
-		let canvas = document.createElement("CANVAS") as HTMLCanvasElement;
+		let canvas = document.createElement("canvas") as HTMLCanvasElement;
 		canvas.width = img.width;
 		canvas.height = img.height;
 

--- a/src/scripts/extensions/clipperInject.ts
+++ b/src/scripts/extensions/clipperInject.ts
@@ -105,7 +105,7 @@ export class ClipperInject extends FrameInjectBase<ClipperInjectOptions> {
 						let doc = (new DOMParser()).parseFromString(range.toHtml(), "text/html");
 						DomUtils.toOnml(doc).then(() => {
 							// Selections are prone to not having an outer html element, which can lead to anomalies in preview
-							let divContainer = document.createElement("DIV");
+							let divContainer = document.createElement("div");
 							divContainer.innerHTML = doc.body.innerHTML;
 							invokeOptions.invokeDataForMode = divContainer.outerHTML;
 

--- a/src/scripts/extensions/styledFrameFactory.ts
+++ b/src/scripts/extensions/styledFrameFactory.ts
@@ -46,7 +46,7 @@ export class StyledFrameFactory {
 	}
 
 	private static getGloballyStyledFrame(): HTMLIFrameElement {
-		let element = document.createElement("IFRAME") as HTMLIFrameElement;
+		let element = document.createElement("iframe") as HTMLIFrameElement;
 		StyledFrameFactory.applyGlobalStyles(element);
 		return element;
 	}

--- a/src/tests/clipperUI/components/previewViewer/augmentationPreview_tests.tsx
+++ b/src/tests/clipperUI/components/previewViewer/augmentationPreview_tests.tsx
@@ -367,7 +367,7 @@ test("If the user selects something in the highlightable preview body, then clic
 	let augmentationPreview = HelperFunctions.mountToFixture(defaultComponent);
 
 	// This id is necessary for the highlighting to be enabled on this element's children
-	let paragraph = document.createElement("P");
+	let paragraph = document.createElement("p");
 	let paragraphId = "para";
 	paragraph.id = paragraphId;
 	let innerText = "Test";
@@ -402,7 +402,7 @@ test("If the user selects something outside the highlightable preview body, then
 	let augmentationPreview = HelperFunctions.mountToFixture(defaultComponent);
 
 	// This id is necessary for the highlighting to be enabled on this element's children
-	let paragraph = document.createElement("P");
+	let paragraph = document.createElement("p");
 	let paragraphId = "para";
 	paragraph.id = paragraphId;
 	let innerText = "Test";

--- a/src/tests/clipperUI/regionSelector_tests.tsx
+++ b/src/tests/clipperUI/regionSelector_tests.tsx
@@ -371,7 +371,7 @@ test("For a single white pixel as the region selection, its quality should not b
 	let controllerInstance = HelperFunctions.mountToFixture(defaultComponent);
 
 	let img = new Image();
-	let canvas = document.createElement("CANVAS") as HTMLCanvasElement;
+	let canvas = document.createElement("canvas") as HTMLCanvasElement;
 	img.onload = () => {
 		canvas.getContext("2d").drawImage(img, 0, 0);
 		let expectedUrl = canvas.toDataURL("image/png");
@@ -389,7 +389,7 @@ test("For a large image as the region selection, the resulting image should be d
 	let controllerInstance = HelperFunctions.mountToFixture(defaultComponent);
 
 	let img = new Image();
-	let canvas = document.createElement("CANVAS") as HTMLCanvasElement;
+	let canvas = document.createElement("canvas") as HTMLCanvasElement;
 	img.onload = () => {
 		canvas.getContext("2d").drawImage(img, 0, 0);
 		let actualUrl = controllerInstance.getCompressedDataUrl(canvas);

--- a/src/tests/contentCapture/augmentationHelper_tests.ts
+++ b/src/tests/contentCapture/augmentationHelper_tests.ts
@@ -156,7 +156,7 @@ test("getAugmentationType returns 'Article' for types that we don't support", ()
 });
 
 test("getArticlePreviewElement should return the MainArticleContainer class element if it exists", () => {
-	let mainArticleContainer = document.createElement("DIV") as HTMLHtmlElement;
+	let mainArticleContainer = <any>document.createElement("div") as HTMLHtmlElement;
 	mainArticleContainer.className = "MainArticleContainer";
 	fixture.appendChild(mainArticleContainer);
 

--- a/src/tests/contentCapture/bookmarkHelper_tests.ts
+++ b/src/tests/contentCapture/bookmarkHelper_tests.ts
@@ -27,7 +27,7 @@ module TestHelper {
 	}
 
 	export function createHTMLMetaElement(attribute: MetadataKeyValuePair, content: string): HTMLMetaElement {
-		let metaElement: HTMLMetaElement = document.createElement("META") as HTMLMetaElement;
+		let metaElement: HTMLMetaElement = document.createElement("meta") as HTMLMetaElement;
 
 		metaElement.setAttribute(attribute.key, attribute.value);
 		if (content) {
@@ -38,7 +38,7 @@ module TestHelper {
 	}
 
 	export function createHTMLImageElement(srcUrl: string): HTMLImageElement {
-		let imgElement: HTMLImageElement = document.createElement("IMG") as HTMLImageElement;
+		let imgElement: HTMLImageElement = document.createElement("img") as HTMLImageElement;
 		if (srcUrl) {
 			imgElement.setAttribute(BookmarkHelper.srcAttrName, srcUrl);
 		}

--- a/src/tests/domParsers/domUtils_tests.ts
+++ b/src/tests/domParsers/domUtils_tests.ts
@@ -11,25 +11,25 @@ import {HelperFunctions} from "../helperFunctions";
 import {DataUrls} from "../clipperUI/regionSelector_tests_dataUrls";
 
 function createRootScriptIFrame(): HTMLIFrameElement {
-	let iframe = document.createElement("IFRAME") as HTMLIFrameElement;
+	let iframe = document.createElement("iframe") as HTMLIFrameElement;
 	iframe.id = Constants.Ids.clipperRootScript;
 	return iframe;
 }
 
 function createUiIFrame(): HTMLIFrameElement {
-	let iframe = document.createElement("IFRAME") as HTMLIFrameElement;
+	let iframe = document.createElement("iframe") as HTMLIFrameElement;
 	iframe.id = Constants.Ids.clipperUiFrame;
 	return iframe;
 }
 
 function createExtIFrame(): HTMLIFrameElement {
-	let iframe = document.createElement("IFRAME") as HTMLIFrameElement;
+	let iframe = document.createElement("iframe") as HTMLIFrameElement;
 	iframe.id = Constants.Ids.clipperExtFrame;
 	return iframe;
 }
 
 function createMainArticleContainer(): HTMLHtmlElement {
-	let div = document.createElement("DIV") as HTMLHtmlElement;
+	let div = <any>document.createElement("div") as HTMLHtmlElement;
 	div.className = "MainArticleContainer";
 	return div;
 }
@@ -93,7 +93,7 @@ test("removeClipperElements should remove all Web Clipper iframes, but not an ar
 	fixture.appendChild(createUiIFrame());
 	fixture.appendChild(createExtIFrame());
 
-	let arbitraryIframe = document.createElement("IFRAME") as HTMLIFrameElement;
+	let arbitraryIframe = document.createElement("iframe") as HTMLIFrameElement;
 	let arbitraryIframeId = "whatever";
 	arbitraryIframe.id = arbitraryIframeId;
 	arbitraryIframe.src = "https://www.mywebsite.doesnotexist";
@@ -116,7 +116,7 @@ test("removeClipperElements should remove all Web Clipper iframes, but not an ar
 });
 
 test("removeUnwantedElements should remove elements with tags that we don't support in full page mode", () => {
-	let tagsNotSupportedForFullPage = ["SCRIPT", "NOSCRIPT"];
+	let tagsNotSupportedForFullPage = ["script", "noscript"];
 	for (let i = 0; i < tagsNotSupportedForFullPage.length; i++) {
 		let element = document.createElement(tagsNotSupportedForFullPage[i]);
 		element.id = tagsNotSupportedForFullPage[i];
@@ -133,7 +133,7 @@ test("removeUnwantedElements should remove elements with tags that we don't supp
 
 test("removeUnwantedElements should not remove elements with tags that we support in full page mode", () => {
 	// Example subset
-	let tagsSupportedForFullPage = ["APPLET", "IMG", "DIV", "STYLE", "SVG", "VIDEO"];
+	let tagsSupportedForFullPage = ["applet", "img", "div", "style", "svg", "video"];
 	for (let i = 0; i < tagsSupportedForFullPage.length; i++) {
 		let element = document.createElement(tagsSupportedForFullPage[i]);
 		element.id = tagsSupportedForFullPage[i];
@@ -150,7 +150,7 @@ test("removeUnwantedElements should not remove elements with tags that we suppor
 
 test("removeUnwantedElements should not remove elements with tags that we support in full page mode when the " +
 	"document has both supported and unsupported elements", () => {
-	let tagsNotSupportedForFullPage = ["SCRIPT", "NOSCRIPT"];
+	let tagsNotSupportedForFullPage = ["script", "noscript"];
 	for (let i = 0; i < tagsNotSupportedForFullPage.length; i++) {
 		let element = document.createElement(tagsNotSupportedForFullPage[i]);
 		element.id = tagsNotSupportedForFullPage[i];
@@ -158,7 +158,7 @@ test("removeUnwantedElements should not remove elements with tags that we suppor
 	}
 
 	// Example subset
-	let tagsSupportedForFullPage = ["APPLET", "IMG", "DIV", "STYLE", "SVG", "VIDEO"];
+	let tagsSupportedForFullPage = ["applet", "img", "div", "style", "svg", "video"];
 	for (let i = 0; i < tagsSupportedForFullPage.length; i++) {
 		let element = document.createElement(tagsSupportedForFullPage[i]);
 		element.id = tagsSupportedForFullPage[i];
@@ -179,7 +179,7 @@ test("removeUnwantedElements should not remove elements with tags that we suppor
 });
 
 test("removeUnwantedAttributes should remove the srcset on images without modifying other attributes", () => {
-	let image = document.createElement("IMG") as HTMLImageElement;
+	let image = document.createElement("img") as HTMLImageElement;
 	let id = "IMG";
 	image.id = id;
 	let src = "https://cdn.mywebsite.doesnotexist";
@@ -202,7 +202,7 @@ test("removeUnwantedAttributes should remove the srcset on images without modify
 	let numberOfImages = 3;
 	let src = "https://cdn.mywebsite.doesnotexist";
 	for (let i = 0; i < numberOfImages; i++) {
-		let image = document.createElement("IMG") as HTMLImageElement;
+		let image = document.createElement("img") as HTMLImageElement;
 		let id = "IMG" + i;
 		image.id = id;
 		image.setAttribute("src", src);


### PR DESCRIPTION
Turns out the Clipper won't work on xhtml sites such as http://us.battle.net/d3/en/profile/leshin-1101/hero/8664666

This is because xhtml does not recognize uppercase elements, i.e., IFRAME won't work, but iframe does. Fixes #61 
