### PR TITLE
Bug/o365 sign in errors

### DIFF
--- a/src/scripts/clipperUI/clipper.tsx
+++ b/src/scripts/clipperUI/clipper.tsx
@@ -576,11 +576,18 @@ class ClipperClass extends ComponentBase<ClipperState, {}> {
 		let handleSignInEvent = new Log.Event.PromiseEvent(Log.Event.Label.HandleSignInEvent);
 
 		this.setState({ userResult: { status: Status.InProgress } });
-		type ErrorObject = { updateReason: UpdateReason, correlationId?: string, error: string, errorDescription: string };
+
+		type ErrorObject = {
+			updateReason: UpdateReason,
+			correlationId?: string,
+			error: string,
+			errorDescription: string
+		};
 
 		Clipper.getExtensionCommunicator().callRemoteFunction(Constants.FunctionKeys.signInUser, {
 			param: authType, callback: (data: UserInfo | ErrorObject) => {
 			// For cleaner referencing
+			// TODO: This kind of thing should go away as we move the communicator to be Promise based.
 			let updatedUser = data as UserInfo;
 			let errorObject = data as ErrorObject;
 

--- a/src/scripts/clipperUI/clipper.tsx
+++ b/src/scripts/clipperUI/clipper.tsx
@@ -576,7 +576,7 @@ class ClipperClass extends ComponentBase<ClipperState, {}> {
 		let handleSignInEvent = new Log.Event.PromiseEvent(Log.Event.Label.HandleSignInEvent);
 
 		this.setState({ userResult: { status: Status.InProgress } });
-		type ErrorObject = { correlationId?: string, error: string, errorDescription: string };
+		type ErrorObject = { updateReason: UpdateReason, correlationId?: string, error: string, errorDescription: string };
 		Clipper.getExtensionCommunicator().callRemoteFunction(Constants.FunctionKeys.signInUser, { param: authType, callback: (data: UserInfo | ErrorObject) => {
 			// For cleaner referencing
 			let updatedUser = data as UserInfo;
@@ -598,7 +598,7 @@ class ClipperClass extends ComponentBase<ClipperState, {}> {
 				handleSignInEvent.setFailureInfo({ error: error });
 
 				errorObject.errorDescription = error;
-				this.state.setState({ userResult: { status: Status.Failed, data: updatedUser } });
+				this.state.setState({ userResult: { status: Status.Failed, data: errorObject } });
 
 				Clipper.logger.logUserFunnel(Log.Funnel.Label.AuthSignInFailed);
 			}

--- a/src/scripts/clipperUI/panels/signInPanel.tsx
+++ b/src/scripts/clipperUI/panels/signInPanel.tsx
@@ -100,9 +100,6 @@ class SignInPanelClass extends ComponentBase<SignInPanelState, SignInPanelProps>
 	debugInformation() {
 		if (this.signInErrorDetected() && this.state.debugInformationShowing) {
 			return <div id={Constants.Ids.signInErrorDebugInformation}>
-				<span id={Constants.Ids.signInErrorDebugInformationDescription} style={Localization.getFontFamilyAsStyle(Localization.FontFamily.Light)}>
-					{this.props.clipperState.userResult.data.errorDescription}
-				</span>
 				<div id={Constants.Ids.signInErrorDebugInformationContainer} style={Localization.getFontFamilyAsStyle(Localization.FontFamily.Light)}>
 					<ul id={Constants.Ids.signInErrorDebugInformationList}>
 						<li>{ClientType[this.props.clipperState.clientInfo.clipperType]}: {this.props.clipperState.clientInfo.clipperVersion}</li>

--- a/src/scripts/extensions/extensionWorkerBase.ts
+++ b/src/scripts/extensions/extensionWorkerBase.ts
@@ -511,6 +511,11 @@ export abstract class ExtensionWorkerBase<TTab, TTabIdentifier> {
 			}).catch((errorObject) => {
 				// Set the user info object to undefined as a result of an attempted sign in
 				this.auth.user.set({ updateReason: UpdateReason.SignInAttempt });
+
+				// Right now we're adding the update reason to the errorObject as well so that it is preserved in the callback.
+				// The right thing to do is revise the way we use callbacks in the communicator and instead use Promises so that
+				// we are able to return distinct objects.
+				errorObject.updateReason = UpdateReason.SignInAttempt;
 				return Promise.reject(errorObject);
 			});
 		});

--- a/src/strings.json
+++ b/src/strings.json
@@ -45,7 +45,7 @@
 	"WebClipper.Error.ConflictingExtension": "Your PDF viewer or another extension might be blocking the OneNote Web Clipper. You could temporarily disable the following extension and try clipping again.",
 	"WebClipper.Error.CannotClipPage": "Sorry, this type of page can\u0027t be clipped.",
 	"WebClipper.Error.CookiesDisabled.Line1": "Cookies must be enabled in order for OneNote Web Clipper to work correctly.",
-	"WebClipper.Error.CookiesDisabled.Line2": "Please allow third-party cookies in your browser or add the onenote.com domain as an exception.",
+	"WebClipper.Error.CookiesDisabled.Line2": "Please allow third-party cookies in your browser or add the onenote.com and live.com domains as an exception.",
 	"WebClipper.Error.CorruptedSection": "Your clip can\u0027t be saved here because the section is corrupt.",
 	"WebClipper.Error.GenericError": "Something went wrong. Please try clipping the page again.",
 	"WebClipper.Error.GenericExpiredTokenRefreshError": "Your login session has ended and we were unable to clip the page. Please sign in again.",


### PR DESCRIPTION
Fixes #296 

The details in each commit describe the fixes more completely, but in general, the O365 errors were not being shown because the updateReason property was not being set in the returning error object.  Because of this, the logic around when to show the message to the user was broken.

I also made a related UI fix and updated the string to include the live.com domain as a needed exception.