### PR TITLE
[Bug] The PDF Number Overlay was not styled correctly in Firefox

### DIFF
--- a/src/styles/previewStyles.less
+++ b/src/styles/previewStyles.less
@@ -563,7 +563,6 @@
 					.pdf-preview-image-container {
 						position: relative;
 						display: flex;
-						flex-direction: column;
 						align-items: center;
 
 						.pdf-preview-image-canvas {

--- a/src/styles/previewStyles.less
+++ b/src/styles/previewStyles.less
@@ -563,8 +563,8 @@
 					.pdf-preview-image-container {
 						position: relative;
 						display: flex;
+						flex-direction: column;
 						align-items: center;
-						justify-content: center;
 
 						.pdf-preview-image-canvas {
 							width: 100%;
@@ -586,6 +586,9 @@
 							background-color: rgba(0,0,0,.65);
 							position: absolute;
 							border-radius: 8px;
+							left: 50%;
+							top: 50%;
+							transform: translate(-50%, -50%);
 							
 							display: flex;
 							align-items: center;


### PR DESCRIPTION
I think there are differences in Chrome and Firefox's Flexbox implementation or we are using flexbox incorrectly and using undefined behavior 