### PR TITLE
Remove unecessary subsequent PATCH permission checks

### DIFF
--- a/src/scripts/clipperUI/clipper.tsx
+++ b/src/scripts/clipperUI/clipper.tsx
@@ -612,6 +612,7 @@ class ClipperClass extends ComponentBase<ClipperState, {}> {
 			let userInfoReturned = updatedUser && !!updatedUser.user;
 			if (userInfoReturned) {
 				// Sign in succeeded
+				Clipper.storeValue(ClipperStorageKeys.hasPatchPermissions, "true");
 				Clipper.logger.logUserFunnel(Log.Funnel.Label.AuthSignInCompleted);
 			}
 			handleSignInEvent.setCustomProperty(Log.PropertyName.Custom.UserInformationReturned, userInfoReturned);

--- a/src/scripts/clipperUI/saveToOneNote.ts
+++ b/src/scripts/clipperUI/saveToOneNote.ts
@@ -378,6 +378,9 @@ export class SaveToOneNote {
 				if (hasPermissions) {
 					resolve();
 				} else {
+					// As of v3.2.9, we have added a new scope for MSA to allow for PATCHing, however currently-logged-in users will not have
+					// this scope, so this call is a workaround to check for permissions, but is very unperformant. We need to investigate a
+					// quicker way of doing this ... perhaps exposing an endpoint that we can use for this sole purpose.
 					let patchPermissionCheckEvent = new Log.Event.PromiseEvent(Log.Event.Label.PatchPermissionCheck);
 					SaveToOneNote.getPages({ top: 1, sectionId: this.clipperState.saveLocation }).then(() => {
 						Clipper.storeValue(ClipperStorageKeys.hasPatchPermissions, "true");

--- a/src/scripts/storage/clipperStorageKeys.ts
+++ b/src/scripts/storage/clipperStorageKeys.ts
@@ -5,6 +5,7 @@ export module ClipperStorageKeys {
 	export var displayLanguageOverride = "displayLocaleOverride";
 	export var doNotPromptRatings = "doNotPromptRatings";
 	export var flightingInfo = "flightingInfo";
+	export var hasPatchPermissions = "hasPatchPermissions";
 	export var lastBadRatingDate = "lastBadRatingDate";
 	export var lastBadRatingVersion = "lastBadRatingVersion";
 	export var lastClippedDate = "lastClippedDate";


### PR DESCRIPTION
Currently, we call getPages() to check for PATCH permissions on every pdf clip, however, we know that if a user has already successfully checked once, or has signed in at some point in this version, that they have the latest scopes, so we store a value in localStorage to mark the device so. Of course, this is still not ideal, so I've added a lengthy comment, and I'll create an issue to track this so we can come up with a more permanent, reliable, and performant solution.
