### PR TITLE
Standardize property name for no op tracker

### DIFF
--- a/src/scripts/logging/submodules/errorUtils.ts
+++ b/src/scripts/logging/submodules/errorUtils.ts
@@ -9,6 +9,7 @@ import {SmartValue} from "../../communicator/smartValue";
 import {Localization} from "../../localization/localization";
 
 import {Failure, LogDataPackage, LogMethods, NoOp, PropertyName, reportData, unknownValue} from "../log";
+import {Context} from "../submodules/context";
 
 export module ErrorUtils {
 	enum ErrorPropertyName {
@@ -158,9 +159,16 @@ export module ErrorUtils {
 	 */
 	function addDelayedSetValuesOnNoOp(props: {[key: string]: string}, clientInfo?: SmartValue<ClientInfo>): void {
 		if (clientInfo) {
-			props[Constants.Urls.QueryParams.clientType] = ObjectUtils.isNullOrUndefined(clientInfo.get()) ? unknownValue : ClientType[clientInfo.get().clipperType];
-			props[Constants.Urls.QueryParams.clipperVersion] = ObjectUtils.isNullOrUndefined(clientInfo.get()) ? unknownValue : clientInfo.get().clipperVersion;
-			props[Constants.Urls.QueryParams.clipperId] = ObjectUtils.isNullOrUndefined(clientInfo.get()) ? unknownValue : clientInfo.get().clipperId;
+			let clientType = ObjectUtils.isNullOrUndefined(clientInfo.get()) ? unknownValue : ClientType[clientInfo.get().clipperType];
+			let clipperVersion = ObjectUtils.isNullOrUndefined(clientInfo.get()) ? unknownValue : clientInfo.get().clipperVersion;
+			let clipperId = ObjectUtils.isNullOrUndefined(clientInfo.get()) ? unknownValue : clientInfo.get().clipperId;
+			props[Constants.Urls.QueryParams.clientType] = clientType;
+			props[Constants.Urls.QueryParams.clipperVersion] = clipperVersion;
+			props[Constants.Urls.QueryParams.clipperId] = clipperId;
+
+			props[Context.Custom.ClipperType] = clientType;
+			props[Context.Custom.AppInfoVersion] = clipperVersion;
+			props[Context.Custom.DeviceInfoId] = clipperId;
 		}
 	}
 }


### PR DESCRIPTION
We still aren't sure why we have so many no-ops, but this will allow us to define a better metric by Distinct Device or Session. Right now the cube is looking for `Device.Id` when it is actually `ClipperType`.

This initial change will see if we can use those reserved properties or not, and if so, we don't have to change the cube. 