### PR TITLE
Add UpdateReason to getexistinguserinfo log

### DIFF
--- a/src/scripts/extensions/authenticationHelper.ts
+++ b/src/scripts/extensions/authenticationHelper.ts
@@ -67,6 +67,8 @@ export class AuthenticationHelper {
 				let writeableCookies = this.isThirdPartyCookiesEnabled(response.data);
 				getInfoEvent.setCustomProperty(Log.PropertyName.Custom.WriteableCookies, writeableCookies);
 
+				getInfoEvent.setCustomProperty(Log.PropertyName.Custom.UserUpdateReason, UpdateReason[updateReason]);
+
 				if (isValidUser) {
 					this.user.set({ user: response.data, lastUpdated: response.lastUpdated, updateReason: updateReason, writeableCookies: writeableCookies });
 				} else {


### PR DESCRIPTION
Fixes #342. Currently, we log WriteableCookies every time we fetch user info. This can be misleading as e.g. it would always return false if the user isn't signed-in on initial Clipper invocation. After this we'll be able to more easily monitor actual success/failure rates (i.e., on sign ins only).