### PR TITLE
PDF mode scroll listener

### DIFF
--- a/src/scripts/constants.ts
+++ b/src/scripts/constants.ts
@@ -362,5 +362,6 @@ export module Constants {
 		export var timeBetweenDifferentTooltips = 1000 * 60 * 60 * 24 * 7 * 1; // 1 week
 		export var timeBetweenSameTooltip = 1000 * 60 * 60 * 24 * 7 * 3; // 3 weeks
 		export var timeBetweenTooltips = 1000 * 60 * 60 * 24 * 7 * 3; // 21 days
+		export var timeUntilPdfPageNumbersFadeOutAfterScroll = 1000; // 1 second
 	}
 }

--- a/src/styles/previewStyles.less
+++ b/src/styles/previewStyles.less
@@ -504,38 +504,40 @@
 						display: flex;
 						align-items: center;
 						justify-content: center;
-					}
 
-					.pdf-preview-image {
-						margin-top: 24px;
-						box-shadow: 2px 2px 1px 1px rgba(0,0,0,0.2), -2px 0px 1px 1px rgba(0,0,0,0.2);
-					}
+						.pdf-preview-image {
+							margin-top: 24px;
+							box-shadow: 2px 2px 1px 1px rgba(0,0,0,0.2), -2px 0px 1px 1px rgba(0,0,0,0.2);
+						}
 
-					.overlay {
-						width: 104px;
-						height: 104px;
-						background-color: rgba(0,0,0,.65);
-						position: absolute;
-						border-radius: 8px;
-						
-						display: flex;
-						align-items: center;
-						justify-content: center;
-					}
+						.overlay {
+							width: 104px;
+							height: 104px;
+							background-color: rgba(0,0,0,.65);
+							position: absolute;
+							border-radius: 8px;
+							
+							display: flex;
+							align-items: center;
+							justify-content: center;
+							opacity: 1;
+						}
 
-					.overlay-number {
-						font-size: 64px;
-						font-family: @SegoeUi;
-						color: white;
-						margin-bottom: 4px;
-					}
+						.overlay-hidden {
+							// We declare these here to only trigger the transitions on fade-out
+							-webkit-transition: opacity 0.5s ease-in-out;
+							-moz-transition: opacity 0.5s ease-in-out;
+							-o-transition: opacity 0.5s ease-in-out;
+							transition: opacity 0.5s ease-in-out;
+							opacity: 0;
+						}
 
-					.fade-out {
-						animation: fadeout 4s linear;
-					}
-
-					.fade-in {
-						animation: fadein 4s linear;
+						.overlay-number {
+							font-size: 64px;
+							font-family: @SegoeUi;
+							color: white;
+							margin-bottom: 4px;
+						}
 					}
 
 					// Allows the same attachment styling as the WAC


### PR DESCRIPTION
When the user scrolls in pdf mode, we 'pop-in' the page numbers. If the user hasn't scrolled in 1 second, we fade out the page numbers over 0.5 seconds.
