### PR TITLE
[Bug] Remove dependency on numeric value of enum for ContentModels in augmentationHelper.ts

### DIFF
--- a/src/scripts/contentCapture/augmentationHelper.ts
+++ b/src/scripts/contentCapture/augmentationHelper.ts
@@ -19,13 +19,14 @@ import * as Log from "../logging/log";
 import {CaptureFailureInfo} from "./captureFailureInfo";
 
 export enum AugmentationModel {
-	None = 0,
-	Article = 1,
-	BizCard = 2,
-	Recipe = 3,
-	Product = 4,
-	Screenshot = 5,
-	Wrapstar = 6
+	None,
+	Article,
+	BizCard,
+	EntityKnowledge,
+	Recipe,
+	Product,
+	Screenshot,
+	Wrapstar
 }
 
 export interface AugmentationResult extends CaptureFailureInfo {
@@ -89,9 +90,11 @@ export class AugmentationHelper {
 			return augmentationType;
 		}
 
+		// TODO: There is a work-item to change the AugmentationApi to return ContentModel as a StringUtils
+		// instead of an integer
 		let contentModel: AugmentationModel = state.augmentationResult.data.ContentModel;
 
-		if (AugmentationHelper.isSupportedAugmentatationType(contentModel)) {
+		if (AugmentationHelper.isSupportedAugmentationType(contentModel)) {
 			augmentationType = AugmentationModel[contentModel].toString();
 		}
 
@@ -137,7 +140,7 @@ export class AugmentationHelper {
 		return mainContainers[0] as HTMLElement;
 	}
 
-	private static isSupportedAugmentatationType(contentModel: number): boolean {
+	private static isSupportedAugmentationType(contentModel: number): boolean {
 		return contentModel === AugmentationModel.Article ||
 			contentModel === AugmentationModel.Recipe ||
 			contentModel === AugmentationModel.Product;


### PR DESCRIPTION
Fixes #276 

We added a new ContentModel, `EntityKnowledge`, on the server and this shifted our ENUM values. 

Recipes were now 4 instead instead of 3, so Recipes were showing up as Products. Products were now 5 instead of 5, so they were converted to `Screenshot`, which is unsupported, so they were defaulting to Article.

There is a work-item for the server to return ContentModel as a string, so that when they add new ContentModels, this doesn't break us. 