### PR TITLE
Make focus indicator clearly visible for high contrast pages

### DIFF
--- a/src/styles/clipper.less
+++ b/src/styles/clipper.less
@@ -82,7 +82,7 @@
 }
 
 #closeButton:focus {
-	outline: @FocusOnPurpleBackground 1px solid;
+	outline: solid 1px @FocusOnPurpleBackground;
 }
 
 #currentUserDetails {
@@ -102,7 +102,7 @@
 }
 
 #highlightButton:focus {
-	outline: @FocusOnPurpleBackground 1px solid;
+	outline: solid 1px @FocusOnPurpleBackground;
 	outline-offset: 2px;
 }
 
@@ -167,7 +167,7 @@
 
 #regionClipCancelButton:focus {
 	outline-offset: 4px;
-	outline: @FocusOnPurpleBackground solid 1px !important;
+	outline: solid 1px @FocusOnPurpleBackground !important;
 }
 
 #regionSelectorContainer {
@@ -200,7 +200,7 @@
 }
 
 #sectionLocationContainer:focus{
-	outline: @FocusOnPurpleBackground 1px solid !important;
+	outline: solid 1px @FocusOnPurpleBackground !important;
 	outline-offset: 2px !important;
 }
 

--- a/src/styles/globalStyles.less
+++ b/src/styles/globalStyles.less
@@ -101,5 +101,5 @@ a {
 }
 
 :focus {
-	outline: @FocusOnPurpleBackground auto 1px;
+	outline: solid 1px @FocusOnPurpleBackground;
 }

--- a/src/styles/mainClassDefinitions.less
+++ b/src/styles/mainClassDefinitions.less
@@ -63,7 +63,7 @@
 }
 
 .control-button:focus {
-	outline: @FocusOnPurpleBackground solid 1px !important;
+	outline: solid 1px @FocusOnPurpleBackground !important;
 	outline-offset: 1px;
 }
 
@@ -292,7 +292,7 @@
 	}
 
 	.pdf-label:focus{
-		outline: @FocusOnPurpleBackground 1px solid;
+		outline: solid 1px @FocusOnPurpleBackground;
 		outline-offset: 2px;
 	}
 
@@ -337,7 +337,7 @@
 		};
 
 		&.selected {
-			outline: @FocusOnPurpleBackground 1px solid !important;
+			outline: solid 1px @FocusOnPurpleBackground !important;
 			outline-offset: 2px;
 		}
 
@@ -453,7 +453,7 @@
 
 #clipButton {
 	&:focus {
-		outline: @FocusOnPurpleBackground solid 1px !important;
+		outline: solid 1px @FocusOnPurpleBackground !important;
 		outline-offset: 2px;
 	}
 }

--- a/src/styles/sectionPickerOverrides.less
+++ b/src/styles/sectionPickerOverrides.less
@@ -12,7 +12,7 @@
 }
 
 #sectionLocationContainer:focus{
-	outline: @FocusOnPurpleBackground solid 1px !important;
+	outline: solid 1px @FocusOnPurpleBackground !important;
 	outline-offset: 2px !important;
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6866265/57947079-c78d5f00-7892-11e9-8f9a-456ce27cdba5.png)
Fix for https://office.visualstudio.com/OneNote/_workitems/edit/3174504