### PR TITLE
[Bug] On Safari, add a check for a file URL before we show the "Not Allowed File Scheme" dialog

### DIFF
--- a/src/scripts/extensions/safari/safariWorker.ts
+++ b/src/scripts/extensions/safari/safariWorker.ts
@@ -113,7 +113,11 @@ export class SafariWorker extends ExtensionWorkerBase<SafariBrowserTab, SafariBr
 
 	protected isAllowedFileSchemeAccessBrowserSpecific(callback: (isAllowed: boolean) => void): void {
 		// When Safari opens a pdf, it is no longer a web environment and won't allow extensions to run
-		callback(false);
+		if (this.tab.url.indexOf("file:///") === 0) {
+			callback(false);
+		} else {
+			callback(true);
+		}
 	}
 
 	/**


### PR DESCRIPTION
I forgot to put the check in to make sure it was actually a local file.