### PR TITLE
Relax range invalidation

### DIFF
--- a/src/scripts/stringUtils.ts
+++ b/src/scripts/stringUtils.ts
@@ -25,6 +25,11 @@ export module StringUtils {
 			let valueToAppend: number[] = [], matches;
 			let currentValue = splitText[i].trim();
 
+			if (currentValue === "") {
+				// We relax the restriction by allowing and ignoring whitespace between commas
+				continue;
+			}
+
 			if (/^\d+$/.test(currentValue)) {
 				let digit = parseInt(currentValue, 10 /* radix */);
 				if (digit === 0) {

--- a/src/tests/stringUtils_tests.ts
+++ b/src/tests/stringUtils_tests.ts
@@ -33,6 +33,21 @@ export class StringUtilsTests extends TestModule {
 			deepEqual(ret, [1, 3, 5, 7], "A page range of '1,3,5,7' should return [1,3,5,7]");
 		});
 
+		test("A range ending in a comma should still be legal", () => {
+			let ret = StringUtils.parsePageRange("1,3,5,7,");
+			deepEqual(ret, [1, 3, 5, 7], "A page range of '1,3,5,7,' should return [1,3,5,7]");
+		});
+
+		test("A range ending in multiple commas should still be legal", () => {
+			let ret = StringUtils.parsePageRange("1,3,5,7,,,");
+			deepEqual(ret, [1, 3, 5, 7], "A page range of '1,3,5,7,,,' should return [1,3,5,7]");
+		});
+
+		test("A range that has whitespace between commas should still be legal", () => {
+			let ret = StringUtils.parsePageRange("1,, , 3");
+			deepEqual(ret, [1, 3], "A page range of '1,, , 3' should return [1, 3]");
+		});
+
 		test("A range with a hyphen in it should return a range including that interval and both endpoints", () => {
 			let ret = StringUtils.parsePageRange("1-5");
 			deepEqual(ret, [1, 2, 3, 4, 5], "A page range of '1-5' should return [1,2,3,4,5]");


### PR DESCRIPTION
We now allow commas that have whitespace between them. We simply ignore them and keep parsing.