### PR TITLE
Extension lifecycle logging

### DIFF
--- a/src/scripts/extensions/extensionBase.ts
+++ b/src/scripts/extensions/extensionBase.ts
@@ -36,7 +36,7 @@ import {WorkerPassthroughLogger} from "./workerPassthroughLogger";
 export abstract class ExtensionBase<TWorker extends ExtensionWorkerBase<TTab, TTabIdentifier>, TTab, TTabIdentifier> {
 	private workers: TWorker[];
 	private logger: Logger;
-	private static browserSessionId: string;
+	private static extensionId: string;
 
 	protected clipperData: ClipperData;
 	protected auth: AuthenticationHelper;
@@ -49,7 +49,7 @@ export abstract class ExtensionBase<TWorker extends ExtensionWorkerBase<TTab, TT
 
 		this.workers = [];
 		this.logger = new WorkerPassthroughLogger(this.workers);
-		ExtensionBase.browserSessionId = StringUtils.generateGuid();
+		ExtensionBase.extensionId = StringUtils.generateGuid();
 
 		this.clipperData = clipperData;
 		this.clipperData.setLogger(this.logger);
@@ -90,8 +90,8 @@ export abstract class ExtensionBase<TWorker extends ExtensionWorkerBase<TTab, TT
 	protected abstract createWorker(tab: TTab): TWorker;
 	protected abstract onFirstRun();
 
-	public static getBrowserSessionId(): string {
-		return ExtensionBase.browserSessionId;
+	public static getExtensionId(): string {
+		return ExtensionBase.extensionId;
 	}
 
 	public static getExtensionVersion(): string {

--- a/src/scripts/extensions/extensionBase.ts
+++ b/src/scripts/extensions/extensionBase.ts
@@ -36,6 +36,8 @@ import {WorkerPassthroughLogger} from "./workerPassthroughLogger";
 export abstract class ExtensionBase<TWorker extends ExtensionWorkerBase<TTab, TTabIdentifier>, TTab, TTabIdentifier> {
 	private workers: TWorker[];
 	private logger: Logger;
+	private static browserSessionId: string;
+
 	protected clipperData: ClipperData;
 	protected auth: AuthenticationHelper;
 	protected tooltip: TooltipHelper;
@@ -47,6 +49,8 @@ export abstract class ExtensionBase<TWorker extends ExtensionWorkerBase<TTab, TT
 
 		this.workers = [];
 		this.logger = new WorkerPassthroughLogger(this.workers);
+		ExtensionBase.browserSessionId = StringUtils.generateGuid();
+
 		this.clipperData = clipperData;
 		this.clipperData.setLogger(this.logger);
 		this.auth = new AuthenticationHelper(this.clipperData, this.logger);
@@ -85,6 +89,10 @@ export abstract class ExtensionBase<TWorker extends ExtensionWorkerBase<TTab, TT
 	protected abstract getIdFromTab(tab: TTab): TTabIdentifier;
 	protected abstract createWorker(tab: TTab): TWorker;
 	protected abstract onFirstRun();
+
+	public static getBrowserSessionId(): string {
+		return ExtensionBase.browserSessionId;
+	}
 
 	public static getExtensionVersion(): string {
 		return ExtensionBase.version;

--- a/src/scripts/extensions/extensionWorkerBase.ts
+++ b/src/scripts/extensions/extensionWorkerBase.ts
@@ -94,6 +94,7 @@ export abstract class ExtensionWorkerBase<TTab, TTabIdentifier> {
 	private initializeContextProperties() {
 		let clientInfo = this.clientInfo.get();
 		this.logger.setContextProperty(Log.Context.Custom.AppInfoId, Settings.getSetting("App_Id"));
+		this.logger.setContextProperty(Log.Context.Custom.BrowserSessionId, ExtensionBase.getBrowserSessionId());
 		this.logger.setContextProperty(Log.Context.Custom.UserInfoId, undefined);
 		this.logger.setContextProperty(Log.Context.Custom.AuthType, "None");
 		this.logger.setContextProperty(Log.Context.Custom.AppInfoVersion, clientInfo.clipperVersion);

--- a/src/scripts/extensions/extensionWorkerBase.ts
+++ b/src/scripts/extensions/extensionWorkerBase.ts
@@ -94,7 +94,7 @@ export abstract class ExtensionWorkerBase<TTab, TTabIdentifier> {
 	private initializeContextProperties() {
 		let clientInfo = this.clientInfo.get();
 		this.logger.setContextProperty(Log.Context.Custom.AppInfoId, Settings.getSetting("App_Id"));
-		this.logger.setContextProperty(Log.Context.Custom.BrowserSessionId, ExtensionBase.getBrowserSessionId());
+		this.logger.setContextProperty(Log.Context.Custom.ExtensionLifecycleId, ExtensionBase.getExtensionId());
 		this.logger.setContextProperty(Log.Context.Custom.UserInfoId, undefined);
 		this.logger.setContextProperty(Log.Context.Custom.AuthType, "None");
 		this.logger.setContextProperty(Log.Context.Custom.AppInfoVersion, clientInfo.clipperVersion);

--- a/src/scripts/logging/context.ts
+++ b/src/scripts/logging/context.ts
@@ -16,9 +16,10 @@ export class ProductionRequirements implements Context {
 	private prodProperties = [
 		Log.Context.toString(Log.Context.Custom.AppInfoId),
 		Log.Context.toString(Log.Context.Custom.AppInfoVersion),
-		Log.Context.toString(Log.Context.Custom.DeviceInfoId),
 		Log.Context.toString(Log.Context.Custom.BrowserLanguage),
+		Log.Context.toString(Log.Context.Custom.BrowserSessionId),
 		Log.Context.toString(Log.Context.Custom.ClipperType),
+		Log.Context.toString(Log.Context.Custom.DeviceInfoId),
 		Log.Context.toString(Log.Context.Custom.FlightInfo),
 		Log.Context.toString(Log.Context.Custom.InPrivateBrowsing)
 	];

--- a/src/scripts/logging/context.ts
+++ b/src/scripts/logging/context.ts
@@ -17,7 +17,7 @@ export class ProductionRequirements implements Context {
 		Log.Context.toString(Log.Context.Custom.AppInfoId),
 		Log.Context.toString(Log.Context.Custom.AppInfoVersion),
 		Log.Context.toString(Log.Context.Custom.BrowserLanguage),
-		Log.Context.toString(Log.Context.Custom.BrowserSessionId),
+		Log.Context.toString(Log.Context.Custom.ExtensionLifecycleId),
 		Log.Context.toString(Log.Context.Custom.ClipperType),
 		Log.Context.toString(Log.Context.Custom.DeviceInfoId),
 		Log.Context.toString(Log.Context.Custom.FlightInfo),

--- a/src/scripts/logging/submodules/context.ts
+++ b/src/scripts/logging/submodules/context.ts
@@ -1,10 +1,11 @@
 export module Context {
 	let contextKeyToStringMap = {
-		AppInfoId : "AppInfo.Id",
-		AppInfoVersion : "AppInfo.Version",
-		DeviceInfoId : "DeviceInfo.Id",
-		SessionId : "Session.Id",
-		UserInfoId : "UserInfo.Id",
+		AppInfoId: "AppInfo.Id",
+		AppInfoVersion: "AppInfo.Version",
+		BrowserSessionId: "BrowserSession.Id",
+		DeviceInfoId: "DeviceInfo.Id",
+		SessionId: "Session.Id",
+		UserInfoId: "UserInfo.Id",
 		UserInfoLanguage: "UserInfo.Language",
 		AuthType: "AuthType",
 		BrowserLanguage: "BrowserLanguage",
@@ -19,6 +20,7 @@ export module Context {
 	export enum Custom {
 		AppInfoId,
 		AppInfoVersion,
+		BrowserSessionId,
 		DeviceInfoId,
 		SessionId,
 		UserInfoId,

--- a/src/scripts/logging/submodules/context.ts
+++ b/src/scripts/logging/submodules/context.ts
@@ -2,8 +2,8 @@ export module Context {
 	let contextKeyToStringMap = {
 		AppInfoId: "AppInfo.Id",
 		AppInfoVersion: "AppInfo.Version",
-		BrowserSessionId: "BrowserSession.Id",
 		DeviceInfoId: "DeviceInfo.Id",
+		ExtensionLifecycleId: "ExtensionLifecycle.Id",
 		SessionId: "Session.Id",
 		UserInfoId: "UserInfo.Id",
 		UserInfoLanguage: "UserInfo.Language",
@@ -20,7 +20,7 @@ export module Context {
 	export enum Custom {
 		AppInfoId,
 		AppInfoVersion,
-		BrowserSessionId,
+		ExtensionLifecycleId,
 		DeviceInfoId,
 		SessionId,
 		UserInfoId,


### PR DESCRIPTION
Adds a new required context property to our logging called 'ExtensionLifecycle.Id'. At the beginning of the extension's construction, we assign a random guid to this property, and every worker that gets instantiated from this instance of the extension will share the same ExtensionLifecycle.Id. Asssuming we are comparing 2 sessions, this id will be different if:

a) The 2 sessions came from 2 different browser processes
b) The 2 sessions came from the same browser process, but the extension was refreshed or updated between sessions

Why is this new id useful? Sometimes, our customers complain about an issue, only to get back to us saying that it was resolved after a restart of the browser or similar action. With this id, we can now know for sure what issues persist across extension lifecycles, or persist for only one lifecycle (i.e., an issue involving extension or browser 'state'). If the customer has a particular issue that seems to be transient, we can simply look at the ExtensionLifecycle.Id of the error log, and look at all sessions across that same extension lifecycle to look for more meaningful patterns.