### PR TITLE
[Bug] When a user hits a 403 trying to clip a PDF in the new Mode, the error panel is not shown

### DIFF
--- a/src/scripts/clipperUI/saveToOneNote.ts
+++ b/src/scripts/clipperUI/saveToOneNote.ts
@@ -339,7 +339,7 @@ export class SaveToOneNote {
 					});
 				});
 			}).catch((error) => {
-				return Promise.reject(error);
+				reject(error);
 			});
 		});
 	}


### PR DESCRIPTION
**Expected**: When a user clips a PDF in the new mode, and they get a 403 when we check their PATCH permissions, we show them a dialog with a nice string and also give them a button to sign out.
**Actual**: The Promise error is swallowed and so the "Failed" status of the call is never bubbled up to the mainController, so the UI says "Clipping..." forever.

The bug is that a Promise created with `new Promise<>((resolve, reject) => {})` apparently can't use `return Promise.resolve(...)` and it must call the original `resolve` function. 
