### PR TITLE
[Bug] Add screen reader feedback when user selects a mode

### DIFF
--- a/src/scripts/clipperUI/components/modeButtonSelector.tsx
+++ b/src/scripts/clipperUI/components/modeButtonSelector.tsx
@@ -23,8 +23,11 @@ class ModeButtonSelectorClass extends ComponentBase<{}, ClipperStateProp> {
 	};
 
 	private getScreenReaderOnlyElementThatAnnouncesCurrentMode(currentMode: ClipMode) {
+		let stringToTellUserModeHasChanged = Localization.getLocalizedString("WebClipper.Accessibility.ScreenReader.CurrentModeHasChanged");
+		stringToTellUserModeHasChanged = stringToTellUserModeHasChanged.replace("{0}", ClipMode[currentMode]);
+
 		return (
-			<div aria-live="polite" className={Constants.Classes.srOnly}>{ClipMode[currentMode]}</div>
+			<div aria-live="polite" className={Constants.Classes.srOnly}>{stringToTellUserModeHasChanged}</div>
 		);
 	}
 

--- a/src/scripts/clipperUI/components/modeButtonSelector.tsx
+++ b/src/scripts/clipperUI/components/modeButtonSelector.tsx
@@ -1,4 +1,5 @@
 import {ClientType} from "../../clientType";
+import {Constants} from "../../constants";
 import {Experiments} from "../../experiments";
 
 import {AugmentationHelper} from "../../contentCapture/augmentationHelper";
@@ -23,8 +24,7 @@ class ModeButtonSelectorClass extends ComponentBase<{}, ClipperStateProp> {
 
 	private getScreenReaderOnlyElementThatAnnouncesCurrentMode(currentMode: ClipMode) {
 		return (
-			<div aria-live="assertive"
-	
+			<div aria-live="polite" className={Constants.Classes.srOnly}>{ClipMode[currentMode]}</div>
 		);
 	}
 

--- a/src/scripts/clipperUI/components/modeButtonSelector.tsx
+++ b/src/scripts/clipperUI/components/modeButtonSelector.tsx
@@ -21,6 +21,13 @@ class ModeButtonSelectorClass extends ComponentBase<{}, ClipperStateProp> {
 		});
 	};
 
+	private getScreenReaderOnlyElementThatAnnouncesCurrentMode(currentMode: ClipMode) {
+		return (
+			<div aria-live="assertive"
+	
+		);
+	}
+
 	private getPdfModeButton(currentMode: ClipMode) {
 		if (this.props.clipperState.pageInfo.contentType !== OneNoteApi.ContentType.EnhancedUrl) {
 			return undefined;
@@ -114,7 +121,8 @@ class ModeButtonSelectorClass extends ComponentBase<{}, ClipperStateProp> {
 		let currentMode = this.props.clipperState.currentMode.get();
 
 		return (
-			<div style={Localization.getFontFamilyAsStyle(Localization.FontFamily.Semilight) }>
+			<div style={Localization.getFontFamilyAsStyle(Localization.FontFamily.Semilight)}>
+				{ this.getScreenReaderOnlyElementThatAnnouncesCurrentMode(currentMode)}
 				{ this.getFullPageModeButton(currentMode) }
 				{ this.getRegionModeButton(currentMode) }
 				{ this.getAugmentationModeButton(currentMode) }

--- a/src/scripts/clipperUI/components/modeButtonSelector.tsx
+++ b/src/scripts/clipperUI/components/modeButtonSelector.tsx
@@ -27,7 +27,7 @@ class ModeButtonSelectorClass extends ComponentBase<{}, ClipperStateProp> {
 		stringToTellUserModeHasChanged = stringToTellUserModeHasChanged.replace("{0}", ClipMode[currentMode]);
 
 		return (
-			<div aria-live="polite" className={Constants.Classes.srOnly}>{stringToTellUserModeHasChanged}</div>
+			<div aria-live="polite" aria-relevant="text" className={Constants.Classes.srOnly}>{stringToTellUserModeHasChanged}</div>
 		);
 	}
 

--- a/src/scripts/constants.ts
+++ b/src/scripts/constants.ts
@@ -51,6 +51,9 @@ export module Constants {
 		// spriteAnimation
 		export var spinner = "spinner";
 
+		// Accessibility 
+		export var srOnly = "sr-only";
+		
 		// tooltip
 		export var tooltip = "tooltip";
 

--- a/src/scripts/constants.ts
+++ b/src/scripts/constants.ts
@@ -53,7 +53,7 @@ export module Constants {
 
 		// Accessibility 
 		export var srOnly = "sr-only";
-		
+
 		// tooltip
 		export var tooltip = "tooltip";
 

--- a/src/strings.json
+++ b/src/strings.json
@@ -1,4 +1,5 @@
 {
+	"WebClipper.Accessibility.ScreenReader.CurrentModeHasChanged" : "The current clipping mode is now '{0}'",	
 	"WebClipper.Action.BackToHome": "Back",
 	"WebClipper.Action.Cancel": "Cancel",
 	"WebClipper.Action.Clip": "Clip",

--- a/src/styles/mainClassDefinitions.less
+++ b/src/styles/mainClassDefinitions.less
@@ -486,3 +486,14 @@
 		}
 	}
 }
+
+.sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0,0,0,0);
+	border: 0;
+}


### PR DESCRIPTION
When a user changes mode, there is no screen reader indicator to tell the user the mode successfully changed.

The recommended way to get around this is to use `aria-live`. When this attribute is put on an HTML Element, the screen reader will read whatever is inside whenever it changes. In this case, we can put the current mode into that html element, and render it along with the mode button selector.

Right now, it renders twice, but that is still better than not saying anything. 