### PR TITLE
Add the <pre> and <code> tags to the SanitizeHtml allowed list

### DIFF
--- a/src/scripts/domParsers/domUtils.ts
+++ b/src/scripts/domParsers/domUtils.ts
@@ -36,6 +36,7 @@ export class DomUtils {
 		canvas: "canvas",
 		center: "center",
 		cite: "cite",
+		code: "code",
 		del: "del",
 		div: "div",
 		em: "em",
@@ -68,6 +69,7 @@ export class DomUtils {
 		object: "object",
 		ol: "ol",
 		p: "p",
+		pre: "pre",
 		progress: "progress",
 		script: "script",
 		span: "span",
@@ -112,7 +114,9 @@ export class DomUtils {
 		DomUtils.tags.sup,
 		DomUtils.tags.sub,
 		DomUtils.tags.cite,
-		DomUtils.tags.font
+		DomUtils.tags.font,
+		DomUtils.tags.pre,
+		DomUtils.tags.code
 	];
 
 	protected static htmlTags = [


### PR DESCRIPTION
Fixes #352 

When we moved to use SanitizeHtml we pass in a list of tags that are allowed.  We missed a couple.*

*Note that I don't remember if the code tag is supported in the ONML, but I decided to let it through just in a case.