### PR TITLE
[Feature] Change the BATCH pipeline to use the new BatchRequest builder object

### DIFF
--- a/src/scripts/clipperUI/components/pdfClipOptions.tsx
+++ b/src/scripts/clipperUI/components/pdfClipOptions.tsx
@@ -179,7 +179,7 @@ class PdfClipOptionsClass extends ComponentBase<PdfClipOptionsState, ClipperStat
 
 		if (pdfIsTooLarge) {
 			return this.getAttachmentIsTooLargeCheckbox();
-		} 
+		}
 
 		return this.getAttachmentPdfCheckbox(pdfHasSucceeded);
 	}

--- a/src/scripts/clipperUI/components/popover.tsx
+++ b/src/scripts/clipperUI/components/popover.tsx
@@ -1,6 +1,5 @@
 import {Constants} from "../../constants";
 import {StringUtils} from "../../stringUtils";
-import {Localization} from "../../localization/localization";
 
 import {ComponentBase} from "../componentBase";
 

--- a/src/scripts/logging/submodules/event.ts
+++ b/src/scripts/logging/submodules/event.ts
@@ -11,7 +11,6 @@ export module Event {
 	export enum Label {
 		AddEmbeddedVideo,
 		AugmentationApiCall,
-		BatchRequests,
 		BookmarkPage,
 		CompressRegionSelection,
 		ClearNoOpTracker,
@@ -56,6 +55,7 @@ export module Event {
 		RegionSelectionLoading,
 		RegionSelectionProcessing,
 		RetrieveUserInformation,
+		SendBatchRequest,
 		SetContextProperty,
 		SetDoNotPromptRatings,
 		ShouldShowRatingsPrompt,

--- a/src/scripts/saveToOneNote/oneNoteApiWithLogging.ts
+++ b/src/scripts/saveToOneNote/oneNoteApiWithLogging.ts
@@ -25,10 +25,10 @@ export class OneNoteApiWithLogging implements OneNoteApi.IOneNoteApi {
 		}, Log.Event.Label.CreatePage);
 	}
 
-	public batchRequests(batchRequests: OneNoteApi.BatchRequest[]): Promise<OneNoteApi.ResponsePackage<any>> {
+	public sendBatchRequest(batchRequest: OneNoteApi.BatchRequest): Promise<OneNoteApi.ResponsePackage<any>> {
 		return this.executeWithLogging(() => {
-			return this.api.batchRequests(batchRequests);
-		}, Log.Event.Label.BatchRequests);
+			return this.api.sendBatchRequest(batchRequest);
+		}, Log.Event.Label.SendBatchRequest);
 	}
 
 	public getPage(pageId: string): Promise<OneNoteApi.ResponsePackage<any>> {

--- a/src/scripts/saveToOneNote/oneNoteApiWithRetries.ts
+++ b/src/scripts/saveToOneNote/oneNoteApiWithRetries.ts
@@ -22,9 +22,9 @@ export class OneNoteApiWithRetries implements OneNoteApi.IOneNoteApi {
 	}
 
 	// TODO: call this sendBatch or somethin to differentiate it
-	public batchRequests(batchRequests: OneNoteApi.BatchRequest[]): Promise<OneNoteApi.ResponsePackage<any>> {
+	public sendBatchRequest(batchRequest: OneNoteApi.BatchRequest): Promise<OneNoteApi.ResponsePackage<any>> {
 		return PromiseUtils.execWithRetry(() => {
-			return this.api.batchRequests(batchRequests);
+			return this.api.sendBatchRequest(batchRequest);
 		});
 	}
 

--- a/src/scripts/saveToOneNote/oneNoteSaveable.ts
+++ b/src/scripts/saveToOneNote/oneNoteSaveable.ts
@@ -9,6 +9,6 @@ export interface OneNoteSaveable {
 	getNumPages(): number;
 	getPatch(index: number): Promise<OneNoteApi.Revision[]>;
 	getNumPatches(): number;
-	getBatch(index: number): Promise<OneNoteApi.BatchRequest[]>;
+	getBatch(index: number): Promise<OneNoteApi.BatchRequest>;
 	getNumBatches(): number;
 }

--- a/src/scripts/saveToOneNote/oneNoteSaveablePage.ts
+++ b/src/scripts/saveToOneNote/oneNoteSaveablePage.ts
@@ -23,7 +23,7 @@ export class OneNoteSaveablePage implements OneNoteSaveable {
 		return 0;
 	}
 
-	public getBatch(index: number): Promise<OneNoteApi.BatchRequest[]> {
+	public getBatch(index: number): Promise<OneNoteApi.BatchRequest> {
 		return Promise.resolve(undefined);
 	}
 

--- a/src/scripts/saveToOneNote/oneNoteSaveablePdf.ts
+++ b/src/scripts/saveToOneNote/oneNoteSaveablePdf.ts
@@ -52,7 +52,7 @@ export class OneNoteSaveablePdf implements OneNoteSaveable {
 		return 0;
 	}
 
-	public getBatch(index: number): Promise<OneNoteApi.BatchRequest[]> {
+	public getBatch(index: number): Promise<OneNoteApi.BatchRequest> {
 		return Promise.resolve(undefined);
 	}
 }

--- a/src/scripts/saveToOneNote/oneNoteSaveablePdfBatched.ts
+++ b/src/scripts/saveToOneNote/oneNoteSaveablePdfBatched.ts
@@ -44,20 +44,20 @@ export class OneNoteSaveablePdfBatched implements OneNoteSaveable {
 		return this.buckets.length;
 	}
 
-	public getBatch(index: number): Promise<OneNoteApi.BatchRequest[]> {
+	public getBatch(index: number): Promise<OneNoteApi.BatchRequest> {
 		const bucket = this.buckets[index];
 		return this.pdf.getPageListAsDataUrls(bucket).then((dataUrls) => {
-			return this.createBatchRequestBody(bucket, dataUrls);
+			return this.createBatchRequest(bucket, dataUrls);
 		});
 	}
 
-	private createBatchRequestBody(pagesIndices: number[], dataUrls: string[]): OneNoteApi.BatchRequest[] {
+	private createBatchRequest(pagesIndices: number[], dataUrls: string[]): OneNoteApi.BatchRequest {
 		const sectionId = this.saveLocation;
 		const apiRoot = "/api/v1.0/me/notes";
 		const sectionPath = sectionId ? "/sections/" + sectionId : "";
 		const url = apiRoot + sectionPath + "/pages";
 
-		let batchRequests = [];
+		let batchRequest = new OneNoteApi.BatchRequest();
 		for (let i = 0; i < pagesIndices.length; i++) {
 			const title = StringUtils.getBatchedPageTitle(this.titleText, pagesIndices[i]);
 			const dataUrl = dataUrls[i];
@@ -65,16 +65,16 @@ export class OneNoteSaveablePdfBatched implements OneNoteSaveable {
 			let page = new OneNoteApi.OneNotePage(title, "", this.contentLocale);
 			page.addOnml("<p><img src=\"" + dataUrl + "\" /></p>&nbsp;");
 
-			const batchRequest = {
+			const batchRequestOperation = {
 				httpMethod: "POST",
 				uri: url,
 				contentType: "text/html",
 				content: page.getEntireOnml()
-			} as OneNoteApi.BatchRequest;
+			} as OneNoteApi.BatchRequestOperation;
 
-			batchRequests.push(batchRequest);
+			batchRequest.addOperation(batchRequestOperation);
 		}
 
-		return batchRequests;
+		return batchRequest;
 	}
 }

--- a/src/scripts/saveToOneNote/oneNoteSaveablePdfSynchronousBatched.ts
+++ b/src/scripts/saveToOneNote/oneNoteSaveablePdfSynchronousBatched.ts
@@ -59,7 +59,7 @@ export class OneNoteSaveablePdfSynchronousBatched implements OneNoteSaveable {
 		return 0;
 	}
 
-	public getBatch(index: number): Promise<OneNoteApi.BatchRequest[]> {
+	public getBatch(index: number): Promise<OneNoteApi.BatchRequest> {
 		return Promise.resolve(undefined);
 	}
 }

--- a/src/scripts/saveToOneNote/saveToOneNote.ts
+++ b/src/scripts/saveToOneNote/saveToOneNote.ts
@@ -29,7 +29,7 @@ export class SaveToOneNote {
 	private static timeBetweenPatchRequests = 7000;
 
 	private static timeBeforeFirstBatch = 1000;
-	private static timeBetweenBatchRequests;
+	private static timeBetweenBatchRequests = 7000;
 
 	private static timeBeforeFirstPost = 1000;
 	private static timeBetweenPostRequests = 0;
@@ -143,17 +143,17 @@ export class SaveToOneNote {
 	}
 
 	private batch(saveable: OneNoteSaveable): Promise<any> {
-		let timeBetweenPatchRequests = SaveToOneNote.timeBeforeFirstPatch;
+		let timeBetweenBatchRequests = SaveToOneNote.timeBeforeFirstBatch;
 		return _.range(saveable.getNumBatches()).reduce((chainedPromise, i) => {
 			return chainedPromise = chainedPromise.then(() => {
 				return new Promise((resolve, reject) => {
 					// Parallelize the BATCH request intervals with the fetching of the next set of dataUrls
 					let getRevisionsPromise = this.getBatchWithLogging(saveable, i);
-					let timeoutPromise = PromiseUtils.wait(timeBetweenPatchRequests);
+					let timeoutPromise = PromiseUtils.wait(timeBetweenBatchRequests);
 
 					Promise.all([getRevisionsPromise, timeoutPromise]).then((values) => {
-						let batchRequests = values[0] as OneNoteApi.BatchRequest[];
-						this.getApi().batchRequests(batchRequests).then(() => {
+						let batchRequest = values[0] as OneNoteApi.BatchRequest;
+						this.getApi().sendBatchRequest(batchRequest).then(() => {
 							resolve();
 						}).catch((error) => {
 							reject(error);
@@ -235,24 +235,25 @@ export class SaveToOneNote {
 		});
 	}
 
-	private getBatchWithLogging(saveable: OneNoteSaveable, index: number): Promise<OneNoteApi.BatchRequest[]> {
+	private getBatchWithLogging(saveable: OneNoteSaveable, index: number): Promise<OneNoteApi.BatchRequest> {
 		let event = new Log.Event.PromiseEvent(Log.Event.Label.ProcessPdfIntoDataUrls);
-		return saveable.getBatch(index).then((batchRequests: OneNoteApi.BatchRequest[]) => {
+		return saveable.getBatch(index).then((batchRequest: OneNoteApi.BatchRequest) => {
 			event.stopTimer();
 
-			let numPages = batchRequests.length;
+			let numPages = batchRequest.getNumOperations();
 			event.setCustomProperty(Log.PropertyName.Custom.NumPages, numPages);
 
-			if (batchRequests.length > 0) {
+			if (numPages > 0) {
 				// There's some html in the content itself, but it's negligible compared to the length of the actual dataUrls
-				let lengthOfDataUrls = _.sumBy(batchRequests, (batchRequest) => { return batchRequest.content.length; });
+				let lengthOfDataUrls = _.sumBy(batchRequest.getOperations(), (batchRequestOperation) => { return batchRequestOperation.content.length; });
+
 				event.setCustomProperty(Log.PropertyName.Custom.ByteLength, lengthOfDataUrls);
 				event.setCustomProperty(Log.PropertyName.Custom.BytesPerPdfPage, lengthOfDataUrls / numPages);
 				event.setCustomProperty(Log.PropertyName.Custom.AverageProcessingDurationPerPage, event.getDuration() / numPages);
 			}
 
 			Clipper.logger.logEvent(event);
-			return Promise.resolve(batchRequests);
+			return Promise.resolve(batchRequest);
 		});
 	}
 


### PR DESCRIPTION
This is the corresponding change for https://github.com/OneNoteDev/OneNoteApi/pull/7.

This code path is right now not used, since we createPages synchronously. However, it is still worth having. Tests will fail when we switch over in 1-2 months, as expected,