### PR TITLE
Always enable add-a-note

### DIFF
--- a/src/scripts/clipperUI/components/previewViewer/previewComponentBase.tsx
+++ b/src/scripts/clipperUI/components/previewViewer/previewComponentBase.tsx
@@ -157,7 +157,7 @@ export abstract class PreviewComponentBase<TState, TProps extends ClipperStatePr
 						<div id={Constants.Ids.previewContentContainer} className={inProgressClassIfApplicable + " " + this.getPreviewContentContainerClass() } >
 							{this.isTitleEnabled() ? <div id={Constants.Ids.previewHeaderContainer}>
 								{this.getPreviewTitle(contentTitle, titleIsEditable, inProgressClassIfApplicable)}
-								{clipButtonEnabled ? this.getPreviewSubtitle() : undefined}
+								{this.getPreviewSubtitle() }
 							</div> : ""}
 							<div
 								style={previewStyle}


### PR DESCRIPTION
I think we should do this across all our modes. It's a global state that exists across all modes, so we shouldn't gate this by a disable clip button.
