### PR TITLE
Fixed overflowing on long pdf options label strings

### DIFF
--- a/src/scripts/clipperUI/components/pdfClipOptions.tsx
+++ b/src/scripts/clipperUI/components/pdfClipOptions.tsx
@@ -111,7 +111,9 @@ class PdfClipOptionsClass extends ComponentBase<PdfClipOptionsState, ClipperStat
 				<div className="pdf-indicator pdf-radio-indicator">
 					{pdfPreviewInfo.allPages ? <div className={Constants.Classes.radioIndicatorFill}></div> : undefined}
 				</div>
-				<span className="pdf-label">{Localization.getLocalizedString("WebClipper.Label.PdfAllPagesRadioButton")}</span>
+				<div className="pdf-label-margin">
+					<span className="pdf-label">{Localization.getLocalizedString("WebClipper.Label.PdfAllPagesRadioButton")}</span>
+				</div>
 			</div>
 		);
 	}
@@ -162,7 +164,9 @@ class PdfClipOptionsClass extends ComponentBase<PdfClipOptionsState, ClipperStat
 			<div className="pdf-control" id={Constants.Ids.checkboxToDistributePages} {...this.enableInvoke(this.onDistributionChange, 65, !pdfPreviewInfo.shouldDistributePages) }>
 				<div className="pdf-indicator pdf-checkbox-indicator"></div>
 				{pdfPreviewInfo.shouldDistributePages ? <div className={Constants.Classes.checkboxCheck}></div> : ""}
-				<span className="pdf-label">{Localization.getLocalizedString("WebClipper.Label.PdfDistributePagesCheckbox")}</span>
+				<div className="pdf-label-margin">
+					<span className="pdf-label">{Localization.getLocalizedString("WebClipper.Label.PdfDistributePagesCheckbox")}</span>
+				</div>
 			</div>
 		);
 	}
@@ -180,7 +184,9 @@ class PdfClipOptionsClass extends ComponentBase<PdfClipOptionsState, ClipperStat
 		return (
 			<div className="pdf-control" id={Constants.Ids.checkboxToAttachPdfDisabled} {...this.enableInvoke(this.onCheckboxChange, 67, !pdfPreviewInfo.shouldAttachPdf) }>
 				<img className="warning-image" src={ExtensionUtils.getImageResourceUrl("warning.png")}></img>
-				<span className="pdf-label disabled">{Localization.getLocalizedString("WebClipper.Label.PdfTooLargeToAttach")}</span>
+				<div className="pdf-label-margin">
+					<span className="pdf-label disabled">{Localization.getLocalizedString("WebClipper.Label.PdfTooLargeToAttach")}</span>
+				</div>
 			</div>
 		);
 	}
@@ -191,9 +197,11 @@ class PdfClipOptionsClass extends ComponentBase<PdfClipOptionsState, ClipperStat
 			<div className="pdf-control" id={Constants.Ids.checkboxToAttachPdf} {...this.enableInvoke(this.onCheckboxChange, 66, !pdfPreviewInfo.shouldAttachPdf) }>
 				<div className="pdf-indicator pdf-checkbox-indicator"></div>
 				{pdfPreviewInfo.shouldAttachPdf ? <div className={Constants.Classes.checkboxCheck}></div> : ""}
-				<span className="pdf-label">{Localization.getLocalizedString("WebClipper.Label.AttachPdfFile") + " "}
-					<span className="sub-label">{Localization.getLocalizedString("WebClipper.Label.AttachPdfFileSubText")}</span>
-				</span>
+				<div className="pdf-label-margin">
+					<span className="pdf-label">{Localization.getLocalizedString("WebClipper.Label.AttachPdfFile") + " "}
+						<span className="sub-label">{Localization.getLocalizedString("WebClipper.Label.AttachPdfFileSubText")}</span>
+					</span>
+				</div>
 			</div>
 		);
 	}

--- a/src/styles/mainClassDefinitions.less
+++ b/src/styles/mainClassDefinitions.less
@@ -192,21 +192,24 @@
 	}
 
 	// PDF
-	.pdf-label {
-		font-size: 15px;
-		font-family: @SegoeUi;
-		color: #fff;
-		cursor: pointer;
-		position: relative;
+	.pdf-label-margin {
 		margin-left: 26px;
-		line-height: 20px;
 
-		&.disabled {
-			color: #E1B1FF;
-		}
+		.pdf-label {
+			font-size: 15px;
+			font-family: @SegoeUi;
+			color: #fff;
+			cursor: pointer;
+			position: relative;
+			line-height: 20px;
 
-		.sub-label {
-			color: #CCC;
+			&.disabled {
+				color: #E1B1FF;
+			}
+
+			.sub-label {
+				color: #CCC;
+			}
 		}
 	}
 
@@ -224,7 +227,6 @@
 		cursor: pointer; 
 		position: relative; 
 		line-height: 28px;
-		height: 28px;
 		margin-right: auto;
 	}
 

--- a/src/tests/clipperUI/components/pdfClipOptions_tests.tsx
+++ b/src/tests/clipperUI/components/pdfClipOptions_tests.tsx
@@ -299,7 +299,7 @@ export class PdfClipOptionsTests extends TestModule {
 				document.getElementById(Constants.Ids.moreClipOptions).click();
 			});
 			let attachmentCheckboxElem = document.getElementById(Constants.Ids.checkboxToAttachPdfDisabled);
-			strictEqual(attachmentCheckboxElem.innerText, this.stringsJson["WebClipper.Label.PdfTooLargeToAttach"]);
+			strictEqual(attachmentCheckboxElem.innerText.trim(), this.stringsJson["WebClipper.Label.PdfTooLargeToAttach"]);
 		});
 
 		test("If the PDF result has not started, or has failed, the checkboxToAttachPdf should not be visible, and the checkboxToAttachPdfDisabled should be visible", () => {


### PR DESCRIPTION
When PDF options strings get too long, they don't overflow neatly. This fixes it.