### PR TITLE
Added logic for blacklisting domains for PageNav experiences

### DIFF
--- a/src/scripts/extensions/safari/safariExtension.ts
+++ b/src/scripts/extensions/safari/safariExtension.ts
@@ -67,7 +67,7 @@ export class SafariExtension extends ExtensionBase<SafariWorker, SafariBrowserTa
 	}
 
 	protected checkIfTabIsOnWhitelistedUrl(tab: SafariBrowserTab): boolean {
-		return UrlUtils.onWhitelistedDomain(tab.url);
+		return !UrlUtils.onBlacklistedDomain(tab.url) && UrlUtils.onWhitelistedDomain(tab.url);
 	}
 
 	protected createWorker(tab: SafariBrowserTab): SafariWorker {
@@ -85,6 +85,9 @@ export class SafariExtension extends ExtensionBase<SafariWorker, SafariBrowserTa
 	}
 
 	protected checkIfTabMatchesATooltipType(tab: SafariBrowserTab, tooltipTypes: TooltipType[]): TooltipType {
+		if (UrlUtils.onBlacklistedDomain(tab.url)) {
+			return undefined;
+		}
 		return UrlUtils.checkIfUrlMatchesAContentType(tab.url, tooltipTypes);
 	}
 

--- a/src/scripts/extensions/webExtensionBase/webExtension.ts
+++ b/src/scripts/extensions/webExtensionBase/webExtension.ts
@@ -63,7 +63,7 @@ export class WebExtension extends ExtensionBase<WebExtensionWorker, W3CTab, numb
 	}
 
 	protected checkIfTabIsOnWhitelistedUrl(tab: W3CTab): boolean {
-		return UrlUtils.onWhitelistedDomain(tab.url);
+		return !UrlUtils.onBlacklistedDomain(tab.url) && UrlUtils.onWhitelistedDomain(tab.url);
 	}
 
 	protected createWorker(tab: W3CTab): WebExtensionWorker {
@@ -83,6 +83,9 @@ export class WebExtension extends ExtensionBase<WebExtensionWorker, W3CTab, numb
 	}
 
 	protected checkIfTabMatchesATooltipType(tab: W3CTab, tooltipTypes: TooltipType[]): TooltipType {
+		if (UrlUtils.onBlacklistedDomain(tab.url)) {
+			return undefined;
+		}
 		return UrlUtils.checkIfUrlMatchesAContentType(tab.url, tooltipTypes);
 	}
 

--- a/src/scripts/urlUtils.ts
+++ b/src/scripts/urlUtils.ts
@@ -121,18 +121,25 @@ export module UrlUtils {
 		}
 	}
 
+	export function onBlacklistedDomain(url: string): boolean {
+		return urlMatchesRegexInSettings(url, ["PageNav_BlacklistedDomains"]);
+	}
+
 	export function onWhitelistedDomain(url: string): boolean {
+		return urlMatchesRegexInSettings(url, ["AugmentationDefault_WhitelistedDomains", "ProductDomains", "RecipeDomains"]);
+	}
+
+	function urlMatchesRegexInSettings(url: string, settingNames: string[]): boolean {
 		if (!url) {
 			return false;
 		}
 
-		let validDomains = ["AugmentationDefault_WhitelistedDomains", "ProductDomains", "RecipeDomains"];
-		let whitelistedDomains = [];
-		validDomains.forEach((domain) => {
-			whitelistedDomains = whitelistedDomains.concat(Settings.getSetting(domain));
+		let domains = [];
+		settingNames.forEach((settingName) => {
+			domains = domains.concat(Settings.getSetting(settingName));
 		});
 
-		for (let identifier of whitelistedDomains) {
+		for (let identifier of domains) {
 			if (new RegExp(identifier).test(url)) {
 				return true;
 			}

--- a/src/settings/default.json
+++ b/src/settings/default.json
@@ -43,7 +43,8 @@
 	"PageNav_BlacklistedDomains": {
 		"Description": "The set of domains where we do not want to show any PageNav tooltip experience",
 		"Value": [
-			"^(http(s)?)://(login\\.live\\.com)"
+			"^(http(s)?)://(login\\.live\\.com)",
+			"^(http(s)?)://(login\\.microsoftonline\\.com)"
 		]
 	},
 	"PdfDomains": {

--- a/src/settings/default.json
+++ b/src/settings/default.json
@@ -40,6 +40,12 @@
 			"\\/(\\d{2}|\\d{4})-\\d{1,2}-\\d{1,2}\\/"
 		]
 	},
+	"PageNav_BlacklistedDomains": {
+		"Description": "The set of domains where we do not want to show any PageNav tooltip experience",
+		"Value": [
+			"^(http(s)?)://(login\\.live\\.com)"
+		]
+	},
 	"PdfDomains": {
 		"Description": "PDF regexes",
 		"Value": [


### PR DESCRIPTION
Fixes #275

Currently only blacklists the logins for msa and orgid, but we can add more domains as we feel necessary.