### PR TITLE
Switch the order for article detection.

### DIFF
--- a/src/scripts/clipperUI/clipper.tsx
+++ b/src/scripts/clipperUI/clipper.tsx
@@ -557,10 +557,12 @@ class ClipperClass extends ComponentBase<ClipperState, {}> {
 		}
 
 		if (this.state && this.state.pageInfo) {
+			if (this.state.pageInfo.contentType === OneNoteApi.ContentType.EnhancedUrl) {
+				return ClipMode.Pdf;
+			}
+
 			if (UrlUtils.onWhitelistedDomain(this.state.pageInfo.rawUrl)) {
 				return ClipMode.Augmentation;
-			} else if (this.state.pageInfo.contentType === OneNoteApi.ContentType.EnhancedUrl) {
-				return ClipMode.Pdf;
 			}
 		}
 


### PR DESCRIPTION
We had things a little out of order, where it was possible to have a PDF,
but still put things in article mode by default (if the URL happened to
match the heuristic). Switched the order so that the other modes will get
priority as appropriate.