### PR TITLE
[Bug] Ratings prompt UT fix

### DIFF
--- a/src/settings/default.json
+++ b/src/settings/default.json
@@ -63,7 +63,7 @@
 			"^(http(s)?)://(paleoleap.com)/([^/]*-[^/]*)/$",
 			"^(http(s)?)://(pinchofyum.com)/([^/]*-[^/]*)$",
 			"^(http(s)?)://(recipe\\.rakuten\\.co\\.jp)()/recipe/[0-9]+/$",
-			"^(http(s)?)://()(thepioneerwoman\\.com)()/(cooking/.+/)$", 
+			"^(http(s)?)://()(thepioneerwoman\\.com)()/(cooking/.+/)$",
 			"^(http(s)?)://((www\\.)?)(allrecipes\\.com)()/([r|R]ecipe/[^/]+/(Detail\\.aspx)?)$",
 			"^(http(s)?)://((www\\.)?)(allrecipes\\.com)()/([R|r]ecipe/.*)$",
 			"^(http(s)?)://(www\\.)(bbc\\.co\\.uk/food/recipes/[^/]*_\\d+)$",
@@ -83,17 +83,17 @@
 			"^(http(s)?)://(www\\.)(foodnetwork\\.com)()/(recipe-collections/.*)$",
 			"^(http(s)?)://(www\\.)(foodnetwork\\.com)()/(recipes.*)$",
 			"^(http(s)?)://(www\\.)(foodnetwork\\.com)()/(recipes/.*)$",
-			"^(http(s)?)://(www\\.)(marthastewart\\.com)()/(([0-9]+|recipe)/.*)$", 
-			"^(http(s)?)://(www\\.)(marthastewart\\.com)()/([0-9]+/[^/]+)$", 
+			"^(http(s)?)://(www\\.)(marthastewart\\.com)()/(([0-9]+|recipe)/.*)$",
+			"^(http(s)?)://(www\\.)(marthastewart\\.com)()/([0-9]+/[^/]+)$",
 			"^(http(s)?)://(www\\.)(myrecipes\\.com)()/(recipe/.*)$",
-			"^(http(s)?)://(www\\.)(myrecipes\\.com)()/(recipe/.*-[0-9]*/)$", 
+			"^(http(s)?)://(www\\.)(myrecipes\\.com)()/(recipe/.*-[0-9]*/)$",
 			"^(http(s)?)://(www\\.)(myrecipes\\.com)()/(recipe/.*)$",
 			"^(http(s)?)://(www\\.)(myrecipes\\.com)()/(recipe/[^/]+.*)$",
-			"^(http(s)?)://(www\\.)(realsimple\\.com)()/(food-recipes/browse-all-recipes/[^\\/]+/index\\.html)$", 
-			"^(http(s)?)://((www)?\\.)(seriouseats\\.com)()/([Rr]ecipes\\/.*\\.(html|HTML)(.*)?)$",			
-			"^(http(s)?)://(www\\.)(simplyrecipes\\.com)()/(recipes/[^/]*/)$", 
+			"^(http(s)?)://(www\\.)(realsimple\\.com)()/(food-recipes/browse-all-recipes/[^\\/]+/index\\.html)$",
+			"^(http(s)?)://((www)?\\.)(seriouseats\\.com)()/([Rr]ecipes\\/.*\\.(html|HTML)(.*)?)$",
+			"^(http(s)?)://(www\\.)(simplyrecipes\\.com)()/(recipes/[^/]*/)$",
 			"^(http(s)?)://((www\\.)?)(simplyrecipes\\.com)()/(recipes/[^/]*/)$",
-			"^(http(s)?)://((www\\.)?)(simplyrecipes\\.com)()/(recipes/.*)$",			
+			"^(http(s)?)://((www\\.)?)(simplyrecipes\\.com)()/(recipes/.*)$",
 			"^(http(s)?)://(www\\.)(tasteofhome\\.com)()/([R|r]ecipes/[^/]+$)$",
 			"^(http(s)?)://(www\\.)(tasteofhome\\.com)()/(recipes/[^/]*/?)$",
 			"^(http(s)?)://(www\\.)(tasteofhome\\.com)()/(recipes/[^\\/]+/?)$",
@@ -125,41 +125,5 @@
 	"App_Id": {
 		"Description": "For identifying the Clipper during interaction with external services",
 		"Value": "OneNote Clipper OSS"
-	},
-	"LogCategory_RatingsPrompt": {
-		"Description": "OFeedback log category for the ratings prompt feature",
-		"Value": "OneNoteClipperRatingsPrompt"
-	},
-	"Bookmarklet_RatingsEnabled": {
-		"Description": "If true, ratings prompt will be enabled for the bookmarklet",
-		"Value": "false"
-	},
-	"ChromeExtension_RatingsEnabled": {
-		"Description": "If true, ratings prompt will be enabled for the Chrome extension",
-		"Value": "false"
-	},
-	"EdgeExtension_RatingsEnabled": {
-		"Description": "If true, ratings prompt will be enabled for the Edge extension",
-		"Value": "false"
-	},
-	"FirefoxExtension_RatingsEnabled": {
-		"Description": "If true, ratings prompt will be enabled for the Firefox extension",
-		"Value": "false"
-	},
-	"SafariExtension_RatingsEnabled": {
-		"Description": "If true, ratings prompt will be enabled for the Safari extension",
-		"Value": "false"
-	},
-	"ChromeExtension_RatingUrl": {
-		"Description": "URL for the Web Clipper in the Chrome Web Store; used to direct users to leave ratings and reviews",
-		"Value": "https://chrome.google.com/webstore/detail/onenote-web-clipper/gojbdfnpnhogfdgjbigejoaolejmgdhk/reviews"
-	},
-	"EdgeExtension_RatingUrl": {
-		"Description": "URL for the Web Clipper in the Windows Store; used to direct users to leave ratings and reviews",
-		"Value": "https://www.microsoft.com/en-us/store/p/onenote-web-clipper/9nblggh4r01n#ratings-reviews"
-	},
-	"FirefoxExtension_RatingUrl": {
-		"Description": "URL for the Web Clipper in Firefox Add-ons; used to direct users to leave ratings and reviews",
-		"Value": ""
 	}
 }

--- a/src/tests/clipperUI/panels/ratingsPanel_tests.tsx
+++ b/src/tests/clipperUI/panels/ratingsPanel_tests.tsx
@@ -249,11 +249,9 @@ test("'Rate' click at RatingsPromptStage.Rate goes to RatingsPromptStage.End whe
 
 	let controllerInstance = HelperFunctions.mountToFixture(ratingsPanel);
 
-	// go to RATE panel, then click 'Rate'
-	let initPositive = document.getElementById(Constants.Ids.ratingsButtonInitYes);
-	HelperFunctions.simulateAction(() => {
-		initPositive.click();
-	});
+	// skip to RATE panel
+	controllerInstance.setState({ userSelectedRatingsPromptStage: RatingsPromptStage.Rate });
+	m.redraw(true);
 
 	let ratePositive = document.getElementById(Constants.Ids.ratingsButtonRateYes);
 	HelperFunctions.simulateAction(() => {
@@ -264,6 +262,8 @@ test("'Rate' click at RatingsPromptStage.Rate goes to RatingsPromptStage.End whe
 });
 
 test("'Rate' click at RatingsPromptStage.Rate not available when rate url does not exist", () => {
+	Settings.setSettingsJsonForTesting({});
+
 	let clipperState = HelperFunctions.getMockClipperState();
 	clipperState.showRatingsPrompt = new SmartValue<boolean>(true);
 
@@ -271,18 +271,13 @@ test("'Rate' click at RatingsPromptStage.Rate not available when rate url does n
 
 	let controllerInstance = HelperFunctions.mountToFixture(ratingsPanel);
 
-	// go to RATE panel
-	let initPositive = document.getElementById(Constants.Ids.ratingsButtonInitYes);
-	HelperFunctions.simulateAction(() => {
-		initPositive.click();
-		// clearing rate url before rendering RATE panel
-		// to test the unexpected case that we got to it without a rate url
-		Settings.setSettingsJsonForTesting({});
-	});
+	// skip to RATE panel
+	controllerInstance.setState({ userSelectedRatingsPromptStage: RatingsPromptStage.Rate });
+	m.redraw(true);
 
 	let ratePositive = document.getElementById(Constants.Ids.ratingsButtonRateYes);
-
 	ok(Utils.isNullOrUndefined(ratePositive), "'Rate' button should not exist");
+
 	strictEqual(RatingsPromptStage[controllerInstance.state.userSelectedRatingsPromptStage], RatingsPromptStage[RatingsPromptStage.None]);
 });
 
@@ -300,11 +295,9 @@ test("'No Thanks' click at RatingsPromptStage.Rate goes to RatingsPromptStage.No
 
 	let controllerInstance = HelperFunctions.mountToFixture(ratingsPanel);
 
-	// go to RATE panel, then click 'No Thanks'
-	let initPositive = document.getElementById(Constants.Ids.ratingsButtonInitYes);
-	HelperFunctions.simulateAction(() => {
-		initPositive.click();
-	});
+	// skip to RATE panel
+	controllerInstance.setState({ userSelectedRatingsPromptStage: RatingsPromptStage.Rate });
+	m.redraw(true);
 
 	let rateNegative = document.getElementById(Constants.Ids.ratingsButtonRateNo);
 	HelperFunctions.simulateAction(() => {
@@ -315,6 +308,8 @@ test("'No Thanks' click at RatingsPromptStage.Rate goes to RatingsPromptStage.No
 });
 
 test("'No Thanks' click at RatingsPromptStage.Rate not available when rate url does not exist", () => {
+	Settings.setSettingsJsonForTesting({});
+
 	let clipperState = HelperFunctions.getMockClipperState();
 	clipperState.showRatingsPrompt = new SmartValue<boolean>(true);
 
@@ -322,18 +317,13 @@ test("'No Thanks' click at RatingsPromptStage.Rate not available when rate url d
 
 	let controllerInstance = HelperFunctions.mountToFixture(ratingsPanel);
 
-	// go to RATE panel
-	let initPositive = document.getElementById(Constants.Ids.ratingsButtonInitYes);
-	HelperFunctions.simulateAction(() => {
-		initPositive.click();
-		// clearing rate url before rendering RATE panel
-		// to test the unexpected case that we got to it without a rate url
-		Settings.setSettingsJsonForTesting({});
-	});
+	// skip to RATE panel
+	controllerInstance.setState({ userSelectedRatingsPromptStage: RatingsPromptStage.Rate });
+	m.redraw(true);
 
 	let rateNegative = document.getElementById(Constants.Ids.ratingsButtonRateNo);
-
 	ok(Utils.isNullOrUndefined(rateNegative), "'No Thanks' button should not exist");
+
 	strictEqual(RatingsPromptStage[controllerInstance.state.userSelectedRatingsPromptStage], RatingsPromptStage[RatingsPromptStage.None]);
 });
 
@@ -353,11 +343,9 @@ test("'Feedback' click at RatingsPromptStage.Feedback goes to RatingsPromptStage
 
 	let controllerInstance = HelperFunctions.mountToFixture(ratingsPanel);
 
-	// go to FEEDBACK panel, then click 'Feedback'
-	let initNegative = document.getElementById(Constants.Ids.ratingsButtonInitNo);
-	HelperFunctions.simulateAction(() => {
-		initNegative.click();
-	});
+	// skip to FEEDBACK panel
+	controllerInstance.setState({ userSelectedRatingsPromptStage: RatingsPromptStage.Feedback });
+	m.redraw(true);
 
 	let feedbackPositive = document.getElementById(Constants.Ids.ratingsButtonFeedbackYes);
 	HelperFunctions.simulateAction(() => {
@@ -368,6 +356,8 @@ test("'Feedback' click at RatingsPromptStage.Feedback goes to RatingsPromptStage
 });
 
 test("'Feedback' click at RatingsPromptStage.Feedback not available when feedback url does not exist", () => {
+	Settings.setSettingsJsonForTesting({});
+
 	Clipper.storeValue(ClipperStorageKeys.lastSeenVersion, "3.1.0");
 
 	let clipperState = HelperFunctions.getMockClipperState();
@@ -377,14 +367,9 @@ test("'Feedback' click at RatingsPromptStage.Feedback not available when feedbac
 
 	let controllerInstance = HelperFunctions.mountToFixture(ratingsPanel);
 
-	// go to FEEDBACK panel
-	let initNegative = document.getElementById(Constants.Ids.ratingsButtonInitNo);
-	HelperFunctions.simulateAction(() => {
-		initNegative.click();
-		// clearing feedback url before rendering FEEDBACK panel
-		// to test the unexpected case that we got to it without a feedback url
-		Settings.setSettingsJsonForTesting({});
-	});
+	// skip to FEEDBACK panel
+	controllerInstance.setState({ userSelectedRatingsPromptStage: RatingsPromptStage.Feedback });
+	m.redraw(true);
 
 	let feedbackPositive = document.getElementById(Constants.Ids.ratingsButtonFeedbackYes);
 
@@ -408,11 +393,9 @@ test("'No Thanks' click at RatingsPromptStage.Feedback goes to RatingsPromptStag
 
 	let controllerInstance = HelperFunctions.mountToFixture(ratingsPanel);
 
-	// go to FEEDBACK panel, then click 'No Thanks'
-	let initNegative = document.getElementById(Constants.Ids.ratingsButtonInitNo);
-	HelperFunctions.simulateAction(() => {
-		initNegative.click();
-	});
+	// skip to FEEDBACK panel
+	controllerInstance.setState({ userSelectedRatingsPromptStage: RatingsPromptStage.Feedback });
+	m.redraw(true);
 
 	let feedbackNegative = document.getElementById(Constants.Ids.ratingsButtonFeedbackNo);
 	HelperFunctions.simulateAction(() => {
@@ -423,6 +406,8 @@ test("'No Thanks' click at RatingsPromptStage.Feedback goes to RatingsPromptStag
 });
 
 test("'No Thanks' click at RatingsPromptStage.Feedback not available when feedback url does not exist", () => {
+	Settings.setSettingsJsonForTesting({});
+
 	Clipper.storeValue(ClipperStorageKeys.lastSeenVersion, "3.1.0");
 
 	let clipperState = HelperFunctions.getMockClipperState();
@@ -432,14 +417,9 @@ test("'No Thanks' click at RatingsPromptStage.Feedback not available when feedba
 
 	let controllerInstance = HelperFunctions.mountToFixture(ratingsPanel);
 
-	// go to FEEDBACK panel
-	let initNegative = document.getElementById(Constants.Ids.ratingsButtonInitNo);
-	HelperFunctions.simulateAction(() => {
-		initNegative.click();
-		// clearing feedback url before rendering FEEDBACK panel
-		// to test the unexpected case that we got to it without a feedback url
-		Settings.setSettingsJsonForTesting({});
-	});
+	// skip to FEEDBACK panel
+	controllerInstance.setState({ userSelectedRatingsPromptStage: RatingsPromptStage.Feedback });
+	m.redraw(true);
 
 	let feedbackNegative = document.getElementById(Constants.Ids.ratingsButtonFeedbackNo);
 

--- a/src/tests/clipperUI/panels/ratingsPanel_tests.tsx
+++ b/src/tests/clipperUI/panels/ratingsPanel_tests.tsx
@@ -261,7 +261,7 @@ test("'Rate' click at RatingsPromptStage.Rate goes to RatingsPromptStage.End whe
 	strictEqual(RatingsPromptStage[controllerInstance.state.userSelectedRatingsPromptStage], RatingsPromptStage[RatingsPromptStage.End]);
 });
 
-test("'Rate' click at RatingsPromptStage.Rate not available when rate url does not exist", () => {
+test("'Rate' click at RatingsPromptStage.Rate not available when rate url does not exist (unexpected scenario)", () => {
 	Settings.setSettingsJsonForTesting({});
 
 	let clipperState = HelperFunctions.getMockClipperState();
@@ -307,7 +307,7 @@ test("'No Thanks' click at RatingsPromptStage.Rate goes to RatingsPromptStage.No
 	strictEqual(RatingsPromptStage[controllerInstance.state.userSelectedRatingsPromptStage], RatingsPromptStage[RatingsPromptStage.None]);
 });
 
-test("'No Thanks' click at RatingsPromptStage.Rate not available when rate url does not exist", () => {
+test("'No Thanks' click at RatingsPromptStage.Rate not available when rate url does not exist (unexpected scenario)", () => {
 	Settings.setSettingsJsonForTesting({});
 
 	let clipperState = HelperFunctions.getMockClipperState();
@@ -355,7 +355,7 @@ test("'Feedback' click at RatingsPromptStage.Feedback goes to RatingsPromptStage
 	strictEqual(RatingsPromptStage[controllerInstance.state.userSelectedRatingsPromptStage], RatingsPromptStage[RatingsPromptStage.End]);
 });
 
-test("'Feedback' click at RatingsPromptStage.Feedback not available when feedback url does not exist", () => {
+test("'Feedback' click at RatingsPromptStage.Feedback not available when feedback url does not exist (unexpected scenario)", () => {
 	Settings.setSettingsJsonForTesting({});
 
 	Clipper.storeValue(ClipperStorageKeys.lastSeenVersion, "3.1.0");
@@ -372,8 +372,8 @@ test("'Feedback' click at RatingsPromptStage.Feedback not available when feedbac
 	m.redraw(true);
 
 	let feedbackPositive = document.getElementById(Constants.Ids.ratingsButtonFeedbackYes);
-
 	ok(Utils.isNullOrUndefined(feedbackPositive), "'Feedback' button should not exist");
+
 	strictEqual(RatingsPromptStage[controllerInstance.state.userSelectedRatingsPromptStage], RatingsPromptStage[RatingsPromptStage.None]);
 });
 
@@ -405,7 +405,7 @@ test("'No Thanks' click at RatingsPromptStage.Feedback goes to RatingsPromptStag
 	strictEqual(RatingsPromptStage[controllerInstance.state.userSelectedRatingsPromptStage], RatingsPromptStage[RatingsPromptStage.None]);
 });
 
-test("'No Thanks' click at RatingsPromptStage.Feedback not available when feedback url does not exist", () => {
+test("'No Thanks' click at RatingsPromptStage.Feedback not available when feedback url does not exist (unexpected scenario)", () => {
 	Settings.setSettingsJsonForTesting({});
 
 	Clipper.storeValue(ClipperStorageKeys.lastSeenVersion, "3.1.0");
@@ -422,7 +422,7 @@ test("'No Thanks' click at RatingsPromptStage.Feedback not available when feedba
 	m.redraw(true);
 
 	let feedbackNegative = document.getElementById(Constants.Ids.ratingsButtonFeedbackNo);
-
 	ok(Utils.isNullOrUndefined(feedbackNegative), "'No Thanks' button should not exist");
+
 	strictEqual(RatingsPromptStage[controllerInstance.state.userSelectedRatingsPromptStage], RatingsPromptStage[RatingsPromptStage.None]);
 });

--- a/src/tests/clipperUI/panels/ratingsPanel_tests.tsx
+++ b/src/tests/clipperUI/panels/ratingsPanel_tests.tsx
@@ -46,7 +46,7 @@ Clipper.getCachedValue = (key: string) => {
 QUnit.module("ratingsPanel", {
 	beforeEach: () => {
 		Clipper.logger = new StubSessionLogger();
-		Settings.setSettingsJsonForTesting();
+		Settings.setSettingsJsonForTesting({});
 
 		mockStorage = {};
 		mockStorageCache = {};
@@ -94,8 +94,6 @@ test("'Positive' click at RatingsPromptStage.Init goes to RatingsPromptStage.Rat
 
 test("'Positive' click at RatingsPromptStage.Init goes to RatingsPromptStage.End when rate url does not exist", (assert: QUnitAssert) => {
 	let done = assert.async();
-
-	Settings.setSettingsJsonForTesting({});
 
 	let clipperState = HelperFunctions.getMockClipperState();
 	clipperState.showRatingsPrompt = new SmartValue<boolean>(true);
@@ -150,8 +148,6 @@ test("'Negative' click at RatingsPromptStage.Init without a prior bad rating goe
 
 test("'Negative' click at RatingsPromptStage.Init without a prior bad rating goes to RatingsPromptStage.End when feedback url does not exist (and doNotPromptRatings === undefined)", (assert: QUnitAssert) => {
 	let done = assert.async();
-
-	Settings.setSettingsJsonForTesting({});
 
 	Clipper.storeValue(ClipperStorageKeys.lastSeenVersion, "3.1.0");
 
@@ -210,8 +206,6 @@ test("'Negative' click at RatingsPromptStage.Init with a prior bad rating sets d
 test("'Negative' click at RatingsPromptStage.Init with a prior bad rating sets doNotPromptRatings to 'true' (feedback url does not exist)", (assert: QUnitAssert) => {
 	let done = assert.async();
 
-	Settings.setSettingsJsonForTesting({});
-
 	Clipper.storeValue(ClipperStorageKeys.lastBadRatingDate, (Date.now() - Constants.Settings.minTimeBetweenBadRatings).toString());
 	Clipper.storeValue(ClipperStorageKeys.lastSeenVersion, "3.1.0");
 
@@ -262,8 +256,6 @@ test("'Rate' click at RatingsPromptStage.Rate goes to RatingsPromptStage.End whe
 });
 
 test("'Rate' click at RatingsPromptStage.Rate not available when rate url does not exist (unexpected scenario)", () => {
-	Settings.setSettingsJsonForTesting({});
-
 	let clipperState = HelperFunctions.getMockClipperState();
 	clipperState.showRatingsPrompt = new SmartValue<boolean>(true);
 
@@ -308,8 +300,6 @@ test("'No Thanks' click at RatingsPromptStage.Rate goes to RatingsPromptStage.No
 });
 
 test("'No Thanks' click at RatingsPromptStage.Rate not available when rate url does not exist (unexpected scenario)", () => {
-	Settings.setSettingsJsonForTesting({});
-
 	let clipperState = HelperFunctions.getMockClipperState();
 	clipperState.showRatingsPrompt = new SmartValue<boolean>(true);
 
@@ -356,8 +346,6 @@ test("'Feedback' click at RatingsPromptStage.Feedback goes to RatingsPromptStage
 });
 
 test("'Feedback' click at RatingsPromptStage.Feedback not available when feedback url does not exist (unexpected scenario)", () => {
-	Settings.setSettingsJsonForTesting({});
-
 	Clipper.storeValue(ClipperStorageKeys.lastSeenVersion, "3.1.0");
 
 	let clipperState = HelperFunctions.getMockClipperState();
@@ -406,8 +394,6 @@ test("'No Thanks' click at RatingsPromptStage.Feedback goes to RatingsPromptStag
 });
 
 test("'No Thanks' click at RatingsPromptStage.Feedback not available when feedback url does not exist (unexpected scenario)", () => {
-	Settings.setSettingsJsonForTesting({});
-
 	Clipper.storeValue(ClipperStorageKeys.lastSeenVersion, "3.1.0");
 
 	let clipperState = HelperFunctions.getMockClipperState();

--- a/src/tests/clipperUI/ratingsHelper_tests.tsx
+++ b/src/tests/clipperUI/ratingsHelper_tests.tsx
@@ -44,7 +44,7 @@ Clipper.getCachedValue = (key: string) => {
 QUnit.module("ratingsHelper", {
 	beforeEach: () => {
 		Clipper.logger = new StubSessionLogger();
-		Settings.setSettingsJsonForTesting();
+		Settings.setSettingsJsonForTesting({});
 
 		mockStorage = {};
 		mockStorageCache = {};
@@ -178,8 +178,6 @@ test("badRatingTimingDelayIsOver returns true when the time between bad rating a
 // getFeedbackUrlIfExists
 
 test("getFeedbackUrlIfExists returns undefined if log category for ratings prompt does not exist", () => {
-	Settings.setSettingsJsonForTesting({});
-
 	let url: string = RatingsHelper.getFeedbackUrlIfExists({});
 	strictEqual(url, undefined, "setting for log category for ratings prompt does not exist");
 
@@ -237,8 +235,6 @@ test("getRateUrlIfExists returns undefined if ClientType/ClipperType is invalid"
 });
 
 test("getRateUrlIfExists returns undefined if a client's rate url does not exist", () => {
-	Settings.setSettingsJsonForTesting({});
-
 	let clientType: ClientType = ClientType.ChromeExtension;
 	let settingName: string = ClientType[clientType] + RatingsHelper.rateUrlSettingNameSuffix;
 
@@ -291,8 +287,6 @@ test("ratingsPromptEnabledForClient returns false if ClientType/ClipperType is i
 });
 
 test("ratingsPromptEnabledForClient returns false if a client's enable value does not exist", () => {
-	Settings.setSettingsJsonForTesting({});
-
 	let clientType: ClientType = ClientType.ChromeExtension;
 	let settingName: string = ClientType[clientType] + RatingsHelper.ratingsPromptEnabledSettingNameSuffix;
 


### PR DESCRIPTION
1. Fix ratings panel UTs that fail when settings are not included
2. Revert [workaround](https://github.com/OneNoteDev/WebClipper/pull/67) for failing UTs
3. Other minor test cleanup
## 

If curious: basically, the problem was that, depending on the way we build, the failing tests could either begin with empty prod settings or non-empty prod settings.

There were two problems: 1) using **prod** (instead of mock) settings in the tests, and 2) including an **extra (and nonstandard) panel transition** from `Init` to `Rate/Feedback`.

Broken behavior flow:

> empty _prod_ settings => test transitions from `Init` to `End`
> non-empty _prod_ settings => test transitions from `Init` to `Rate/Feedback` to `None`

Fixed behavior flow:

> empty _mock_ settings => test transitions from `Rate/Feedback` to `None`

The empty mocks are enforced with the `Settings.setSettingsJsonForTesting({})` call in `beforeEach`. Starting at the `Rate/Feedback` panel (instead of `Init`) is setup with the `controllerInstance.setState({...})` calls.
