### PR TITLE
Remove local/extension URLs from the DOM

### DIFF
--- a/src/scripts/clipperUI/clipper.tsx
+++ b/src/scripts/clipperUI/clipper.tsx
@@ -312,7 +312,7 @@ class ClipperClass extends ComponentBase<ClipperState, {}> {
 
 		let metadataElements: Element[] = BookmarkHelper.getElementsByTagName(doc, BookmarkHelper.metadataTagNames);
 
-		let imageElements: HTMLImageElement[] = BookmarkHelper.getElementsByTagName(doc.body, [DomUtils.Tags.img]) as HTMLImageElement[];
+		let imageElements: HTMLImageElement[] = BookmarkHelper.getElementsByTagName(doc.body, [DomUtils.tags.img]) as HTMLImageElement[];
 
 		// because we are cleaning the document in order to get the cleanest text possible in our description,
 		// make sure this is the last operation being performed on the document

--- a/src/scripts/contentCapture/augmentationHelper.ts
+++ b/src/scripts/contentCapture/augmentationHelper.ts
@@ -8,7 +8,7 @@ import {ClipperState} from "../clipperUI/clipperState";
 import {OneNoteApiUtils} from "../clipperUI/oneNoteApiUtils";
 import {Status} from "../clipperUI/status";
 
-import {DomUtils} from "../domParsers/domUtils";
+import {DomUtils, EmbeddedVideoIFrameSrcs} from "../domParsers/domUtils";
 
 import {HttpWithRetries} from "../http/HttpWithRetries";
 
@@ -60,9 +60,7 @@ export class AugmentationHelper {
 					let doc = (new DOMParser()).parseFromString(result.ContentInHtml, "text/html");
 					let previewElement = AugmentationHelper.getArticlePreviewElement(doc);
 
-					DomUtils.removeElementsNotSupportedInOnml(doc);
-					DomUtils.removeDisallowedIframes(doc);
-					DomUtils.removeBlankImages(doc).then(() => {
+					DomUtils.toOnml(doc).then(() => {
 						DomUtils.addPreviewContainerStyling(previewElement);
 						AugmentationHelper.addSupportedVideosToElement(previewElement, pageContent, url);
 						result.ContentInHtml = doc.body.innerHTML;
@@ -150,7 +148,7 @@ export class AugmentationHelper {
 		let addEmbeddedVideoEvent = new Log.Event.PromiseEvent(Log.Event.Label.AddEmbeddedVideo); // start event timer, just in case it gets logged
 		addEmbeddedVideoEvent.setCustomProperty(Log.PropertyName.Custom.Url, url);
 
-		DomUtils.addEmbeddedVideosWhereSupported(previewElement, pageContent, url).then((videoSrcUrls: DomUtils.EmbeddedVideoIFrameSrcs[]) => {
+		DomUtils.addEmbeddedVideosWhereSupported(previewElement, pageContent, url).then((videoSrcUrls: EmbeddedVideoIFrameSrcs[]) => {
 			// only log when supported video is found on page
 			if (!ObjectUtils.isNullOrUndefined(videoSrcUrls)) {
 				addEmbeddedVideoEvent.setCustomProperty(Log.PropertyName.Custom.VideoSrcUrl, JSON.stringify(videoSrcUrls.map(function (v) { return v.srcAttribute; })));

--- a/src/scripts/contentCapture/bookmarkHelper.ts
+++ b/src/scripts/contentCapture/bookmarkHelper.ts
@@ -29,7 +29,7 @@ export interface MetadataKeyValuePair {
 export class BookmarkHelper {
 	public static maxNumCharsInDescription = 140;
 
-	public static metadataTagNames: string[] = [ DomUtils.Tags.meta, DomUtils.Tags.link ];
+	public static metadataTagNames: string[] = [ DomUtils.tags.meta, DomUtils.tags.link ];
 
 	public static nameAttrName = "name";
 	public static propertyAttrName = "property";

--- a/src/scripts/domParsers/domUtils.ts
+++ b/src/scripts/domParsers/domUtils.ts
@@ -923,12 +923,6 @@ export class DomUtils {
 			"onblur"
 		];
 
-		// for (let attribute of attributesToRemove) {
-		// 	let elements: NodeList = doc.querySelectorAll("[" + attribute + "]");
-		// 	for (let i = 0; i < elements.length; i++) {
-		// 		elements[i].removeAttribute(attribute);
-		// 	}
-
 		for (let i = 0; i < attributesToRemove.length; i++) {
 			let elements = doc.querySelectorAll("[" + attributesToRemove[i] + "]");
 			for (let j = 0; j < elements.length; j++) {
@@ -998,11 +992,6 @@ export class DomUtils {
 	}
 
 	private static isLocalReferenceUrl(url: string): Boolean {
-		return (
-			url.indexOf("chrome-extension://") === 0 ||
-			url.indexOf("edge-extension://") === 0 ||
-			url.indexOf("file://") === 0 ||
-			url.indexOf("firefox-extension://") === 0 ||
-			url.indexOf("safari-extension://") === 0);
+		return !(url.indexOf("https://") === 0 || url.indexOf("http://") === 0);
 	}
 }

--- a/src/scripts/domParsers/videoExtractorFactory.ts
+++ b/src/scripts/domParsers/videoExtractorFactory.ts
@@ -1,6 +1,6 @@
 import {KhanAcademyVideoExtractor} from "./khanAcademyVideoExtractor";
 import {VideoExtractor} from "./VideoExtractor";
-import {VideoUtils} from "./videoUtils";
+import {SupportedVideoDomains, VideoUtils} from "./videoUtils";
 import {VimeoVideoExtractor} from "./vimeoVideoExtractor";
 import {YoutubeVideoExtractor} from "./YoutubeVideoExtractor";
 
@@ -10,9 +10,9 @@ import {YoutubeVideoExtractor} from "./YoutubeVideoExtractor";
  * to be used in the preview and posting to OneNote
  */
 export module VideoExtractorFactory {
-	export function createVideoExtractor(domain: VideoUtils.SupportedVideoDomains): VideoExtractor {
+	export function createVideoExtractor(domain: SupportedVideoDomains): VideoExtractor {
 		// shorter typename
-		let domains = VideoUtils.SupportedVideoDomains;
+		let domains = SupportedVideoDomains;
 		switch (domain) {
 			case domains.KhanAcademy:
 				return new KhanAcademyVideoExtractor();

--- a/src/scripts/domParsers/videoUtils.ts
+++ b/src/scripts/domParsers/videoUtils.ts
@@ -1,21 +1,21 @@
 import {ObjectUtils} from "../objectUtils";
 import {UrlUtils} from "../urlUtils";
 
-export module VideoUtils {
-	export const youTubeWatchVideoBaseUrl = "https://www.youtube.com/watch";
-	export const youTubeVideoIdQueryKey = "v";
+export enum SupportedVideoDomains {
+	YouTube,
+	Vimeo,
+	KhanAcademy
+}
 
-	export enum SupportedVideoDomains {
-		YouTube,
-		Vimeo,
-		KhanAcademy
-	}
+export class VideoUtils {
+	public youTubeWatchVideoBaseUrl = "https://www.youtube.com/watch";
+	public youTubeVideoIdQueryKey = "v";
 
 	/**
 	 * Returns a string from the SupportedVideoDomains enum iff
 	 * the pageUrl's hostname contains the enum string
 	 */
-	export function videoDomainIfSupported(pageUrl: string): string {
+	public static videoDomainIfSupported(pageUrl: string): string {
 		if (!pageUrl) {
 			return;
 		}
@@ -37,7 +37,7 @@ export module VideoUtils {
 		return;
 	}
 
-	export function matchRegexFromPageContent(pageContent: string, regexes: RegExp[]): string[] {
+	public static matchRegexFromPageContent(pageContent: string, regexes: RegExp[]): string[] {
 		if (ObjectUtils.isNullOrUndefined(pageContent)) {
 			return;
 		}

--- a/src/tests/domParsers/domUtils_tests.ts
+++ b/src/tests/domParsers/domUtils_tests.ts
@@ -94,14 +94,14 @@ export class DomUtilsTests extends TestModule {
 				"The non Web Clipper iframe should still be present");
 		});
 
-		test("removeExtensionLinkHrefs should remove all URLs which refer to local extensions, but not any others", () => {
+		test("removeUnsupportedHrefs should remove all URLs which refer to local extensions, but not any others", () => {
 			let linksToCreate: any = [
 				{ id: "chromeExtensionLink", url: "chrome-extension://abc123abc123abc123/test.css", shouldRemain: false},
 				{ id: "edgeExtensionLink", url: "edge-extension://abc123abc123abc123/test.css", shouldRemain: false },
 				{ id: "fileExtensionLink", url: "file://c:/foo/bar/test.css", shouldRemain: false },
 				{ id: "firefoxExtensionLink", url: "firefox-extension://abc123abc123abc123/test.css", shouldRemain: false },
-				{ id: "safarExtensionLink", url: "safari-extension://abc123abc123abc123/test.css", shouldRemain: false },
-				{ id: "normaHttplLink", url: "https://foo/bar/test.css", shouldRemain: true },
+				{ id: "safariExtensionLink", url: "safari-extension://abc123abc123abc123/test.css", shouldRemain: false },
+				{ id: "normalHttplLink", url: "https://foo/bar/test.css", shouldRemain: true },
 			];
 
 			for (let link of linksToCreate) {
@@ -111,7 +111,7 @@ export class DomUtilsTests extends TestModule {
 			DomUtils.removeUnsupportedHrefs(document);
 
 			for (let link of linksToCreate) {
-				ok(!!document.getElementById(link.id) === link.shouldRemain, "Url not removed when it was expected to: " + link.url);
+				strictEqual(!!document.getElementById(link.id), link.shouldRemain, "Url not removed when it was expected to: " + link.url);
 			}
 		});
 


### PR DESCRIPTION
Fixes #348 

Because we are sending up the DOM to be rendered on the service (for the
full page screenshot), we sometimes run into problems because of a URL
that is impossible to resolve, URLs like ones injected by another
extension.  This change basically strips out those URLs before the DOM is
sent up.

Oh, and because I really wanted to make a private method, I converted
DomUtils.ts to a true class, which had a little bit of a cascading effect.
I have a bigger change that I want to do which converts all of our
exported functions into classes, but that's for another day.