### PR TITLE
Change error message on FullPageScreenshot failure, gray out clip button

### DIFF
--- a/src/scripts/clipperUI/clipper.tsx
+++ b/src/scripts/clipperUI/clipper.tsx
@@ -246,7 +246,7 @@ class ClipperClass extends ComponentBase<ClipperState, {}> {
 				this.state.setState({
 					fullPageResult: {
 						data: {
-							failureMessage: Localization.getLocalizedString("WebClipper.Preview.FullPageModeGenericError")
+							failureMessage: Localization.getLocalizedString("WebClipper.Preview.NoFullPageScreenshotFound")
 						},
 						status: Status.Failed
 					}

--- a/src/scripts/clipperUI/clipperState.ts
+++ b/src/scripts/clipperUI/clipperState.ts
@@ -97,9 +97,8 @@ export module ClipperStateHelperFunctions {
 				}
 				return true;
 			case ClipMode.FullPage:
-				// The pdf and full page screenshots are only needed for preview. In the case of pdf, binary downloads
-				// can be deferred to the clip wait.
-				return true;
+				let fullPageScreenshotResult = clipperState.fullPageResult;
+				return fullPageScreenshotResult.status === Status.Succeeded;
 			case ClipMode.Region:
 				let regionResult = clipperState.regionResult;
 				return regionResult.status === Status.Succeeded && regionResult.data && regionResult.data.length > 0;

--- a/src/strings.json
+++ b/src/strings.json
@@ -92,6 +92,7 @@
 	"WebClipper.Preview.BookmarkModeGenericError": "Something went wrong creating the bookmark. Try again, or choose a different clipping mode.",
 	"WebClipper.Preview.FullPageModeGenericError": "A preview isn't available, but you can still clip your page.",
 	"WebClipper.Preview.LoadingMessage": "Loading preview...",
+	"WebClipper.Preview.NoFullPageScreenshotFound": "No content found. Try another clipping mode.",
 	"WebClipper.Preview.NoContentFound": "No article found. Try another clipping mode.",
 	"WebClipper.Preview.UnableToClipLocalFile": "Local files can only be clipped using Region mode.",
 	"WebClipper.Preview.Header.AddAnotherRegionButtonLabel": "Add another region",


### PR DESCRIPTION
If we are happy with this string, I can kick off localization.

Also I realized there was no UTs for optionsPanel. I have gone ahead and created an issue for this, but in the meantime, we're safe to merge this if we like it enough.

Fixes #169