### PR TITLE
[Bug] Make long citations copy-able/fully readable

### DIFF
--- a/src/scripts/clipperUI/components/previewViewer/bookmarkPreview.tsx
+++ b/src/scripts/clipperUI/components/previewViewer/bookmarkPreview.tsx
@@ -99,7 +99,7 @@ class BookmarkPreview extends PreviewComponentBase<{}, ClipperStateProp> {
 							{ this.renderTitleIfExists(result.title) }
 							<tr>
 								<td style={urlTdStyle}>
-									<a href={url} target="_blank">{url}</a>
+									<a href={url} target="_blank" title={url}>{url}</a>
 								</td>
 							</tr>
 							{ this.renderDescriptionIfExists(result.description) }

--- a/src/scripts/clipperUI/components/previewViewer/previewComponentBase.tsx
+++ b/src/scripts/clipperUI/components/previewViewer/previewComponentBase.tsx
@@ -83,7 +83,7 @@ export abstract class PreviewComponentBase<TState, TProps extends ClipperStatePr
 				{this.props.clipperState.currentMode.get() !== ClipMode.Bookmark
 					? <div id={Constants.Ids.previewUrlContainer}>
 						{sourceUrlCitationPrefix}
-						<a href={sourceUrl} target="_blank">{sourceUrl}</a>
+						<a href={sourceUrl} target="_blank" title={sourceUrl}>{sourceUrl}</a>
 					</div>
 					: undefined}
 			</div>

--- a/src/scripts/clipperUI/components/previewViewer/previewComponentBase.tsx
+++ b/src/scripts/clipperUI/components/previewViewer/previewComponentBase.tsx
@@ -70,8 +70,10 @@ export abstract class PreviewComponentBase<TState, TProps extends ClipperStatePr
 	}
 
 	private getPreviewSubtitle(): any {
-		let sourceUrlCitation = Localization.getLocalizedString("WebClipper.FromCitation")
-			.replace("{0}", this.props.clipperState.pageInfo ? this.props.clipperState.pageInfo.rawUrl : "");
+		let sourceUrlCitationPrefix = Localization.getLocalizedString("WebClipper.FromCitation")
+			.replace("{0}", ""); // TODO can we change this loc string to remove the {0}?
+
+		let sourceUrl = this.props.clipperState.pageInfo ? this.props.clipperState.pageInfo.rawUrl : "";
 
 		return (
 			<div id={Constants.Ids.previewSubtitleContainer}>
@@ -80,7 +82,8 @@ export abstract class PreviewComponentBase<TState, TProps extends ClipperStatePr
 					: undefined}
 				{this.props.clipperState.currentMode.get() !== ClipMode.Bookmark
 					? <div id={Constants.Ids.previewUrlContainer}>
-						{sourceUrlCitation}
+						{sourceUrlCitationPrefix}
+						<a href={sourceUrl} target="_blank">{sourceUrl}</a>
 					</div>
 					: undefined}
 			</div>


### PR DESCRIPTION
1. On hover, the full URL will show up (thanks to the `title` property)
2. If a user wants to copy the URL, they can right click -> copy link address

Fixes https://github.com/OneNoteDev/WebClipper/issues/77
