### PR TITLE
[Bug] Turn off Firefox tooltips until we can sort out the height-animator issue

### DIFF
--- a/src/scripts/extensions/extensionBase.ts
+++ b/src/scripts/extensions/extensionBase.ts
@@ -367,18 +367,22 @@ export abstract class ExtensionBase<TWorker extends ExtensionWorkerBase<TTab, TT
 
 			let extensionVersion = new Version(ExtensionBase.getExtensionVersion());
 
-			let tooltips = [TooltipType.Pdf, TooltipType.Product, TooltipType.Recipe];
+			// TODO: There seems to be some animation problem with the tooltips on Firefox, so we are going to
+			// stop showing them, until we can figure it out :(
+				
+			// let tooltips = [TooltipType.Pdf, TooltipType.Product, TooltipType.Recipe];
 			// Returns the Type of tooltip to show IF the delay is over and the tab has the correct content type
-			let typeToShow = this.shouldShowTooltip(tab, tooltips);
-			if (typeToShow) {
-				this.showTooltip(tab, typeToShow);
-				return;
-			}
 
-			if (this.shouldShowVideoTooltip(tab)) {
-				this.showTooltip(tab, TooltipType.Video);
-				return;
-			}
+			// let typeToShow = this.shouldShowTooltip(tab, tooltips);
+			// if (typeToShow) {
+			// 	this.showTooltip(tab, typeToShow);
+			// 	return;
+			// }
+
+			// if (this.shouldShowVideoTooltip(tab)) {
+			// 	this.showTooltip(tab, TooltipType.Video);
+			// 	return;
+			// }
 
 			// We don't show updates more recent than the local version for now, as it is easy
 			// for a changelog to be released before a version is actually out

--- a/src/scripts/extensions/extensionBase.ts
+++ b/src/scripts/extensions/extensionBase.ts
@@ -367,22 +367,20 @@ export abstract class ExtensionBase<TWorker extends ExtensionWorkerBase<TTab, TT
 
 			let extensionVersion = new Version(ExtensionBase.getExtensionVersion());
 
-			// TODO: There seems to be some animation problem with the tooltips on Firefox, so we are going to
-			// stop showing them, until we can figure it out :(
-				
-			// let tooltips = [TooltipType.Pdf, TooltipType.Product, TooltipType.Recipe];
-			// Returns the Type of tooltip to show IF the delay is over and the tab has the correct content type
+			if (this.clientInfo.get().clipperType !== ClientType.FirefoxExtension) {
+				let tooltips = [TooltipType.Pdf, TooltipType.Product, TooltipType.Recipe];
+				// Returns the Type of tooltip to show IF the delay is over and the tab has the correct content type
+				let typeToShow = this.shouldShowTooltip(tab, tooltips);
+				if (typeToShow) {
+					this.showTooltip(tab, typeToShow);
+					return;
+				}
 
-			// let typeToShow = this.shouldShowTooltip(tab, tooltips);
-			// if (typeToShow) {
-			// 	this.showTooltip(tab, typeToShow);
-			// 	return;
-			// }
-
-			// if (this.shouldShowVideoTooltip(tab)) {
-			// 	this.showTooltip(tab, TooltipType.Video);
-			// 	return;
-			// }
+				if (this.shouldShowVideoTooltip(tab)) {
+					this.showTooltip(tab, TooltipType.Video);
+					return;
+				}
+			}
 
 			// We don't show updates more recent than the local version for now, as it is easy
 			// for a changelog to be released before a version is actually out


### PR DESCRIPTION
Tooltips don't animate correctly on Firefox anymore. It's ship blocking so I am turning them off. The debugging could take an undetermined amount of time (or may not be fixable). 
