### PR TITLE
Replace undefined event variable with `ev`, the properly scoped event

### DIFF
--- a/src/scripts/clipperUI/panels/optionsPanel.tsx
+++ b/src/scripts/clipperUI/panels/optionsPanel.tsx
@@ -69,7 +69,7 @@ class OptionsPanelClass extends ComponentBase<{}, OptionsPanelProp> {
 					this.checkOptionsBeforeStartClip();
 				}
 				if (oldOnKeyDown) {
-					oldOnKeyDown.call(document, event);
+					oldOnKeyDown.call(document, ev);
 				}
 			};
 


### PR DESCRIPTION
Apparently lib.d.ts has a line `declare var event: Event | null;` which is maybe why the compiler did not catch this?

I am not sure