### PR TITLE
Fixing -  Button text in high contrast has coloring of normal text

### DIFF
--- a/src/scripts/clipperUI/components/footer.tsx
+++ b/src/scripts/clipperUI/components/footer.tsx
@@ -106,16 +106,8 @@ class FooterClass extends ComponentBase<FooterState, FooterProps> {
 							style={Localization.getFontFamilyAsStyle(Localization.FontFamily.Regular)}>
 							<hr className="userDivider" />
 							<div className="userDetails">
-<<<<<<< HEAD
 								<label for={Constants.Ids.signOutButton} id={Constants.Ids.currentUserEmail}>{this.props.clipperState.userResult.data.user.emailAddress}</label>
-								<a id={Constants.Ids.signOutButton} role="button" className="userActionButton"
-=======
-								<label for={Constants.Ids.signOutButton} id={Constants.Ids.currentUserEmail} aria-hidden="true">
-									{this.props.clipperState.userResult.data.user.emailAddress}
-								</label>
-								<a id={Constants.Ids.signOutButton} role="button" className="buttonTextInHighContrast userActionButton"
-									aria-label={Localization.getLocalizedString("WebClipper.Action.SignOut") + " " + this.props.clipperState.userResult.data.user.emailAddress}
->>>>>>> 3cbf171... Fixed button-text color for high contrast mode
+								<a id={Constants.Ids.signOutButton} role="button" className="userActionButton buttonTextInHighContrast"
 									{...this.enableInvoke({callback: this.handleSignOutButton, tabIndex: 82})}>
 									{Localization.getLocalizedString("WebClipper.Action.SignOut")}
 								</a>

--- a/src/scripts/clipperUI/components/footer.tsx
+++ b/src/scripts/clipperUI/components/footer.tsx
@@ -77,7 +77,7 @@ class FooterClass extends ComponentBase<FooterState, FooterProps> {
 					<div className="footerButtonsLeft">
 						<a id={Constants.Ids.feedbackButton} role="button" {...this.enableInvoke({callback: this.handleFeedbackButton, tabIndex: 80})}>
 							<img id={Constants.Ids.feedbackImage} src={ExtensionUtils.getImageResourceUrl("feedback_smiley.png")}/>
-							<span id={Constants.Ids.feedbackLabel}>{Localization.getLocalizedString("WebClipper.Action.Feedback") }</span>
+							<span id={Constants.Ids.feedbackLabel} class="buttonTextInHighContrast">{Localization.getLocalizedString("WebClipper.Action.Feedback") }</span>
 						</a>
 					</div>
 					{showUserInfo
@@ -86,12 +86,12 @@ class FooterClass extends ComponentBase<FooterState, FooterProps> {
 								<div id={Constants.Ids.currentUserDetails}>
 									{
 										this.props.clipperState.userResult.data.user.fullName
-										? <div id={Constants.Ids.currentUserName}>{this.props.clipperState.userResult.data.user.fullName}</div>
-										: <div id={Constants.Ids.currentUserName}>{Localization.getLocalizedString("WebClipper.Label.SignedIn")}</div>
+										? <div id={Constants.Ids.currentUserName} class="buttonTextInHighContrast">{this.props.clipperState.userResult.data.user.fullName}</div>
+										: <div id={Constants.Ids.currentUserName} class="buttonTextInHighContrast">{Localization.getLocalizedString("WebClipper.Label.SignedIn")}</div>
 									}
 									{
 										this.props.clipperState.userResult.data.user.emailAddress
-										? <div id={Constants.Ids.currentUserId} className="currentUserIdFont" style={Localization.getFontFamilyAsStyle(Localization.FontFamily.Regular)}>{this.props.clipperState.userResult.data.user.emailAddress}</div>
+										? <div id={Constants.Ids.currentUserId} className="buttonTextInHighContrast currentUserIdFont" style={Localization.getFontFamilyAsStyle(Localization.FontFamily.Regular)}>{this.props.clipperState.userResult.data.user.emailAddress}</div>
 										: ""
 									}
 								</div>
@@ -106,8 +106,16 @@ class FooterClass extends ComponentBase<FooterState, FooterProps> {
 							style={Localization.getFontFamilyAsStyle(Localization.FontFamily.Regular)}>
 							<hr className="userDivider" />
 							<div className="userDetails">
+<<<<<<< HEAD
 								<label for={Constants.Ids.signOutButton} id={Constants.Ids.currentUserEmail}>{this.props.clipperState.userResult.data.user.emailAddress}</label>
 								<a id={Constants.Ids.signOutButton} role="button" className="userActionButton"
+=======
+								<label for={Constants.Ids.signOutButton} id={Constants.Ids.currentUserEmail} aria-hidden="true">
+									{this.props.clipperState.userResult.data.user.emailAddress}
+								</label>
+								<a id={Constants.Ids.signOutButton} role="button" className="buttonTextInHighContrast userActionButton"
+									aria-label={Localization.getLocalizedString("WebClipper.Action.SignOut") + " " + this.props.clipperState.userResult.data.user.emailAddress}
+>>>>>>> 3cbf171... Fixed button-text color for high contrast mode
 									{...this.enableInvoke({callback: this.handleSignOutButton, tabIndex: 82})}>
 									{Localization.getLocalizedString("WebClipper.Action.SignOut")}
 								</a>

--- a/src/scripts/clipperUI/panels/dialogPanel.tsx
+++ b/src/scripts/clipperUI/panels/dialogPanel.tsx
@@ -57,7 +57,7 @@ export abstract class DialogPanelClass extends ComponentBase<{}, DialogPanelProp
 							return (
 								<div className="wideButtonContainer dialogButton">
 									<a id={button.id} { ...this.enableInvoke({ callback: button.handler, tabIndex: 70 }) }
-										className="wideButtonFont wideActionButton"
+										className="buttonTextInHighContrast wideButtonFont wideActionButton"
 										role="button"
 										style={Localization.getFontFamilyAsStyle(buttonFontFamily)}>
 										{ button.label }

--- a/src/scripts/clipperUI/panels/optionsPanel.tsx
+++ b/src/scripts/clipperUI/panels/optionsPanel.tsx
@@ -106,13 +106,13 @@ class OptionsPanelClass extends ComponentBase<{}, OptionsPanelProp> {
 				<div id={Constants.Ids.clipButtonContainer} className={clipButtonContainerClassName}>
 					{clipButtonEnabled
 					?	<a id={Constants.Ids.clipButton} className="wideActionButton" {...this.enableInvoke({callback: this.checkOptionsBeforeStartClip.bind(this), tabIndex: 71})} role="button">
-							<span className="wideButtonFont"
+							<span className="wideButtonFont buttonTextInHighContrast"
 								style={Localization.getFontFamilyAsStyle(Localization.FontFamily.Semibold)}>
 								{Localization.getLocalizedString("WebClipper.Action.Clip")}
 							</span>
 						</a>
 					:	<a id={Constants.Ids.clipButton} className="wideActionButton" role="button">
-							<span className="wideButtonFont"
+							<span className="wideButtonFont buttonTextInHighContrast"
 								style={Localization.getFontFamilyAsStyle(Localization.FontFamily.Semibold)}>
 								{Localization.getLocalizedString("WebClipper.Action.Clip")}
 							</span>

--- a/src/scripts/clipperUI/panels/regionSelectingPanel.tsx
+++ b/src/scripts/clipperUI/panels/regionSelectingPanel.tsx
@@ -28,7 +28,7 @@ class RegionSelectingPanelClass extends ComponentBase<{}, ClipperStateProp> {
 						<a id={ Constants.Ids.regionClipCancelButton } role="button"
 							{...this.onElementFirstDraw(this.initiallySetFocusToBackButton)}
 							{...this.enableInvoke({callback: this.handleCancelButton, tabIndex: 0})} >
-							<span className="wideButtonFont wideActionButton" style={Localization.getFontFamilyAsStyle(Localization.FontFamily.Semibold)}>
+							<span className="wideButtonFont wideActionButton buttonTextInHighContrast" style={Localization.getFontFamilyAsStyle(Localization.FontFamily.Semibold)}>
 								{Localization.getLocalizedString("WebClipper.Action.BackToHome")}
 							</span>
 						</a>

--- a/src/scripts/clipperUI/panels/signInPanel.tsx
+++ b/src/scripts/clipperUI/panels/signInPanel.tsx
@@ -173,14 +173,14 @@ class SignInPanelClass extends ComponentBase<SignInPanelState, SignInPanelProps>
 					</div>
 					{this.errorInformationDescription()}
 					<div className="wideButtonContainer">
-						<a id={Constants.Ids.signInButtonMsa} className="wideButtonFont wideActionButton" role="button"
+						<a id={Constants.Ids.signInButtonMsa} className="wideButtonFont wideActionButton buttonTextInHighContrast" role="button"
 							{ ...this.enableInvoke({ callback: this.onSignInMsa, tabIndex: 11, args: AuthType.Msa }) }
 							style={Localization.getFontFamilyAsStyle(Localization.FontFamily.Regular)}>
 							{Localization.getLocalizedString("WebClipper.Action.SigninMsa")}
 						</a>
 					</div>
 					<div className="wideButtonContainer">
-						<a id={Constants.Ids.signInButtonOrgId} className="wideButtonFont wideActionButton" role="button"
+						<a id={Constants.Ids.signInButtonOrgId} className="wideButtonFont wideActionButton buttonTextInHighContrast" role="button"
 							{...this.enableInvoke({callback: this.onSignInOrgId, tabIndex: 12, args: AuthType.OrgId})}
 							style={Localization.getFontFamilyAsStyle(Localization.FontFamily.Regular)}>
 							{Localization.getLocalizedString("WebClipper.Action.SigninOrgId") }

--- a/src/scripts/clipperUI/panels/successPanel.tsx
+++ b/src/scripts/clipperUI/panels/successPanel.tsx
@@ -37,7 +37,7 @@ class SuccessPanelClass extends ComponentBase<{ }, ClipperStateProp> {
 					</span>
 				</div>
 				<div className="wideButtonContainer">
-					<a id={Constants.Ids.launchOneNoteButton} className="wideButtonFont wideActionButton" role="button"
+					<a id={Constants.Ids.launchOneNoteButton} className="wideButtonFont wideActionButton buttonTextInHighContrast" role="button"
 						{...this.enableInvoke({callback: this.onLaunchOneNoteButton, tabIndex: 70})}
 						style={Localization.getFontFamilyAsStyle(Localization.FontFamily.Regular)}>
 						{Localization.getLocalizedString("WebClipper.Action.ViewInOneNote")}

--- a/src/styles/clipper.less
+++ b/src/styles/clipper.less
@@ -225,3 +225,9 @@
 	padding-left: 5px;
 }
 
+@media (forced-colors: active) {
+	.buttonTextInHighContrast{
+		forced-color-adjust: none;
+		color: ButtonText !important;
+	}
+}


### PR DESCRIPTION
**Issue** - Button text in high contrast has coloring of normal text. The [bug 3176988](https://office.visualstudio.com/DefaultCollection/OneNote/_workitems/edit/3176988)  here says the text should take link color but the text inside the button is not a link so ideally it should take color of button-text. 

**Fix** - The buttons here are made by <a> with role = "button" instead of <button> tag, this is the reason why high contrast mode is treating the text inside it as normal text.  added css to pickup right color for button text in high contrast. The bug is only for particular button, fixing the same for all the buttons.

**Test** - Tested with all available High contrast modes in windows that the color of button-text is taken up correctly.