### PR TITLE
Reduce the Edge languages in the package

### DIFF
--- a/src/scripts/extensions/edge/package/AppXManifest.xml
+++ b/src/scripts/extensions/edge/package/AppXManifest.xml
@@ -20,59 +20,7 @@
 	</Dependencies> 
 
 	<Resources>
-		<Resource Language="en" />
-		<Resource Language="am" />
-		<Resource Language="ar" />
-		<Resource Language="bg" />
-		<Resource Language="bn" />
-		<Resource Language="ca" />
-		<Resource Language="cs" />
-		<Resource Language="da" />
-		<Resource Language="de" />
-		<Resource Language="el" />
-		<Resource Language="en-gb" />
 		<Resource Language="en-us" />
-		<Resource Language="es" />
-		<Resource Language="es-419" />
-		<Resource Language="et" />
-		<Resource Language="fa" />
-		<Resource Language="fi" />
-		<Resource Language="fil" />
-		<Resource Language="fr" />
-		<Resource Language="gu" />
-		<Resource Language="he" />
-		<Resource Language="hi" />
-		<Resource Language="hr" />
-		<Resource Language="hu" />
-		<Resource Language="id" />
-		<Resource Language="it" />
-		<Resource Language="ja" />
-		<Resource Language="kn" />
-		<Resource Language="ko" />
-		<Resource Language="lt" />
-		<Resource Language="lv" />
-		<Resource Language="ml" />
-		<Resource Language="mr" />
-		<Resource Language="ms" />
-		<Resource Language="nl" />
-		<Resource Language="no" />
-		<Resource Language="pl" />
-		<Resource Language="pt-br" />
-		<Resource Language="pt-pt" />
-		<Resource Language="ro" />
-		<Resource Language="ru" />
-		<Resource Language="sk" />
-		<Resource Language="sl" />
-		<Resource Language="sv" />
-		<Resource Language="sw" />
-		<Resource Language="ta" />
-		<Resource Language="te" />
-		<Resource Language="th" />
-		<Resource Language="tr" />
-		<Resource Language="uk" />
-		<Resource Language="vi" />
-		<Resource Language="zh-cn" />
-		<Resource Language="zh-tw" />
 		<Resource uap:Scale="200"/>
 	</Resources> 
 


### PR DESCRIPTION
I'm reducing the package locales down to en-us only.  This doesn't mean
that we are not supporting the other locales, we do. What it does is make
the store submission process a little easier.  We have the description
localized in a whole lot of languages, but there really isn't a good
reason to keep this list in sync, and in fact caused problems the last
time I submitted. To keep things simple and easier to submit, I'm making
this en-us only in the package.

At runtime we still continue to show the 100+ languages that the clipper
is localized in.