### PR TITLE
Increase FullPageScreenshot timeout

### DIFF
--- a/src/scripts/contentCapture/fullPageScreenshotHelper.ts
+++ b/src/scripts/contentCapture/fullPageScreenshotHelper.ts
@@ -23,6 +23,8 @@ export interface FullPageScreenshotResult extends CaptureFailureInfo {
 }
 
 export class FullPageScreenshotHelper {
+	private static timeout = 50000;
+
 	public static getFullPageScreenshot(pageInfoContentData: string): Promise<FullPageScreenshotResult> {
 		return new Promise<FullPageScreenshotResult>((resolve, reject) => {
 			let fullPageScreenshotEvent = new Log.Event.PromiseEvent(Log.Event.Label.FullPageScreenshotCall);
@@ -41,7 +43,7 @@ export class FullPageScreenshotHelper {
 				OneNoteApiUtils.logOneNoteApiRequestError(fullPageScreenshotEvent, error);
 			};
 
-			Http.post(Constants.Urls.fullPageScreenshotUrl, pageInfoContentData, headers, [200, 204]).then((request: XMLHttpRequest) => {
+			Http.post(Constants.Urls.fullPageScreenshotUrl, pageInfoContentData, headers, [200, 204], FullPageScreenshotHelper.timeout).then((request: XMLHttpRequest) => {
 				if (request.status === 200) {
 					try {
 						resolve(JSON.parse(request.response) as FullPageScreenshotResult);


### PR DESCRIPTION
We're hitting the full page screenshot 30s timeout consistently on certain sites, such as http://html5doctor.com/the-figure-figcaption-elements/
This would be a combination of things like upload/download time, and processing time on the server.

I think we should up our timeout so users don't get frustrated on certain sites. Would 50s be enough?

Fixes #68 
