### PR TITLE
Fix WhatsNew failing due to bad promise logic

### DIFF
--- a/src/scripts/extensions/extensionWorkerBase.ts
+++ b/src/scripts/extensions/extensionWorkerBase.ts
@@ -602,7 +602,7 @@ export abstract class ExtensionWorkerBase<TTab, TTabIdentifier> {
 		return new Promise<boolean>((resolve) => {
 			this.getLocalizedStringsForBrowser((localizedStrings) => {
 				if (localizedStrings) {
-					return this.pageNavUiCommunicator.registerFunction(Constants.FunctionKeys.clipperStringsFrontLoaded, () => {
+					this.pageNavUiCommunicator.registerFunction(Constants.FunctionKeys.clipperStringsFrontLoaded, () => {
 						return Promise.resolve(!!localizedStrings);
 					});
 				}


### PR DESCRIPTION
When we cleaned up promises, we made a mistake here. Whenever we decided it's time to show the WhatsNew, our resolve would get swallowed, and WhatsNew would not appear. Additionally, we keep attempting to show WhatsNew since the previous attempts failed, leading to large amounts of session logging.