### PR TITLE
Remove the injected div in non-Chrome browsers

### DIFF
--- a/src/scripts/extensions/edge/manifest.json
+++ b/src/scripts/extensions/edge/manifest.json
@@ -3,15 +3,14 @@
 	"name": "OneNote Web Clipper",
 	"description": "__MSG_appDesc__",
 	"default_locale": "en",
-	"version": "3.5.2.0",
-
+	"version": "3.5.2",
 	"background": {
-		"page": "edgeExtension.html",
+		"scripts": [ "edgeExtension.js" ],
 		"persistent": true
 	},
 
 	"content_scripts": [{
-		"matches": ["<all_urls>"],
+		"matches": ["https://onenote.officeapps.live.com/*", "https://ppc-onenote.officeapps.live.com/*", "https://onenote.officeapps-df.live.com/*", "https://onenote.officeapps.live-int.com/*"],
 		"js": ["appendIsInstalledMarker.js"],
 		"run_at": "document_start",
 		"all_frames": true
@@ -53,7 +52,5 @@
 		"96": "icons/icon-96.png",
 		"128": "icons/icon-128.png",
 		"256": "icons/icon-256.png"
-	},
-
-	"minimum_edge_version": "37.14316.1000.0"
+	}
 }

--- a/src/scripts/extensions/firefox/manifest.json
+++ b/src/scripts/extensions/firefox/manifest.json
@@ -9,7 +9,7 @@
 	},
 
 	"content_scripts": [{
-		"matches": ["<all_urls>"],
+		"matches": ["https://onenote.officeapps.live.com/*", "https://ppc-onenote.officeapps.live.com/*", "https://onenote.officeapps-df.live.com/*", "https://onenote.officeapps.live-int.com/*"],
 		"js": ["appendIsInstalledMarker.js"],
 		"run_at": "document_start",
 		"all_frames": true

--- a/src/scripts/extensions/safari/Info.plist
+++ b/src/scripts/extensions/safari/Info.plist
@@ -42,7 +42,6 @@
 		<dict>
 			<key>Start</key>
 			<array>
-				<string>appendIsInstalledMarker.js</string>
 				<string>safariDebugLoggingInject.js</string>
 				<string>safariInject.js</string>
 				<string>safariPageNavInject.js</string>


### PR DESCRIPTION
It looks like the change we made earlier to remove the injected div in
every page didn't make it to any browser except Chrome. This adds the same
logic to the Edge/Firefox manifest.json files and removes it completely
from Safari.

Note: Also cleaned up the Edge manifest.json to be a little more
consistent with the other Web Extension-based browsers.