### PR TITLE
Fix the regular expression for onenote.com

### DIFF
--- a/src/settings/default.json
+++ b/src/settings/default.json
@@ -6,7 +6,7 @@
 	"AugmentationDefault_WhitelistedDomains": {
 		"Description": "The set of domains on which we are changing the default clip mode to Augmentation.",
 		"Value": [
-			"[^\\w]onenote",
+			"^https?:\\/\\/www\\.onenote\\.com",
 			"[^\\w]wikipedia",
 			"[^\\w]nytimes",
 			"[^\\w]lifehacker",

--- a/src/tests/urlUtils_tests.ts
+++ b/src/tests/urlUtils_tests.ts
@@ -274,6 +274,10 @@ export class UrlUtilsTests extends TestModule {
 			ok(!UrlUtils.onWhitelistedDomain("http://www.sdfdsfsdasdsa.com/2014/garden/when-blogging-becomes-a-slog.html?_r=1"));
 		});
 
+		test("onWhiteListedDomain should return false for live sign-in URL", () => {
+			ok(!UrlUtils.onWhitelistedDomain("https://login.live.com/oauth20_authorize.srf?client_id=123456-789a-bcde-1234-123456789abc&scope=wl.signin%20wl.basic%20wl.emails%20wl.offline_access%20office.onenote_update&redirect_uri=https://www.onenote.com/webclipper/auth&response_type=code"));
+		});
+
 		test("onWhiteListedDomain should return false given undefined or empty string", () => {
 			ok(!UrlUtils.onWhitelistedDomain(""));
 			ok(!UrlUtils.onWhitelistedDomain(undefined));


### PR DESCRIPTION
Fixes #275 

It was possible for the What's New dialog to appear in the sign-in dialog.  This is because the
regular expression used to detect onenote.com was a bit over-aggressive and the redirect URL on
the sign-in's query parameter list was triggering it.

The fix is to scope the regular expression a little such that it only matches on the real page.