### PR TITLE
Remove base64 encoded binaries in <style>

### DIFF
--- a/src/scripts/domParsers/domUtils.ts
+++ b/src/scripts/domParsers/domUtils.ts
@@ -202,7 +202,7 @@ export class DomUtils {
 	 */
 	public static removeStylesWithBase64EncodedBinaries(doc: Document): void {
 		DomUtils.domReplacer(doc, "style", (node: HTMLElement) => {
-			return node.innerHTML.indexOf("data:application") !== -1 ? document.createElement("style") : node;
+			return node.innerHTML.indexOf("data:application") !== -1 ? undefined : node;
 		});
 	}
 

--- a/src/scripts/domParsers/domUtils.ts
+++ b/src/scripts/domParsers/domUtils.ts
@@ -195,6 +195,17 @@ export class DomUtils {
 		return sanitizedHtml;
 	}
 
+	/**
+	 * Many extensions inject their own stylings into the page, and generally that isn't a problem. But,
+	 * occasionally the styling includes a specific font, which can be very, very large. This method
+	 * removes any base64 encoded binaries defined in any <style> tags.
+	 */
+	public static removeStylesWithBase64EncodedBinaries(doc: Document): void {
+		DomUtils.domReplacer(doc, "style", (node: HTMLElement) => {
+			return node.innerHTML.indexOf("data:application") !== -1 ? document.createElement("style") : node;
+		});
+	}
+
 	public static removeElementsNotSupportedInOnml(doc: Document): void {
 		// For elements that cannot be converted into something equivalent in ONML, we remove them ...
 		DomUtils.domReplacer(doc, DomUtils.tagsNotSupportedInOnml.join());
@@ -332,6 +343,7 @@ export class DomUtils {
 	}
 
 	public static removeUnwantedItems(doc: Document): void {
+		DomUtils.removeStylesWithBase64EncodedBinaries(doc);
 		DomUtils.removeClipperElements(doc);
 		DomUtils.removeUnwantedElements(doc);
 		DomUtils.removeUnwantedAttributes(doc);


### PR DESCRIPTION
Fixes #349 

It turns out that there are a lot of exensions in the world, and sometimes those extensions modify the DOM of the page (ours included). Generally we don't have a problem with this, but if an extension injects a large base64-encoded binary into the mix, then we run into problems.  This is mostly because the request size very quickly can be bloated beyond the max.  This change targets one particular place where this happens the most, in the <style> tag where someone may inject a custom font into the page.  When we detect this, we remove the style (from our copy of the DOM) before sending it up.