### PR TITLE
Use the "Back" string for the region clip dialog

### DIFF
--- a/src/scripts/clipperUI/panels/regionSelectingPanel.tsx
+++ b/src/scripts/clipperUI/panels/regionSelectingPanel.tsx
@@ -25,7 +25,7 @@ class RegionSelectingPanelClass extends ComponentBase<{}, ClipperStateProp> {
 						<div className="wideButtonContainer">
 							<span className="wideButtonFont wideActionButton"
 								style={Localization.getFontFamilyAsStyle(Localization.FontFamily.Semibold)}>
-								{Localization.getLocalizedString("WebClipper.Action.Cancel") }
+								{Localization.getLocalizedString("WebClipper.Action.BackToHome") }
 							</span>
 						</div>
 					</a>


### PR DESCRIPTION
As we have been reviewing things, it makes a lot more sense to have the
word, "back" when going into region mode.

Fixes #319 