### PR TITLE
Added underlines back to <a> tags in the preview

### DIFF
--- a/src/styles/previewStyles.less
+++ b/src/styles/previewStyles.less
@@ -439,7 +439,7 @@
 					}
 
 					a {
-						text-decoration: none;
+						text-decoration: underline;
 					}
 
 					figure {


### PR DESCRIPTION
At some point a while ago, we changed links to not have underlines in the preview, however, they have underlines in OneNote clients. Adding underlines back in to be consistent.

Fixes #60 together with a previous PR that added some additional sanitization to article extracted content.