### PR TITLE
[Bug] Add some more logging to PDF mode

### DIFF
--- a/src/scripts/clipperUI/clipper.tsx
+++ b/src/scripts/clipperUI/clipper.tsx
@@ -675,8 +675,8 @@ class ClipperClass extends ComponentBase<ClipperState, {}> {
 		let mode = ClipMode[this.state.currentMode.get()];
 
 		if (this.state.currentMode.get() === ClipMode.Pdf) {
+			clipEvent.setCustomProperty(Log.PropertyName.Custom.NumPages, this.state.pdfResult.data.get().pdf.numPages());
 			Clipper.storeValue(ClipperStorageKeys.lastClippedTooltipTimeBase + TooltipType[TooltipType.Pdf], Date.now().toString());
-			mode += ": " + OneNoteApi.ContentType[this.state.pageInfo.contentType];
 		}
 
 		if (this.state.currentMode.get() === ClipMode.Augmentation) {
@@ -717,6 +717,10 @@ class ClipperClass extends ComponentBase<ClipperState, {}> {
 
 			this.state.setState({ oneNoteApiResult: { data: error, status: Status.Failed } });
 		}).then(() => {
+			if (this.state.currentMode.get() === ClipMode.Pdf) {
+				clipEvent.stopTimer();
+				clipEvent.setCustomProperty(Log.PropertyName.Custom.AverageProcessingDurationPerPage, clipEvent.getDuration() / this.state.pdfResult.data.get().pdf.numPages());
+			}
 			Clipper.logger.logEvent(clipEvent);
 		});
 	}

--- a/src/scripts/clipperUI/saveToOneNote.ts
+++ b/src/scripts/clipperUI/saveToOneNote.ts
@@ -330,10 +330,10 @@ export class SaveToOneNote {
 	 */
 	private static createAndPatchPdfPage(page: OneNoteApi.OneNotePage, pageIndexes: number[]): Promise<OneNoteApi.ResponsePackage<any>> {
 		return new Promise<OneNoteApi.ResponsePackage<any>>((resolve, reject) => {
-			return SaveToOneNote.checkIfUserHasPermissionToPatch().then(() => {
-				return SaveToOneNote.pdfCreatePage(page).then((postPageResponse /* should also be a onenote response */) => {
+			SaveToOneNote.checkIfUserHasPermissionToPatch().then(() => {
+				SaveToOneNote.pdfCreatePage(page).then((postPageResponse /* should also be a onenote response */) => {
 					let pageId = postPageResponse.parsedResponse.id;
-					return SaveToOneNote.sendPagesAsPatchRequests(pageId, pageIndexes).then(() => {
+					SaveToOneNote.sendPagesAsPatchRequests(pageId, pageIndexes).then(() => {
 						resolve(postPageResponse);
 					});
 				});

--- a/src/scripts/clipperUI/saveToOneNote.ts
+++ b/src/scripts/clipperUI/saveToOneNote.ts
@@ -330,10 +330,10 @@ export class SaveToOneNote {
 	 */
 	private static createAndPatchPdfPage(page: OneNoteApi.OneNotePage, pageIndexes: number[]): Promise<OneNoteApi.ResponsePackage<any>> {
 		return new Promise<OneNoteApi.ResponsePackage<any>>((resolve, reject) => {
-			SaveToOneNote.checkIfUserHasPermissionToPatch().then(() => {
-				SaveToOneNote.pdfCreatePage(page).then((postPageResponse /* should also be a onenote response */) => {
+			return SaveToOneNote.checkIfUserHasPermissionToPatch().then(() => {
+				return SaveToOneNote.pdfCreatePage(page).then((postPageResponse /* should also be a onenote response */) => {
 					let pageId = postPageResponse.parsedResponse.id;
-					SaveToOneNote.sendPagesAsPatchRequests(pageId, pageIndexes).then(() => {
+					return SaveToOneNote.sendPagesAsPatchRequests(pageId, pageIndexes).then(() => {
 						resolve(postPageResponse);
 					});
 				});


### PR DESCRIPTION
Add numPages and processingTime to ClipToOneNoteAction and change the ClipMode to be more reflective of the mode

We changed `ProcessPdfIntoDatUrls` from working on the entire PDF to just specific ranges, and so we lost the logging we had on the overall number of pages in the pdf (I think).

We also used to log the PDF clips as "FullPage: EnhancedUrl", but it is now just "Pdf". I think to reconcile the dashboards we will have to use a custom function. 
