### PR TITLE
Fixing Luminocity ratio issue with icons under location

### DIFF
--- a/src/styles/sectionPickerOverrides.less
+++ b/src/styles/sectionPickerOverrides.less
@@ -35,6 +35,12 @@
 	color: #604a60;
 }
 
+.SectionPickerContainer {
+	img{ //this is color #604a60 which is color of text in sectionPickerContainer
+		filter: brightness(0) saturate(100%) invert(32%) sepia(7%) saturate(1393%) hue-rotate(251deg) brightness(94%) contrast(96%);
+	}
+}
+
 .SectionPickerPopup * {
 	font-size: 14px;
 	line-height: 20px;


### PR DESCRIPTION
**Issue** - [Bug 3716766](https://office.visualstudio.com/DefaultCollection/OneNote/_workitems/edit/3716766): [Visual Requirement - location of the clipper]: Luminosity ratio is less than 3:1 for “Expand/Collapse(v)” icons under location combo box.

**Fix** - The icons need a color change to be under considerable luminosity ratio. It can be done two ways - 1. Changing the color of icons through CSS
2. Replace the current icons with the updated icons with proper color - This will need updated icons (with color #604a60) from designers/UX.

So going ahead with 1st way.
