### PR TITLE
Replace server.respond() calls with server.respondImmediately = true

### DIFF
--- a/src/tests/clipperUI/components/sectionPicker_tests.tsx
+++ b/src/tests/clipperUI/components/sectionPicker_tests.tsx
@@ -200,6 +200,7 @@ QUnit.module("sectionPicker-sinon", {
 		};
 
 		server = sinon.fakeServer.create();
+		server.respondImmediately = true;
 	},
 	afterEach: () => {
 		xhr.restore();
@@ -223,14 +224,6 @@ test("retrieveAndUpdateNotebookAndSectionSelection should update states correctl
 	};
 	initializeClipperStorage(JSON.stringify(mockNotebooks), JSON.stringify(mockSection), defaultUserInfoAsJsonString);
 
-	let component = <SectionPicker
-		onPopupToggle={() => {}}
-		clipperState={clipperState} />;
-	let controllerInstance = HelperFunctions.mountToFixture(component);
-	let retrievePromise = controllerInstance.retrieveAndUpdateNotebookAndSectionSelection();
-	strictEqual(JSON.stringify(controllerInstance.state), JSON.stringify({ notebooks: mockNotebooks, status: Status.Succeeded, curSection: mockSection }),
-		"After the component is mounted, the state should be updated to reflect the notebooks and section found in storage");
-
 	// After retrieving fresh notebooks, the storage should be updated with the fresh notebooks (although it's the same in this case)
 	let freshNotebooks = HelperFunctions.getMockNotebooks();
 	let responseJson = {
@@ -239,7 +232,13 @@ test("retrieveAndUpdateNotebookAndSectionSelection should update states correctl
 	};
 	server.respondWith([200, {}, JSON.stringify(responseJson)]);
 
-	retrievePromise.then((response) => {
+	let component = <SectionPicker onPopupToggle={() => {}} clipperState={clipperState} />;
+	let controllerInstance = HelperFunctions.mountToFixture(component);
+
+	strictEqual(JSON.stringify(controllerInstance.state), JSON.stringify({ notebooks: mockNotebooks, status: Status.Succeeded, curSection: mockSection }),
+		"After the component is mounted, the state should be updated to reflect the notebooks and section found in storage");
+
+	controllerInstance.retrieveAndUpdateNotebookAndSectionSelection().then((response) => {
 		Clipper.getStoredValue(ClipperStorageKeys.cachedNotebooks, (notebooks) => {
 			Clipper.getStoredValue(ClipperStorageKeys.currentSelectedSection, (curSection) => {
 				strictEqual(notebooks, JSON.stringify(freshNotebooks),
@@ -258,8 +257,6 @@ test("retrieveAndUpdateNotebookAndSectionSelection should update states correctl
 	}, (error) => {
 		ok(false, "reject should not be called");
 	});
-
-	server.respond();
 });
 
 test("retrieveAndUpdateNotebookAndSectionSelection should update states correctly when there's notebook and curSection information found in storage," +
@@ -282,7 +279,7 @@ test("retrieveAndUpdateNotebookAndSectionSelection should update states correctl
 		onPopupToggle={() => {}}
 		clipperState={clipperState} />;
 	let controllerInstance = HelperFunctions.mountToFixture(component);
-	let retrievePromise = controllerInstance.retrieveAndUpdateNotebookAndSectionSelection();
+
 	strictEqual(JSON.stringify(controllerInstance.state), JSON.stringify({ notebooks: mockNotebooks, status: Status.Succeeded, curSection: mockSection }),
 		"After the component is mounted, the state should be updated to reflect the notebooks and section found in storage");
 
@@ -295,7 +292,7 @@ test("retrieveAndUpdateNotebookAndSectionSelection should update states correctl
 	};
 	server.respondWith([200, {}, JSON.stringify(responseJson)]);
 
-	retrievePromise.then((response: SectionPickerState) => {
+	controllerInstance.retrieveAndUpdateNotebookAndSectionSelection().then((response: SectionPickerState) => {
 		Clipper.getStoredValue(ClipperStorageKeys.cachedNotebooks, (notebooks) => {
 			Clipper.getStoredValue(ClipperStorageKeys.currentSelectedSection, (curSection) => {
 				strictEqual(notebooks, JSON.stringify(freshNotebooks),
@@ -315,8 +312,6 @@ test("retrieveAndUpdateNotebookAndSectionSelection should update states correctl
 	}, (error) => {
 		ok(false, "reject should not be called");
 	});
-
-	server.respond();
 });
 
 test("retrieveAndUpdateNotebookAndSectionSelection should update states correctly when there's notebook, but no curSection information found in storage," +
@@ -334,7 +329,7 @@ test("retrieveAndUpdateNotebookAndSectionSelection should update states correctl
 		onPopupToggle={() => {}}
 		clipperState={clipperState} />;
 	let controllerInstance = HelperFunctions.mountToFixture(component);
-	let retrievePromise = controllerInstance.retrieveAndUpdateNotebookAndSectionSelection();
+
 	strictEqual(JSON.stringify(controllerInstance.state), JSON.stringify({ notebooks: mockNotebooks, status: Status.Succeeded, curSection: undefined }),
 		"After the component is mounted, the state should be updated to reflect the notebooks and section found in storage");
 
@@ -353,7 +348,7 @@ test("retrieveAndUpdateNotebookAndSectionSelection should update states correctl
 		section: mockNotebooks[0].sections[0]
 	};
 
-	retrievePromise.then((response: SectionPickerState) => {
+	controllerInstance.retrieveAndUpdateNotebookAndSectionSelection().then((response: SectionPickerState) => {
 		Clipper.getStoredValue(ClipperStorageKeys.cachedNotebooks, (notebooks) => {
 			Clipper.getStoredValue(ClipperStorageKeys.currentSelectedSection, (curSection) => {
 				strictEqual(notebooks, JSON.stringify(freshNotebooks),
@@ -373,8 +368,6 @@ test("retrieveAndUpdateNotebookAndSectionSelection should update states correctl
 	}, (error) => {
 		ok(false, "reject should not be called");
 	});
-
-	server.respond();
 });
 
 test("retrieveAndUpdateNotebookAndSectionSelection should update states correctly when there's notebook, but no curSection information found in storage," +
@@ -392,7 +385,7 @@ test("retrieveAndUpdateNotebookAndSectionSelection should update states correctl
 		onPopupToggle={() => {}}
 		clipperState={clipperState} />;
 	let controllerInstance = HelperFunctions.mountToFixture(component);
-	let retrievePromise = controllerInstance.retrieveAndUpdateNotebookAndSectionSelection();
+
 	strictEqual(JSON.stringify(controllerInstance.state), JSON.stringify({ notebooks: mockNotebooks, status: Status.Succeeded, curSection: undefined }),
 		"After the component is mounted, the state should be updated to reflect the notebooks and section found in storage");
 
@@ -435,7 +428,7 @@ test("retrieveAndUpdateNotebookAndSectionSelection should update states correctl
 		};
 		server.respondWith([200, {}, JSON.stringify(responseJson)]);
 
-		retrievePromise.then((response: SectionPickerState) => {
+		controllerInstance.retrieveAndUpdateNotebookAndSectionSelection().then((response: SectionPickerState) => {
 			Clipper.getStoredValue(ClipperStorageKeys.cachedNotebooks, (notebooks) => {
 				Clipper.getStoredValue(ClipperStorageKeys.currentSelectedSection, (curSection2) => {
 					strictEqual(notebooks, JSON.stringify(freshNotebooks),
@@ -456,13 +449,12 @@ test("retrieveAndUpdateNotebookAndSectionSelection should update states correctl
 			ok(false, "reject should not be called");
 		});
 	});
-
-	server.respond();
 });
 
 test("retrieveAndUpdateNotebookAndSectionSelection should update states correctly when there's notebook and curSection information found in storage," +
 	" and then information is found on the server, but that selected section no longer exists.", (assert: QUnitAssert) => {
 	let done = assert.async();
+
 	let clipperState = HelperFunctions.getMockClipperState();
 
 	// Set up the storage mock
@@ -478,7 +470,7 @@ test("retrieveAndUpdateNotebookAndSectionSelection should update states correctl
 		onPopupToggle={() => {}}
 		clipperState={clipperState} />;
 	let controllerInstance = HelperFunctions.mountToFixture(component);
-	let retrievePromise = controllerInstance.retrieveAndUpdateNotebookAndSectionSelection();
+
 	strictEqual(JSON.stringify(controllerInstance.state), JSON.stringify({ notebooks: mockNotebooks, status: Status.Succeeded, curSection: mockSection }),
 		"After the component is mounted, the state should be updated to reflect the notebooks and section found in storage");
 
@@ -491,7 +483,7 @@ test("retrieveAndUpdateNotebookAndSectionSelection should update states correctl
 	};
 	server.respondWith([200, {}, JSON.stringify(responseJson)]);
 
-	retrievePromise.then((response: SectionPickerState) => {
+	controllerInstance.retrieveAndUpdateNotebookAndSectionSelection().then((response: SectionPickerState) => {
 		Clipper.getStoredValue(ClipperStorageKeys.cachedNotebooks, (notebooks) => {
 			Clipper.getStoredValue(ClipperStorageKeys.currentSelectedSection, (curSection2) => {
 				strictEqual(notebooks, JSON.stringify(freshNotebooks),
@@ -510,8 +502,6 @@ test("retrieveAndUpdateNotebookAndSectionSelection should update states correctl
 	}, (error) => {
 		ok(false, "reject should not be called");
 	});
-
-	server.respond();
 });
 
 test("retrieveAndUpdateNotebookAndSectionSelection should update states correctly when there's notebook and curSection information found in storage," +
@@ -533,7 +523,7 @@ test("retrieveAndUpdateNotebookAndSectionSelection should update states correctl
 		onPopupToggle={() => {}}
 		clipperState={clipperState} />;
 	let controllerInstance = HelperFunctions.mountToFixture(component);
-	let retrievePromise = controllerInstance.retrieveAndUpdateNotebookAndSectionSelection();
+
 	strictEqual(JSON.stringify(controllerInstance.state), JSON.stringify({ notebooks: mockNotebooks, status: Status.Succeeded, curSection: mockSection }),
 		"After the component is mounted, the state should be updated to reflect the notebooks and section found in storage");
 
@@ -544,10 +534,9 @@ test("retrieveAndUpdateNotebookAndSectionSelection should update states correctl
 	};
 	server.respondWith([200, {}, JSON.stringify(responseJson)]);
 
-	retrievePromise.then((response: SectionPickerState) => {
+	controllerInstance.retrieveAndUpdateNotebookAndSectionSelection().then((response: SectionPickerState) => {
 		ok(false, "resolve should not be called");
-	},
-	(error) => {
+	}, (error) => {
 		Clipper.getStoredValue(ClipperStorageKeys.cachedNotebooks,
 		(notebooks) => {
 			Clipper.getStoredValue(ClipperStorageKeys.currentSelectedSection,
@@ -570,8 +559,6 @@ test("retrieveAndUpdateNotebookAndSectionSelection should update states correctl
 			});
 		});
 	});
-
-	server.respond();
 });
 
 test("retrieveAndUpdateNotebookAndSectionSelection should update states correctly when there's notebook and curSection information found in storage," +
@@ -593,7 +580,7 @@ test("retrieveAndUpdateNotebookAndSectionSelection should update states correctl
 		onPopupToggle={() => {}}
 		clipperState={clipperState} />;
 	let controllerInstance = HelperFunctions.mountToFixture(component);
-	let retrievePromise = controllerInstance.retrieveAndUpdateNotebookAndSectionSelection();
+
 	strictEqual(JSON.stringify(controllerInstance.state), JSON.stringify({ notebooks: mockNotebooks, status: Status.Succeeded, curSection: mockSection }),
 		"After the component is mounted, the state should be updated to reflect the notebooks and section found in storage");
 
@@ -601,7 +588,7 @@ test("retrieveAndUpdateNotebookAndSectionSelection should update states correctl
 	let responseJson = {};
 	server.respondWith([404, {}, JSON.stringify(responseJson)]);
 
-	retrievePromise.then((response: SectionPickerState) => {
+	controllerInstance.retrieveAndUpdateNotebookAndSectionSelection().then((response: SectionPickerState) => {
 		ok(false, "resolve should not be called");
 	}, (error) => {
 		Clipper.getStoredValue(ClipperStorageKeys.cachedNotebooks, (notebooks) => {
@@ -620,8 +607,6 @@ test("retrieveAndUpdateNotebookAndSectionSelection should update states correctl
 			});
 		});
 	});
-
-	server.respond();
 });
 
 test("retrieveAndUpdateNotebookAndSectionSelection should update states correctly when there's no notebook and curSection information found in storage," +
@@ -637,15 +622,15 @@ test("retrieveAndUpdateNotebookAndSectionSelection should update states correctl
 		onPopupToggle={() => {}}
 		clipperState={clipperState} />;
 	let controllerInstance = HelperFunctions.mountToFixture(component);
-	let retrievePromise = controllerInstance.retrieveAndUpdateNotebookAndSectionSelection();
-	strictEqual(JSON.stringify(controllerInstance.state), JSON.stringify({ notebooks: undefined, status: Status.InProgress, curSection: undefined }),
-		"After the component is mounted, the state should be updated to reflect that the attempt to get notebooks is still underway");
+
+	strictEqual(JSON.stringify(controllerInstance.state), JSON.stringify({ notebooks: undefined, status: Status.NotStarted, curSection: undefined }),
+		"After the component is mounted, the state should be updated to reflect that notebooks and current section are not found in storage");
 
 	// After retrieving fresh undefined notebooks, the storage should not be updated with the undefined value, but should still keep the old cached information
 	let responseJson = {};
 	server.respondWith([404, {}, JSON.stringify(responseJson)]);
 
-	retrievePromise.then((response: SectionPickerState) => {
+	controllerInstance.retrieveAndUpdateNotebookAndSectionSelection().then((response: SectionPickerState) => {
 		ok(false, "resolve should not be called");
 	}, (error) => {
 		Clipper.getStoredValue(ClipperStorageKeys.cachedNotebooks, (notebooks) => {
@@ -664,12 +649,11 @@ test("retrieveAndUpdateNotebookAndSectionSelection should update states correctl
 			});
 		});
 	});
-
-	server.respond();
 });
 
 test("fetchFreshNotebooks should parse out @odata.context from the raw 200 response and return the notebook object list and XHR in the resolve", (assert: QUnitAssert) => {
 	let done = assert.async();
+
 	let controllerInstance = HelperFunctions.mountToFixture(defaultComponent);
 
 	let notebooks = HelperFunctions.getMockNotebooks();
@@ -688,13 +672,12 @@ test("fetchFreshNotebooks should parse out @odata.context from the raw 200 respo
 		ok(false, "reject should not be called");
 	}).then(() => {
 		done();
-		});
-
-	server.respond();
+	});
 });
 
 test("fetchFreshNotebooks should parse out @odata.context from the raw 201 response and return the notebook object list and XHR in the resolve", (assert: QUnitAssert) => {
 	let done = assert.async();
+
 	let controllerInstance = HelperFunctions.mountToFixture(defaultComponent);
 
 	let notebooks = HelperFunctions.getMockNotebooks();
@@ -714,11 +697,11 @@ test("fetchFreshNotebooks should parse out @odata.context from the raw 201 respo
 	}).then(() => {
 		done();
 	});
-	server.respond();
 });
 
 test("fetchFreshNotebooks should reject with the error object and a copy of the response if the status code is 4XX", (assert: QUnitAssert) => {
 	let done = assert.async();
+
 	let controllerInstance = HelperFunctions.mountToFixture(defaultComponent);
 
 	let responseJson = {
@@ -745,11 +728,11 @@ test("fetchFreshNotebooks should reject with the error object and a copy of the 
 	}).then(() => {
 		done();
 	});
-	server.respond();
 });
 
 test("fetchFreshNotebooks should reject with the error object and an API response code if one is returned by the API", (assert: QUnitAssert) => {
 	let done = assert.async();
+
 	let controllerInstance = HelperFunctions.mountToFixture(defaultComponent);
 
 	let responseJson = {
@@ -770,10 +753,7 @@ test("fetchFreshNotebooks should reject with the error object and an API respons
 
 	server.respondWith([expected.statusCode, expected.responseHeaders, expected.response]);
 
-	let freshNotebooks: Promise<OneNoteApi.ResponsePackage<OneNoteApi.Notebook[]>>;
-	freshNotebooks = controllerInstance.fetchFreshNotebooks("sessionId");
-
-	freshNotebooks.then((responsePackage: OneNoteApi.ResponsePackage<OneNoteApi.Notebook[]>) => {
+	controllerInstance.fetchFreshNotebooks("sessionId").then((responsePackage: OneNoteApi.ResponsePackage<OneNoteApi.Notebook[]>) => {
 		ok(false, "resolve should not be called");
 	}, (error: OneNoteApi.RequestError) => {
 		deepEqual(error, expected, "The error object should be rejected");
@@ -781,11 +761,11 @@ test("fetchFreshNotebooks should reject with the error object and an API respons
 	}).then(() => {
 		done();
 	});
-	server.respond();
 });
 
 test("fetchFreshNotebooks should reject with the error object and a copy of the response if the status code is 5XX", (assert: QUnitAssert) => {
 	let done = assert.async();
+
 	let controllerInstance = HelperFunctions.mountToFixture(defaultComponent);
 
 	let responseJson = {
@@ -810,7 +790,6 @@ test("fetchFreshNotebooks should reject with the error object and a copy of the 
 	}).then(() => {
 		done();
 	});
-	server.respond();
 });
 
 QUnit.module("sectionPicker-static", {});

--- a/src/tests/contentCapture/augmentationHelper_tests.ts
+++ b/src/tests/contentCapture/augmentationHelper_tests.ts
@@ -18,6 +18,7 @@ QUnit.module("augmentationHelper-sinon", {
 		};
 
 		server = sinon.fakeServer.create();
+		server.respondImmediately = true;
 	},
 	afterEach: () => {
 		xhr.restore();
@@ -50,7 +51,6 @@ test("makeAugmentationRequest should return the parsed response and the original
 	}).then(() => {
 		done();
 	});
-	server.respond();
 });
 
 test("makeAugmentationRequest should return the error object in the rejected promise if the status code is not 200", (assert: QUnitAssert) => {
@@ -75,7 +75,6 @@ test("makeAugmentationRequest should return the error object in the rejected pro
 	}).then(() => {
 		done();
 	});
-	server.respond();
 });
 
 test("makeAugmentationRequest should return the error object in the rejected promise if the status code is 200, but the response cannot be parsed as json", (assert: QUnitAssert) => {
@@ -105,7 +104,6 @@ test("makeAugmentationRequest should return the error object in the rejected pro
 	}).then(() => {
 		done();
 	});
-	server.respond();
 });
 
 let fixture: HTMLDivElement;

--- a/src/tests/extensions/authenticationHelper_tests.ts
+++ b/src/tests/extensions/authenticationHelper_tests.ts
@@ -32,6 +32,7 @@ QUnit.module("authenticationHelper-sinon", {
 		};
 
 		server = sinon.fakeServer.create();
+		server.respondImmediately = true;
 
 		mockClipperData = sinon.createStubInstance(ClipperData) as any;
 		mockLogger = sinon.createStubInstance(Logger) as any;
@@ -63,7 +64,6 @@ test("retrieveUserInformation resolves the response as a json string if it repre
 	}).then(() => {
 		done();
 	});
-	server.respond();
 });
 
 test("retrieveUserInformation resolves the response with no parameter if it returns an empty object", (assert: QUnitAssert) => {
@@ -82,7 +82,6 @@ test("retrieveUserInformation resolves the response with no parameter if it retu
 	}).then(() => {
 		done();
 	});
-	server.respond();
 });
 
 test("retrieveUserInformation resolves the response with no parameter if it returns an empty string", (assert: QUnitAssert) => {
@@ -101,7 +100,6 @@ test("retrieveUserInformation resolves the response with no parameter if it retu
 	}).then(() => {
 		done();
 	});
-	server.respond();
 });
 
 test("retrieveUserInformation resolves the response with no parameter if it represents incomplete user information", (assert: QUnitAssert) => {
@@ -122,7 +120,6 @@ test("retrieveUserInformation resolves the response with no parameter if it repr
 	}).then(() => {
 		done();
 	});
-	server.respond();
 });
 
 test("retrieveUserInformation resolves the response with no parameter if it represents empty user information", (assert: QUnitAssert) => {
@@ -149,7 +146,6 @@ test("retrieveUserInformation resolves the response with no parameter if it repr
 	}).then(() => {
 		done();
 	});
-	server.respond();
 });
 
 test("retrieveUserInformation rejects the response with error object if the status code is 4XX", (assert: QUnitAssert) => {
@@ -176,7 +172,6 @@ test("retrieveUserInformation rejects the response with error object if the stat
 	}).then(() => {
 		done();
 	});
-	server.respond();
 });
 
 test("retrieveUserInformation rejects the response with error object if the status code is 5XX", (assert: QUnitAssert) => {
@@ -204,7 +199,6 @@ test("retrieveUserInformation rejects the response with error object if the stat
 	}).then(() => {
 		done();
 	});
-	server.respond();
 });
 
 QUnit.module("authenticationHelper", {});

--- a/src/tests/http/http_tests.ts
+++ b/src/tests/http/http_tests.ts
@@ -14,6 +14,7 @@ QUnit.module("http", {
 		};
 
 		server = sinon.fakeServer.create();
+		server.respondImmediately = true;
 	},
 	afterEach: () => {
 		xhr.restore();
@@ -34,7 +35,6 @@ test("When get is called with valid parameters and the server returns 200, the r
 	}).then(() => {
 		done();
 	});
-	server.respond();
 });
 
 test("When get is called with valid parameters and the server returns 204 when the caller specified that its a valid response code, the request should be returned in the resolve", (assert: QUnitAssert) => {
@@ -50,7 +50,6 @@ test("When get is called with valid parameters and the server returns 204 when t
 	}).then(() => {
 		done();
 	});
-	server.respond();
 });
 
 test("When get is called with valid parameters and the server returns non-200 2XX, the promise should be rejected with the request error object", (assert: QUnitAssert) => {
@@ -79,7 +78,6 @@ test("When get is called with valid parameters and the server returns non-200 2X
 	}).then(() => {
 		done();
 	});
-	server.respond();
 });
 
 test("When get is called with an undefined url, an Error should be thrown", () => {
@@ -120,7 +118,6 @@ test("When get is called with valid parameters and the server returns 4XX, the p
 	}).then(() => {
 		done();
 	});
-	server.respond();
 });
 
 test("When get is called with valid parameters and the server returns 5XX, the promise should be rejected with the request error object", (assert: QUnitAssert) => {
@@ -149,7 +146,6 @@ test("When get is called with valid parameters and the server returns 5XX, the p
 	}).then(() => {
 		done();
 	});
-	server.respond();
 });
 
 test("When post is called with valid parameters and the server returns 200, the request should be returned in the resolve", (assert: QUnitAssert) => {
@@ -165,7 +161,6 @@ test("When post is called with valid parameters and the server returns 200, the 
 	}).then(() => {
 		done();
 	});
-	server.respond();
 });
 
 test("When post is called with data as an empty string and the server returns 200, the request should be returned in the resolve", (assert: QUnitAssert) => {
@@ -181,7 +176,6 @@ test("When post is called with data as an empty string and the server returns 20
 	}).then(() => {
 		done();
 	});
-	server.respond();
 });
 
 test("When post is called with valid parameters and the server returns 204 when the caller specified that its a valid response code, the request should be returned in the resolve", (assert: QUnitAssert) => {
@@ -197,7 +191,6 @@ test("When post is called with valid parameters and the server returns 204 when 
 	}).then(() => {
 		done();
 	});
-	server.respond();
 });
 
 test("When post is called with valid parameters and the server returns non-200 2XX, the promise should be rejected with the request error object", (assert: QUnitAssert) => {
@@ -226,7 +219,6 @@ test("When post is called with valid parameters and the server returns non-200 2
 	}).then(() => {
 		done();
 	});
-	server.respond();
 });
 
 test("When post is called with an undefined url, an Error should be thrown", () => {
@@ -273,7 +265,6 @@ test("When post is called with valid parameters and the server returns 4XX, the 
 	}).then(() => {
 		done();
 	});
-	server.respond();
 });
 
 test("When post is called with valid parameters and the server returns 5XX, the promise should be rejected with the request error object", (assert: QUnitAssert) => {
@@ -302,5 +293,4 @@ test("When post is called with valid parameters and the server returns 5XX, the 
 	}).then(() => {
 		done();
 	});
-	server.respond();
 });


### PR DESCRIPTION
`server.respond()` assumes that you have already sent a request, which can make async code blocks hard to test. Here's a scenario:

```
function fnBeingTested() {
    doSomethingInBackground().then(() => {
        console.log("foo");
        // send xhr
    });
}
```

Imagine you are testing the above function. You want to get your mock server to send a response, so you set up your response in your test and do the following:

```
fnBeingTested();
server.respond();
```

This is the expected order of execution:

```
"foo"
response
```

This is what happens:

```
response (no-op, because we haven't sent xhr yet)
"foo"
```

This is because doSomethingInBackground is an async function, which means as soon as it gets hit, we call the server.respond() before the Thenable. We now have a race condition, and `server.respond()` no longer cuts the cheese. Rather than doing this, we now use `server.respondImmediately = true`, which in a nutshell, sets up a listener for the XHR being sent before automatically sending the response.

This will also make our tests more readable as it will follow a very natural flow that is similar to how we actually write our code in our codebase. For examples, simply look at some of the before vs after tests in sectionPicker_tests.tsx :)

From now on, let's disallow the use of `server.respond()`.
Fixes #110 
