### PR TITLE
Fix the parsing of the error description.

### DIFF
--- a/src/scripts/constants.ts
+++ b/src/scripts/constants.ts
@@ -314,7 +314,7 @@ export module Constants {
 			export var clipperVersion = "clipperVersion";
 			export var correlationId = "correlationId";
 			export var error = "error";
-			export var errorDescription = "errorDescription";
+			export var errorDescription = "error_?description";
 			export var event = "event";
 			export var eventName = "eventName";
 			export var failureId = "failureId";

--- a/src/tests/utils_tests.ts
+++ b/src/tests/utils_tests.ts
@@ -294,6 +294,21 @@ test("getQueryValue should return undefined if any of the parameters are undefin
 	strictEqual(Utils.getQueryValue("", "q"), undefined);
 });
 
+test("getQueryValue should return a valid error if an error is specified.", () => {
+	let url = "https://www.onenote.com/webclipper/auth?error=access_denied&error_description=AADSTS50000:+There+was+an+error+issuing+a+token.&state=abcdef12-6ac8-41bd-0445-f7ef7a4182e7";
+	strictEqual(Utils.getQueryValue(url, Constants.Urls.QueryParams.error), "access_denied");
+});
+
+test("getQueryValue should return a valid error description if an O365 error_description is specified.", () => {
+	let url = "https://www.onenote.com/webclipper/auth?error=access_denied&error_description=AADSTS50000:+There+was+an+error+issuing+a+token.&state=abcdef12-6ac8-41bd-0445-f7ef7a4182e7";
+	strictEqual(Utils.getQueryValue(url, Constants.Urls.QueryParams.errorDescription), "AADSTS50000: There was an error issuing a token.");
+});
+
+test("getQueryValue should return a valid error description if an MSA errorDescription is specified.", () => {
+	let url = "https://www.onenote.com/webclipper/auth?error=access_denied&errorDescription=AADSTS50000:+There+was+an+error+issuing+a+token.&state=abcdef12-6ac8-41bd-0445-f7ef7a4182e7";
+	strictEqual(Utils.getQueryValue(url, Constants.Urls.QueryParams.errorDescription), "AADSTS50000: There was an error issuing a token.");
+});
+
 test("isNumeric should return false when the value is a string", () => {
 	let value = "string";
 	ok(!Utils.isNumeric(value), "isNumeric should return false");


### PR DESCRIPTION
It looks like O365 returns a slightly different query parameter for the error description field.  This is a slight modification to the constant regular expression such that it matches both versions.

Fixes #83 
