### PR TITLE
Remove the "sr" language as it is not supported

### DIFF
--- a/src/scripts/extensions/edge/package/AppXManifest.xml
+++ b/src/scripts/extensions/edge/package/AppXManifest.xml
@@ -63,7 +63,6 @@
 		<Resource Language="ru" />
 		<Resource Language="sk" />
 		<Resource Language="sl" />
-		<Resource Language="sr" />
 		<Resource Language="sv" />
 		<Resource Language="sw" />
 		<Resource Language="ta" />


### PR DESCRIPTION
It turns out that the "sr" language by itself is not supported in the Edge store.  This is causing problems with the download so I'm removing it.