### PR TITLE
[Bug] Update ratings prompt logic for delayed client switch ons

### DIFF
--- a/src/scripts/clipperUI/ratingsHelper.ts
+++ b/src/scripts/clipperUI/ratingsHelper.ts
@@ -77,7 +77,7 @@ export class RatingsHelper {
 			ClipperStorageKeys.lastBadRatingVersion,
 			ClipperStorageKeys.lastSeenVersion,
 			ClipperStorageKeys.numSuccessfulClips,
-			ClipperStorageKeys.numSuccessfulClipsOnFirstRatingsEnablement
+			ClipperStorageKeys.numSuccessfulClipsRatingsEnablement
 		];
 		Clipper.preCacheStoredValues(ratingsPromptStorageKeys);
 	}
@@ -195,12 +195,12 @@ export class RatingsHelper {
 	}
 
 	/**
-	 * Sets ClipperStorageKeys.numSuccessfulClipsOnFirstRatingsEnablement to be
-	 * the current value of ClipperStorageKeys.numSuccessfulClips, if needed.
+	 * Sets ClipperStorageKeys.numSuccessfulClipsRatingsEnablement to be
+	 * the current value of (ClipperStorageKeys.numSuccessfulClips - 1), if needed.
 	 *
 	 * The set is "needed" if ALL of the below applies:
 	 *   * The user has not already interacted with the prompt (ClipperStorageKeys.doNotPromptRatings is not set)
-	 *   * ClipperStorageKeys.numSuccessfulClipsOnFirstRatingsEnablement has not already been set
+	 *   * ClipperStorageKeys.numSuccessfulClipsRatingsEnablement has not already been set
 	 *
 	 * Public for testing
 	 *
@@ -209,19 +209,20 @@ export class RatingsHelper {
 	 * re-raise the prompt for users who have already interacted with it (although it is possible users who didn't interact
 	 * with the original prompt see it up to twice as many times as originally planned).
 	 */
-	public static setNumSuccessfulClipsOnFirstRatingsEnablement(): void {
+	public static setNumSuccessfulClipsRatingsEnablement(): void {
 		let doNotPromptRatingsAsStr: string = Clipper.getCachedValue(ClipperStorageKeys.doNotPromptRatings);
 		if (RatingsHelper.doNotPromptRatingsIsSet(doNotPromptRatingsAsStr)) {
 			return;
 		}
 
-		let numSuccessfulClipsOnFirstRatingsEnablementAsStr: string = Clipper.getCachedValue(ClipperStorageKeys.numSuccessfulClipsOnFirstRatingsEnablement);
-		if (parseInt(numSuccessfulClipsOnFirstRatingsEnablementAsStr, 10) >= 0) {
+		let numSuccessfulClipsRatingsEnablementAsStr: string = Clipper.getCachedValue(ClipperStorageKeys.numSuccessfulClipsRatingsEnablement);
+		if (parseInt(numSuccessfulClipsRatingsEnablementAsStr, 10) >= 0) {
 			return;
 		}
 
-		let numSuccessfulClipsAsStr: string = Clipper.getCachedValue(ClipperStorageKeys.numSuccessfulClips);
-		Clipper.storeValue(ClipperStorageKeys.numSuccessfulClipsOnFirstRatingsEnablement, numSuccessfulClipsAsStr);
+		let numSuccessfulClips: number = parseInt(Clipper.getCachedValue(ClipperStorageKeys.numSuccessfulClips), 10);
+		// subtracting 1 below to account for the fact that this set is occuring after one already successful clip
+		Clipper.storeValue(ClipperStorageKeys.numSuccessfulClipsRatingsEnablement, (numSuccessfulClips - 1).toString());
 	}
 
 	/**
@@ -246,14 +247,14 @@ export class RatingsHelper {
 			return false;
 		}
 
-		RatingsHelper.setNumSuccessfulClipsOnFirstRatingsEnablement();
+		RatingsHelper.setNumSuccessfulClipsRatingsEnablement();
 
 		let doNotPromptRatingsStr: string = Clipper.getCachedValue(ClipperStorageKeys.doNotPromptRatings);
 		let lastBadRatingDateAsStr: string = Clipper.getCachedValue(ClipperStorageKeys.lastBadRatingDate);
 		let lastBadRatingVersion: string = Clipper.getCachedValue(ClipperStorageKeys.lastBadRatingVersion);
 		let lastSeenVersion: string = Clipper.getCachedValue(ClipperStorageKeys.lastSeenVersion);
 		let numClipsAsStr: string = Clipper.getCachedValue(ClipperStorageKeys.numSuccessfulClips);
-		let numClipsAnchorAsStr: string = Clipper.getCachedValue(ClipperStorageKeys.numSuccessfulClipsOnFirstRatingsEnablement);
+		let numClipsAnchorAsStr: string = Clipper.getCachedValue(ClipperStorageKeys.numSuccessfulClipsRatingsEnablement);
 
 		if (RatingsHelper.doNotPromptRatingsIsSet(doNotPromptRatingsStr)) {
 			logEventInfo.doNotPromptRatings = true;

--- a/src/scripts/clipperUI/ratingsHelper.ts
+++ b/src/scripts/clipperUI/ratingsHelper.ts
@@ -182,8 +182,35 @@ export class RatingsHelper {
 			return false;
 		}
 
+		// TODO numClips = number of clips since ratings prompt was enabled for the user's client
+		// handle if numSuccessfulClipsOnFirstRatingsEnablement does not exist (assume 0)
+
 		return numClips >= Constants.Settings.minClipSuccessForRatingsPrompt &&
 			numClips <= Constants.Settings.maxClipSuccessForRatingsPrompt;
+	}
+
+	/**
+	 * Sets ClipperStorageKeys.numSuccessfulClipsOnFirstRatingsEnablement to be
+	 * the current value of ClipperStorageKeys.numSuccessfulClips, if needed.
+	 *
+	 * The set is "needed" if ALL of the below applies:
+	 *   * The user has not already interacted with the prompt (ClipperStorageKeys.doNotPromptRatings is not set)
+	 *   * ClipperStorageKeys.numSuccessfulClipsOnFirstRatingsEnablement has not already been set
+	 *
+	 * Public for testing (TODO)
+	 *
+	 * NOTE OF EXPLANATION: We first check if the user has already interacted with the prompt for backwards compatibility
+	 * with the original implementation of the ratings prompt that did not include this method. It ensures that we will not
+	 * re-raise the prompt for users who have already interacted with it (although it is possible users who didn't interact
+	 * with the original prompt see it up to twice as many times as originally planned).
+	 */
+	public static setNumSuccessfulClipsOnFirstRatingsEnablement(): void {
+		/* TODO let doNotPromptRatingsStr: string = Clipper.getCachedValue(ClipperStorageKeys.doNotPromptRatings);
+		if (RatingsHelper.doNotPromptRatingsIsSet(doNotPromptRatingsStr)) {
+			return;
+		}*/
+
+		// TODO if numSuccessfulClipsOnFirstRatingsEnablement does not already exist, perform the copy
 	}
 
 	/**
@@ -208,13 +235,15 @@ export class RatingsHelper {
 			return false;
 		}
 
+		RatingsHelper.setNumSuccessfulClipsOnFirstRatingsEnablement();
+
 		let doNotPromptRatingsStr: string = Clipper.getCachedValue(ClipperStorageKeys.doNotPromptRatings);
 		let lastBadRatingDateAsStr: string = Clipper.getCachedValue(ClipperStorageKeys.lastBadRatingDate);
 		let lastBadRatingVersion: string = Clipper.getCachedValue(ClipperStorageKeys.lastBadRatingVersion);
 		let lastSeenVersion: string = Clipper.getCachedValue(ClipperStorageKeys.lastSeenVersion);
 		let numClipsAsStr: string = Clipper.getCachedValue(ClipperStorageKeys.numSuccessfulClips);
 
-		if (!Utils.isNullOrUndefined(doNotPromptRatingsStr) && doNotPromptRatingsStr.toLowerCase() === "true") {
+		if (RatingsHelper.doNotPromptRatingsIsSet(doNotPromptRatingsStr)) {
 			logEventInfo.doNotPromptRatings = true;
 			return false;
 		}
@@ -260,5 +289,9 @@ export class RatingsHelper {
 	private static isValidDate(date: number): boolean {
 		let minimumTimeValue: number = (Constants.Settings.maximumJSTimeValue * -1);
 		return date >= minimumTimeValue && date <= Constants.Settings.maximumJSTimeValue;
+	}
+
+	private static doNotPromptRatingsIsSet(doNotPromptRatingsStr: string): boolean {
+		return !Utils.isNullOrUndefined(doNotPromptRatingsStr) && doNotPromptRatingsStr.toLowerCase() === "true";
 	}
 }

--- a/src/scripts/clipperUI/ratingsHelper.ts
+++ b/src/scripts/clipperUI/ratingsHelper.ts
@@ -27,6 +27,7 @@ interface RatingsLoggingInfo {
 	lastBadRatingVersion?: string;
 	lastSeenVersion?: string;
 	numSuccessfulClips?: number;
+	numSuccessfulClipsAnchor?: number;
 	ratingsPromptEnabledForClient?: boolean;
 	usedCachedValue?: boolean;
 }
@@ -172,12 +173,12 @@ export class RatingsHelper {
 
 	/**
 	 * Returns true if ALL of the below applies:
-	 *   * Number of successful clips >= {Constants.Settings.minClipSuccessForRatingsPrompt}
-	 *   * Number of successful clips <= {Constants.Settings.maxClipSuccessForRatingsPrompt}
+	 *   * (Number of successful clips - Anchor clip value) >= {Constants.Settings.minClipSuccessForRatingsPrompt}
+	 *   * (Number of successful clips - Anchor clip value) <= {Constants.Settings.maxClipSuccessForRatingsPrompt}
 	 *
 	 * Public for testing
 	 */
-	public static clipSuccessDelayIsOver(numClips: number): boolean {
+	public static clipSuccessDelayIsOver(numClips: number, anchorClipValue = 0): boolean {
 		if (isNaN(numClips)) {
 			return false;
 		}
@@ -242,6 +243,7 @@ export class RatingsHelper {
 		let lastBadRatingVersion: string = Clipper.getCachedValue(ClipperStorageKeys.lastBadRatingVersion);
 		let lastSeenVersion: string = Clipper.getCachedValue(ClipperStorageKeys.lastSeenVersion);
 		let numClipsAsStr: string = Clipper.getCachedValue(ClipperStorageKeys.numSuccessfulClips);
+		let numClipsAnchorAsStr: string = Clipper.getCachedValue(ClipperStorageKeys.numSuccessfulClipsOnFirstRatingsEnablement);
 
 		if (RatingsHelper.doNotPromptRatingsIsSet(doNotPromptRatingsStr)) {
 			logEventInfo.doNotPromptRatings = true;
@@ -250,6 +252,7 @@ export class RatingsHelper {
 
 		let lastBadRatingDate: number = parseInt(lastBadRatingDateAsStr, 10);
 		let numClips: number = parseInt(numClipsAsStr, 10);
+		let numClipsAnchor: number = parseInt(numClipsAnchorAsStr, 10);
 
 		/* tslint:disable:no-null-keyword */
 			// null is the value storage gives back; also, setting to undefined will keep this kvp from being logged at all
@@ -258,10 +261,11 @@ export class RatingsHelper {
 		logEventInfo.lastBadRatingVersion = lastBadRatingVersion;
 		logEventInfo.lastSeenVersion = lastSeenVersion;
 		logEventInfo.numSuccessfulClips = numClips;
+		logEventInfo.numSuccessfulClipsAnchor = numClipsAnchor;
 
 		let badRatingTimingDelayIsOver: boolean = RatingsHelper.badRatingTimingDelayIsOver(lastBadRatingDate, Date.now());
 		let badRatingVersionDelayIsOver: boolean = RatingsHelper.badRatingVersionDelayIsOver(lastBadRatingVersion, lastSeenVersion);
-		let clipSuccessDelayIsOver: boolean = RatingsHelper.clipSuccessDelayIsOver(numClips);
+		let clipSuccessDelayIsOver: boolean = RatingsHelper.clipSuccessDelayIsOver(numClips, numClipsAnchor);
 
 		logEventInfo.badRatingTimingDelayIsOver = badRatingTimingDelayIsOver;
 		logEventInfo.badRatingVersionDelayIsOver = badRatingVersionDelayIsOver;

--- a/src/scripts/storage/clipperStorageKeys.ts
+++ b/src/scripts/storage/clipperStorageKeys.ts
@@ -15,7 +15,7 @@ export module ClipperStorageKeys {
 	export var locale = "locale";
 	export var locStrings = "locStrings";
 	export var numSuccessfulClips = "numSuccessfulClips";
-	export var numSuccessfulClipsOnFirstRatingsEnablement = "numSuccessfulClipsOnFirstRatingsEnablement";
+	export var numSuccessfulClipsRatingsEnablement = "numSuccessfulClipsRatingsEnablement";
 	export var numTimesTooltipHasBeenSeenBase = "numTimesTooltipHasBeenSeen";
 	export var userInformation = "userInformation";
 }

--- a/src/scripts/storage/clipperStorageKeys.ts
+++ b/src/scripts/storage/clipperStorageKeys.ts
@@ -15,6 +15,7 @@ export module ClipperStorageKeys {
 	export var locale = "locale";
 	export var locStrings = "locStrings";
 	export var numSuccessfulClips = "numSuccessfulClips";
+	export var numSuccessfulClipsOnFirstRatingsEnablement = "numSuccessfulClipsOnFirstRatingsEnablement";
 	export var numTimesTooltipHasBeenSeenBase = "numTimesTooltipHasBeenSeen";
 	export var userInformation = "userInformation";
 }

--- a/src/tests/clipperUI/ratingsHelper_tests.tsx
+++ b/src/tests/clipperUI/ratingsHelper_tests.tsx
@@ -161,7 +161,7 @@ test("clipSuccessDelayIsOver returns true when anchorClipValue is invalid (and d
 
 	for (let anchorClipValue of invalidAnchors) {
 		let over: boolean = RatingsHelper.clipSuccessDelayIsOver(Constants.Settings.minClipSuccessForRatingsPrompt, anchorClipValue);
-		strictEqual(over, false, "anchorClipValue is invalid with value " + anchorClipValue + ", but should be ignored since numClips is valid with value " + Constants.Settings.minClipSuccessForRatingsPrompt);
+		strictEqual(over, true, "anchorClipValue is invalid with value " + anchorClipValue + ", but should be ignored since numClips is valid with value " + Constants.Settings.minClipSuccessForRatingsPrompt);
 	}
 });
 
@@ -530,6 +530,7 @@ test("shouldShowRatingsPrompt returns true when do not prompt ratings is set in 
 
 	Clipper.storeValue(ClipperStorageKeys.doNotPromptRatings, "invalid");
 	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClips, Constants.Settings.minClipSuccessForRatingsPrompt.toString());
+	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClipsOnFirstRatingsEnablement, "0");
 
 	let clipperState = HelperFunctions.getMockClipperState();
 
@@ -544,11 +545,10 @@ test("shouldShowRatingsPrompt returns true when a valid configuration is provide
 		}
 	});
 
-	let outOfRangeValue = Constants.Settings.maxClipSuccessForRatingsPrompt + 1;
-	let validClipRange = (Constants.Settings.maxClipSuccessForRatingsPrompt - Constants.Settings.minClipSuccessForRatingsPrompt);
+	let anchorClipValue = Constants.Settings.maxClipSuccessForRatingsPrompt + 1;
 
-	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClips, (outOfRangeValue + validClipRange).toString());
-	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClipsOnFirstRatingsEnablement, outOfRangeValue.toString());
+	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClips, (anchorClipValue + Constants.Settings.maxClipSuccessForRatingsPrompt).toString());
+	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClipsOnFirstRatingsEnablement, anchorClipValue.toString());
 	Clipper.storeValue(ClipperStorageKeys.lastBadRatingDate, (Date.now() - Constants.Settings.minTimeBetweenBadRatings).toString());
 	Clipper.storeValue(ClipperStorageKeys.lastBadRatingVersion, "3.0.9");
 	Clipper.storeValue(ClipperStorageKeys.lastSeenVersion, "3.1.0");
@@ -568,6 +568,7 @@ test("shouldShowRatingsPrompt returns false when number of successful clips is b
 	});
 
 	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClips, (Constants.Settings.minClipSuccessForRatingsPrompt - 1).toString());
+	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClipsOnFirstRatingsEnablement, "0");
 	Clipper.storeValue(ClipperStorageKeys.lastBadRatingDate, (Date.now() - Constants.Settings.minTimeBetweenBadRatings).toString());
 	Clipper.storeValue(ClipperStorageKeys.lastBadRatingVersion, "3.0.9");
 	Clipper.storeValue(ClipperStorageKeys.lastSeenVersion, "3.1.0");
@@ -588,6 +589,7 @@ test("shouldShowRatingsPrompt returns false when last bad rating date is too rec
 	let timeDiffInMs = 1000 * 60 * 60 * 24; // to make last bad rating date 1 day sooner than the min time delay
 
 	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClips, Constants.Settings.minClipSuccessForRatingsPrompt.toString());
+	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClipsOnFirstRatingsEnablement, "0");
 	Clipper.storeValue(ClipperStorageKeys.lastBadRatingDate, (Date.now() - Constants.Settings.minTimeBetweenBadRatings + timeDiffInMs).toString());
 	Clipper.storeValue(ClipperStorageKeys.lastBadRatingVersion, "3.0.9");
 	Clipper.storeValue(ClipperStorageKeys.lastSeenVersion, "3.1.0");
@@ -606,6 +608,7 @@ test("shouldShowRatingsPrompt returns false when there has not been a significan
 	});
 
 	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClips, Constants.Settings.minClipSuccessForRatingsPrompt.toString());
+	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClipsOnFirstRatingsEnablement, "0");
 	Clipper.storeValue(ClipperStorageKeys.lastBadRatingDate, (Date.now() - Constants.Settings.minTimeBetweenBadRatings).toString());
 	Clipper.storeValue(ClipperStorageKeys.lastBadRatingVersion, "3.0.9");
 	Clipper.storeValue(ClipperStorageKeys.lastSeenVersion, "3.0.999");
@@ -623,14 +626,10 @@ test("shouldShowRatingsPrompt returns false when (numSuccessfulClips - numSucces
 		}
 	});
 
-	let outOfRangeValue = Constants.Settings.maxClipSuccessForRatingsPrompt + 1;
-	let validClipRange = (Constants.Settings.maxClipSuccessForRatingsPrompt - Constants.Settings.minClipSuccessForRatingsPrompt);
+	let anchorClipValue = Constants.Settings.maxClipSuccessForRatingsPrompt + 1;
 
-	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClips, (outOfRangeValue + validClipRange + 1).toString());
-	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClipsOnFirstRatingsEnablement, outOfRangeValue.toString());
-	Clipper.storeValue(ClipperStorageKeys.lastBadRatingDate, (Date.now() - Constants.Settings.minTimeBetweenBadRatings).toString());
-	Clipper.storeValue(ClipperStorageKeys.lastBadRatingVersion, "3.0.9");
-	Clipper.storeValue(ClipperStorageKeys.lastSeenVersion, "3.1.0");
+	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClips, (anchorClipValue + Constants.Settings.maxClipSuccessForRatingsPrompt + 1).toString());
+	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClipsOnFirstRatingsEnablement, anchorClipValue.toString());
 
 	let clipperState = HelperFunctions.getMockClipperState();
 	clipperState.clientInfo.clipperType = ClientType.FirefoxExtension;

--- a/src/tests/clipperUI/ratingsHelper_tests.tsx
+++ b/src/tests/clipperUI/ratingsHelper_tests.tsx
@@ -61,50 +61,50 @@ export module TestConstants {
 	}
 }
 
-// setNumSuccessfulClipsOnFirstRatingsEnablement
+// setNumSuccessfulClipsRatingsEnablement
 
-test("setNumSuccessfulClipsOnFirstRatingsEnablement does not set the value when ClipperStorageKeys.doNotPromptRatings is set", (assert: QUnitAssert) => {
+test("setNumSuccessfulClipsRatingsEnablement does not set the value when ClipperStorageKeys.doNotPromptRatings is set", (assert: QUnitAssert) => {
 	let done = assert.async();
 
 	let numClips = 12;
 	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClips, numClips.toString());
 	Clipper.storeValue(ClipperStorageKeys.doNotPromptRatings, "true");
 
-	RatingsHelper.setNumSuccessfulClipsOnFirstRatingsEnablement();
+	RatingsHelper.setNumSuccessfulClipsRatingsEnablement();
 
-	Clipper.getStoredValue(ClipperStorageKeys.numSuccessfulClipsOnFirstRatingsEnablement, (numClipsAnchorAsStr: string) => {
+	Clipper.getStoredValue(ClipperStorageKeys.numSuccessfulClipsRatingsEnablement, (numClipsAnchorAsStr: string) => {
 		ok(Utils.isNullOrUndefined(numClipsAnchorAsStr));
 		done();
 	});
 });
 
-test("setNumSuccessfulClipsOnFirstRatingsEnablement does not overwrite the value when it already exists", (assert: QUnitAssert) => {
+test("setNumSuccessfulClipsRatingsEnablement does not overwrite the value when it already exists", (assert: QUnitAssert) => {
 	let done = assert.async();
 
 	let numClips = 12;
 	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClips, numClips.toString());
 
 	let expectedStorageValue = 999;
-	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClipsOnFirstRatingsEnablement, expectedStorageValue.toString());
+	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClipsRatingsEnablement, expectedStorageValue.toString());
 
-	RatingsHelper.setNumSuccessfulClipsOnFirstRatingsEnablement();
+	RatingsHelper.setNumSuccessfulClipsRatingsEnablement();
 
-	Clipper.getStoredValue(ClipperStorageKeys.numSuccessfulClipsOnFirstRatingsEnablement, (numClipsAnchorAsStr: string) => {
+	Clipper.getStoredValue(ClipperStorageKeys.numSuccessfulClipsRatingsEnablement, (numClipsAnchorAsStr: string) => {
 		strictEqual(parseInt(numClipsAnchorAsStr, 10), expectedStorageValue);
 		done();
 	});
 });
 
-test("setNumSuccessfulClipsOnFirstRatingsEnablement sets the value to ClipperStorageKeys.numSuccessfulClips when applicable", (assert: QUnitAssert) => {
+test("setNumSuccessfulClipsRatingsEnablement sets the value to (ClipperStorageKeys.numSuccessfulClips - 1) when applicable", (assert: QUnitAssert) => {
 	let done = assert.async();
 
 	let numClips = 12;
 	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClips, numClips.toString());
 
-	RatingsHelper.setNumSuccessfulClipsOnFirstRatingsEnablement();
+	RatingsHelper.setNumSuccessfulClipsRatingsEnablement();
 
-	Clipper.getStoredValue(ClipperStorageKeys.numSuccessfulClipsOnFirstRatingsEnablement, (numClipsAnchorAsStr: string) => {
-		strictEqual(parseInt(numClipsAnchorAsStr, 10), numClips);
+	Clipper.getStoredValue(ClipperStorageKeys.numSuccessfulClipsRatingsEnablement, (numClipsAnchorAsStr: string) => {
+		strictEqual(parseInt(numClipsAnchorAsStr, 10), numClips - 1);
 		done();
 	});
 });
@@ -143,6 +143,13 @@ test("clipSuccessDelayIsOver returns false when anchorClipValue is greater than 
 	let anchorClipValue = numClips + 1;
 	let over: boolean = RatingsHelper.clipSuccessDelayIsOver(numClips, anchorClipValue);
 	strictEqual(over, false, "anchorClipValue should never be greater than numClips");
+});
+
+test("clipSuccessDelayIsOver returns false when anchorClipValue is equal to numClips", () => {
+	let numClips = Constants.Settings.minClipSuccessForRatingsPrompt;
+	let anchorClipValue = numClips;
+	let over: boolean = RatingsHelper.clipSuccessDelayIsOver(numClips, anchorClipValue);
+	strictEqual(over, false, "anchorClipValue should never be equal to numClips");
 });
 
 test("clipSuccessDelayIsOver returns false when (numClips - anchorClipValue) is out of range", () => {
@@ -530,7 +537,7 @@ test("shouldShowRatingsPrompt returns true when do not prompt ratings is set in 
 
 	Clipper.storeValue(ClipperStorageKeys.doNotPromptRatings, "invalid");
 	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClips, Constants.Settings.minClipSuccessForRatingsPrompt.toString());
-	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClipsOnFirstRatingsEnablement, "0");
+	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClipsRatingsEnablement, "0");
 
 	let clipperState = HelperFunctions.getMockClipperState();
 
@@ -548,7 +555,7 @@ test("shouldShowRatingsPrompt returns true when a valid configuration is provide
 	let anchorClipValue = Constants.Settings.maxClipSuccessForRatingsPrompt + 1;
 
 	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClips, (anchorClipValue + Constants.Settings.maxClipSuccessForRatingsPrompt).toString());
-	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClipsOnFirstRatingsEnablement, anchorClipValue.toString());
+	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClipsRatingsEnablement, anchorClipValue.toString());
 	Clipper.storeValue(ClipperStorageKeys.lastBadRatingDate, (Date.now() - Constants.Settings.minTimeBetweenBadRatings).toString());
 	Clipper.storeValue(ClipperStorageKeys.lastBadRatingVersion, "3.0.9");
 	Clipper.storeValue(ClipperStorageKeys.lastSeenVersion, "3.1.0");
@@ -568,7 +575,7 @@ test("shouldShowRatingsPrompt returns false when number of successful clips is b
 	});
 
 	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClips, (Constants.Settings.minClipSuccessForRatingsPrompt - 1).toString());
-	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClipsOnFirstRatingsEnablement, "0");
+	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClipsRatingsEnablement, "0");
 	Clipper.storeValue(ClipperStorageKeys.lastBadRatingDate, (Date.now() - Constants.Settings.minTimeBetweenBadRatings).toString());
 	Clipper.storeValue(ClipperStorageKeys.lastBadRatingVersion, "3.0.9");
 	Clipper.storeValue(ClipperStorageKeys.lastSeenVersion, "3.1.0");
@@ -589,7 +596,7 @@ test("shouldShowRatingsPrompt returns false when last bad rating date is too rec
 	let timeDiffInMs = 1000 * 60 * 60 * 24; // to make last bad rating date 1 day sooner than the min time delay
 
 	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClips, Constants.Settings.minClipSuccessForRatingsPrompt.toString());
-	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClipsOnFirstRatingsEnablement, "0");
+	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClipsRatingsEnablement, "0");
 	Clipper.storeValue(ClipperStorageKeys.lastBadRatingDate, (Date.now() - Constants.Settings.minTimeBetweenBadRatings + timeDiffInMs).toString());
 	Clipper.storeValue(ClipperStorageKeys.lastBadRatingVersion, "3.0.9");
 	Clipper.storeValue(ClipperStorageKeys.lastSeenVersion, "3.1.0");
@@ -608,7 +615,7 @@ test("shouldShowRatingsPrompt returns false when there has not been a significan
 	});
 
 	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClips, Constants.Settings.minClipSuccessForRatingsPrompt.toString());
-	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClipsOnFirstRatingsEnablement, "0");
+	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClipsRatingsEnablement, "0");
 	Clipper.storeValue(ClipperStorageKeys.lastBadRatingDate, (Date.now() - Constants.Settings.minTimeBetweenBadRatings).toString());
 	Clipper.storeValue(ClipperStorageKeys.lastBadRatingVersion, "3.0.9");
 	Clipper.storeValue(ClipperStorageKeys.lastSeenVersion, "3.0.999");
@@ -619,7 +626,7 @@ test("shouldShowRatingsPrompt returns false when there has not been a significan
 	strictEqual(shouldShowRatingsPrompt, false);
 });
 
-test("shouldShowRatingsPrompt returns false when (numSuccessfulClips - numSuccessfulClipsOnFirstRatingsEnablement) is out of range", () => {
+test("shouldShowRatingsPrompt returns false when (numSuccessfulClips - numSuccessfulClipsRatingsEnablement) is out of range", () => {
 	Settings.setSettingsJsonForTesting({
 		"FirefoxExtension_RatingsEnabled": {
 			"Value": "true"
@@ -629,7 +636,7 @@ test("shouldShowRatingsPrompt returns false when (numSuccessfulClips - numSucces
 	let anchorClipValue = Constants.Settings.maxClipSuccessForRatingsPrompt + 1;
 
 	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClips, (anchorClipValue + Constants.Settings.maxClipSuccessForRatingsPrompt + 1).toString());
-	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClipsOnFirstRatingsEnablement, anchorClipValue.toString());
+	Clipper.storeValue(ClipperStorageKeys.numSuccessfulClipsRatingsEnablement, anchorClipValue.toString());
 
 	let clipperState = HelperFunctions.getMockClipperState();
 	clipperState.clientInfo.clipperType = ClientType.FirefoxExtension;

--- a/src/tests/clipperUI/ratingsHelper_tests.tsx
+++ b/src/tests/clipperUI/ratingsHelper_tests.tsx
@@ -386,6 +386,11 @@ test("badRatingAlreadyOccurred returns true when lastBadRatingDate is a valid nu
 
 // shouldShowRatingsPrompt
 
+// TODO test different settings of ClipperStorageKeys.numSuccessfulClipsOnFirstRatingsEnablement:
+//  * does not exist
+//  * exists and combines with ClipperStorageKeys.numSuccessfulClips to stay within valid clip range
+//  * exists but combines with ClipperStorageKeys.numSuccessfulClips to exit valid clip range
+
 test("shouldShowRatingsPrompt returns hardcoded false when clipperState is undefined", () => {
 	let shouldShowRatingsPrompt: boolean = RatingsHelper.shouldShowRatingsPrompt(undefined);
 	strictEqual(shouldShowRatingsPrompt, false);


### PR DESCRIPTION
Ensuring ratings prompt shows as intended for users on initially disabled clients (e.g., Firefox).
