### PR TITLE
Fix Edge PDF view & clip

### DIFF
--- a/src/scripts/domParsers/domUtils.ts
+++ b/src/scripts/domParsers/domUtils.ts
@@ -260,17 +260,20 @@ export module DomUtils {
 		let anchor = doc.createElement("a");
 		anchor.href = doc.URL;
 		if (/\.pdf$/i.test(anchor.pathname)) {
-			// Check if there's a PDF embed element
-			let embedElement = doc.querySelector("embed");
-			if (embedElement && /application\/pdf/i.test((<any>embedElement).type)) {
-				return OneNoteApi.ContentType.EnhancedUrl;
-			}
-
-			// Check if this was a PDF rendered with PDF.js
-			if (window && (<any>window).PDFJS) {
-				return OneNoteApi.ContentType.EnhancedUrl;
-			}
+			return OneNoteApi.ContentType.EnhancedUrl;
 		}
+
+		// Check if there's a PDF embed element
+		let embedElement = doc.querySelector("embed");
+		if (embedElement && /application\/pdf/i.test((<any>embedElement).type)) {
+			return OneNoteApi.ContentType.EnhancedUrl;
+		}
+
+		// Check if this was a PDF rendered with PDF.js
+		if (window && (<any>window).PDFJS) {
+			return OneNoteApi.ContentType.EnhancedUrl;
+		}
+
 		return OneNoteApi.ContentType.Html;
 	}
 


### PR DESCRIPTION
It looks like in Edge, the embed element has an undefined type for PDFs.
We're going to evaluate the value of this check in the first place, but
fixing the logic such that the file extension (PDF) returns the
EnhancedUrl type is the right thing to do.
