### PR TITLE
Bug/safari crash on signout

### DIFF
--- a/src/scripts/extensions/safari/safariWorker.ts
+++ b/src/scripts/extensions/safari/safariWorker.ts
@@ -131,11 +131,12 @@ export class SafariWorker extends ExtensionWorkerBase<SafariBrowserTab, SafariBr
 
 	private launchSafariPopup(url: string, autoCloseDestinationUrl: string, waitForClose = false): Promise<boolean> {
 		return new Promise<boolean>((resolve, reject) => {
-			let redirectOccurred = false;
 			let newWindow = safari.application.openBrowserWindow();
 			newWindow.activeTab.url = url;
 
 			if (waitForClose) {
+				let redirectOccurred = false;
+
 				let errorObject;
 				let redirectListener = (event) => {
 					if (event && event.target && event.target.url && !event.target.url.toLowerCase().indexOf(autoCloseDestinationUrl)) {


### PR DESCRIPTION
Fixes #129 

On clipper sign-out, we were listening for the response URL and then manually closing the popup window.  However, it looks like on sign-out, this isn't necessary as the window gets closed automatically.

This causes a problem because the listener we set up gets called and tries to access the newWindow object, which is now null.  In pre-Sierra versions of Safari this seemed to be ok, but in Sierra it now causes the browser to crash.
