### PR TITLE
Fix three a11y bugs

### DIFF
--- a/src/scripts/clipperUI/components/previewViewer/editorPreviewComponentBase.tsx
+++ b/src/scripts/clipperUI/components/previewViewer/editorPreviewComponentBase.tsx
@@ -13,6 +13,7 @@ import {PreviewComponentBase} from "./previewComponentBase";
 import {PreviewViewerAugmentationHeader} from "./previewViewerAugmentationHeader";
 
 import * as _ from "lodash";
+import { Localization } from "../../../localization/localization";
 
 export interface EditorPreviewState {
 	textHighlighter?: any;
@@ -80,10 +81,29 @@ export abstract class EditorPreviewComponentBase<TState extends EditorPreviewSta
 		return this.state.textHighlighter && this.state.textHighlighter.isEnabled() ? Constants.Classes.highlightable : "";
 	}
 
+	private announceWithAriaLive(announcement: string) {
+		const ariaLiveDiv = document.getElementById(Constants.Ids.previewAriaLiveDiv);
+		if (!ariaLiveDiv) {
+			throw new Error("announceWithAriaLive: AriaLive div not found");
+			// TODO Log properly
+		}
+		// To make duplicate text announcement work. See https://core.trac.wordpress.org/ticket/36853
+		if (ariaLiveDiv.textContent === announcement) {
+			announcement += " \u00A0";
+		}
+		ariaLiveDiv.textContent = announcement;
+	}
+
 	private changeFontFamily(serif: boolean) {
 		_.assign(_.extend(this.props.clipperState.previewGlobalInfo, {
 			serif: serif
 		} as PreviewGlobalInfo), this.props.clipperState.setState);
+
+		if (serif) {
+			this.announceWithAriaLive(Localization.getLocalizedString("WebClipper.Accessibility.ScreenReader.ChangeFontToSerif"));
+		} else {
+			this.announceWithAriaLive(Localization.getLocalizedString("WebClipper.Accessibility.ScreenReader.ChangeFontToSansSerif"));
+		}
 	}
 
 	private changeFontSize(increase: boolean) {
@@ -97,6 +117,12 @@ export abstract class EditorPreviewComponentBase<TState extends EditorPreviewSta
 		_.assign(_.extend(this.props.clipperState.previewGlobalInfo, {
 			fontSize: newFontSize
 		} as PreviewGlobalInfo), this.props.clipperState.setState);
+
+		if (increase) {
+			this.announceWithAriaLive(Localization.getLocalizedString("WebClipper.Accessibility.ScreenReader.IncreaseFontSize"));
+		} else {
+			this.announceWithAriaLive(Localization.getLocalizedString("WebClipper.Accessibility.ScreenReader.DecreaseFontSize"));
+		}
 	}
 
 	private deleteHighlight(timestamp: number) {

--- a/src/scripts/clipperUI/components/previewViewer/editorPreviewComponentBase.tsx
+++ b/src/scripts/clipperUI/components/previewViewer/editorPreviewComponentBase.tsx
@@ -14,6 +14,8 @@ import {PreviewViewerAugmentationHeader} from "./previewViewerAugmentationHeader
 
 import * as _ from "lodash";
 import { Localization } from "../../../localization/localization";
+import { Clipper } from "../../frontEndGlobals";
+import * as Log from "../../../logging/log";
 
 export interface EditorPreviewState {
 	textHighlighter?: any;
@@ -84,8 +86,8 @@ export abstract class EditorPreviewComponentBase<TState extends EditorPreviewSta
 	private announceWithAriaLive(announcement: string) {
 		const ariaLiveDiv = document.getElementById(Constants.Ids.previewAriaLiveDiv);
 		if (!ariaLiveDiv) {
-			throw new Error("announceWithAriaLive: AriaLive div not found");
-			// TODO Log properly
+			Clipper.logger.logTrace(Log.Trace.Label.General, Log.Trace.Level.Warning, `Aria-live div with id ${Constants.Ids.sectionLocationContainer} not found`);
+			return
 		}
 		// To make duplicate text announcement work. See https://core.trac.wordpress.org/ticket/36853
 		if (ariaLiveDiv.textContent === announcement) {

--- a/src/scripts/clipperUI/components/previewViewer/editorPreviewComponentBase.tsx
+++ b/src/scripts/clipperUI/components/previewViewer/editorPreviewComponentBase.tsx
@@ -87,7 +87,7 @@ export abstract class EditorPreviewComponentBase<TState extends EditorPreviewSta
 		const ariaLiveDiv = document.getElementById(Constants.Ids.previewAriaLiveDiv);
 		if (!ariaLiveDiv) {
 			Clipper.logger.logTrace(Log.Trace.Label.General, Log.Trace.Level.Warning, `Aria-live div with id ${Constants.Ids.sectionLocationContainer} not found`);
-			return
+			return;
 		}
 		// To make duplicate text announcement work. See https://core.trac.wordpress.org/ticket/36853
 		if (ariaLiveDiv.textContent === announcement) {

--- a/src/scripts/clipperUI/components/previewViewer/previewComponentBase.tsx
+++ b/src/scripts/clipperUI/components/previewViewer/previewComponentBase.tsx
@@ -148,6 +148,7 @@ export abstract class PreviewComponentBase<TState, TProps extends ClipperStatePr
 						className={previewInnerContainerClass}
 						role="region"
 						aria-label={Localization.getLocalizedString("WebClipper.Accessibility.ScreenReader.PagePreview")}>
+						<div id={Constants.Ids.previewAriaLiveDiv} aria-live="polite" aria-relevant="additions text" className={Constants.Classes.srOnly}></div>
 						<div id={Constants.Ids.previewOptionsContainer}>
 							{this.getHeader()}
 						</div>

--- a/src/scripts/clipperUI/components/regionSelection.tsx
+++ b/src/scripts/clipperUI/components/regionSelection.tsx
@@ -3,6 +3,7 @@ import * as Log from "../../logging/log";
 import {ExtensionUtils} from "../../extensions/extensionUtils";
 
 import {ComponentBase} from "../componentBase";
+import { Localization } from "../../localization/localization";
 
 export interface RegionSelectionProps {
 	imageSrc: string;
@@ -23,7 +24,7 @@ class RegionSelectionClass extends ComponentBase<{}, RegionSelectionProps> {
 			this.props.onRemove
 				? <a className="region-selection-remove-button" role="button"
 					{...this.enableInvoke({callback: this.buttonHandler, tabIndex: 300, idOverride: Log.Click.Label.regionSelectionRemoveButton})}>
-					<img src={ExtensionUtils.getImageResourceUrl("editorOptions/delete_button.png") } /></a>
+					<img src={ExtensionUtils.getImageResourceUrl("editorOptions/delete_button.png")} alt={Localization.getLocalizedString("WebClipper.Preview.RemoveSelectedRegion")} /></a>
 				: undefined
 		);
 	}
@@ -34,7 +35,7 @@ class RegionSelectionClass extends ComponentBase<{}, RegionSelectionProps> {
 				<p className="region-selection">
 					{this.getRemoveButton()}
 					<img className="region-selection-image"
-						src={this.props.imageSrc} />
+						src={this.props.imageSrc} alt={Localization.getLocalizedString("WebClipper.Preview.SelectedRegion")}/>
 				</p>
 			</div>
 		);

--- a/src/scripts/clipperUI/components/sectionPicker.tsx
+++ b/src/scripts/clipperUI/components/sectionPicker.tsx
@@ -236,10 +236,10 @@ export class SectionPickerClass extends ComponentBase<SectionPickerState, Sectio
 	}
 
 	addSrOnlyLocationDiv(element: HTMLElement) {
-		const pickerLinkElement = document.getElementById("sectionLocationContainer");
+		const pickerLinkElement = document.getElementById(Constants.Ids.sectionLocationContainer);
 		if (!pickerLinkElement) {
-			throw new Error("Unable to add screen reader only text: No element with id 'sectionLocationContainer' found");
-			// TODO Log properly
+			Clipper.logger.logTrace(Log.Trace.Label.General, Log.Trace.Level.Warning, `Unable to add sr-only div: Parent element with id ${Constants.Ids.sectionLocationContainer} not found`);
+			return
 		}
 		const srDiv = document.createElement("div");
 		srDiv.textContent = Localization.getLocalizedString("WebClipper.Label.ClipLocation") + ": ";
@@ -297,12 +297,12 @@ export class SectionPickerClass extends ComponentBase<SectionPickerState, Sectio
 		return (
 			<div id={Constants.Ids.locationPickerContainer} {...this.onElementFirstDraw(this.addSrOnlyLocationDiv)}>
 				<div id={Constants.Ids.optionLabel} className="optionLabel">
-					<label htmlFor="sectionLocationContainer" aria-label={locationString} className="buttonLabelFont" style={Localization.getFontFamilyAsStyle(Localization.FontFamily.Regular)}>
+					<label htmlFor={Constants.Ids.sectionLocationContainer} aria-label={locationString} className="buttonLabelFont" style={Localization.getFontFamilyAsStyle(Localization.FontFamily.Regular)}>
 						<span aria-hidden="true">{locationString}</span>
 					</label>
 				</div>
 				<OneNotePicker.OneNotePickerComponent
-					id="sectionLocationContainer"
+					id={Constants.Ids.sectionLocationContainer}
 					tabIndex={70}
 					notebooks={this.state.notebooks}
 					status={Status[this.state.status]}

--- a/src/scripts/clipperUI/components/sectionPicker.tsx
+++ b/src/scripts/clipperUI/components/sectionPicker.tsx
@@ -239,7 +239,7 @@ export class SectionPickerClass extends ComponentBase<SectionPickerState, Sectio
 		const pickerLinkElement = document.getElementById(Constants.Ids.sectionLocationContainer);
 		if (!pickerLinkElement) {
 			Clipper.logger.logTrace(Log.Trace.Label.General, Log.Trace.Level.Warning, `Unable to add sr-only div: Parent element with id ${Constants.Ids.sectionLocationContainer} not found`);
-			return
+			return;
 		}
 		const srDiv = document.createElement("div");
 		srDiv.textContent = Localization.getLocalizedString("WebClipper.Label.ClipLocation") + ": ";

--- a/src/scripts/clipperUI/components/sectionPicker.tsx
+++ b/src/scripts/clipperUI/components/sectionPicker.tsx
@@ -235,6 +235,19 @@ export class SectionPickerClass extends ComponentBase<SectionPickerState, Sectio
 		};
 	}
 
+	addSrOnlyLocationDiv(element: HTMLElement) {
+		const pickerLinkElement = document.getElementById("sectionLocationContainer");
+		if (!pickerLinkElement) {
+			throw new Error("Unable to add screen reader only text: No element with id 'sectionLocationContainer' found");
+			// TODO Log properly
+		}
+		const srDiv = document.createElement("div");
+		srDiv.textContent = Localization.getLocalizedString("WebClipper.Label.ClipLocation") + ": ";
+		srDiv.setAttribute("class", Constants.Classes.srOnly);
+		// Make srDiv the first child of pickerLinkElement
+		pickerLinkElement.insertBefore(srDiv, pickerLinkElement.firstChild);
+	}
+
 	render() {
 		if (this.dataSourceUninitialized()) {
 			// This logic gets executed on app launch (if already signed in) and whenever the user signs in or out ...
@@ -282,7 +295,7 @@ export class SectionPickerClass extends ComponentBase<SectionPickerState, Sectio
 		let locationString = Localization.getLocalizedString("WebClipper.Label.ClipLocation");
 
 		return (
-			<div id={Constants.Ids.locationPickerContainer}>
+			<div id={Constants.Ids.locationPickerContainer} {...this.onElementFirstDraw(this.addSrOnlyLocationDiv)}>
 				<div id={Constants.Ids.optionLabel} className="optionLabel">
 					<label htmlFor="sectionLocationContainer" aria-label={locationString} className="buttonLabelFont" style={Localization.getFontFamilyAsStyle(Localization.FontFamily.Regular)}>
 						<span aria-hidden="true">{locationString}</span>

--- a/src/scripts/constants.ts
+++ b/src/scripts/constants.ts
@@ -224,6 +224,7 @@ export module Constants {
 
 		// sectionPicker
 		export var locationPickerContainer = "locationPickerContainer";
+		export var sectionLocationContainer = "sectionLocationContainer";
 
 		// signInPanel
 		export var signInButtonMsa = "signInButtonMsa";

--- a/src/scripts/constants.ts
+++ b/src/scripts/constants.ts
@@ -156,6 +156,7 @@ export module Constants {
 		export var previewTitleContainer = "previewTitleContainer";
 		export var previewSubtitleContainer = "previewSubtitleContainer";
 		export var previewInnerContainer = "previewInnerContainer";
+		export var previewAriaLiveDiv = "previewAriaLiveDiv";
 		export var previewOptionsContainer = "previewOptionsContainer";
 		export var previewInnerWrapper = "previewInnerWrapper";
 		export var previewOuterContainer = "previewOuterContainer";

--- a/src/scripts/logging/submodules/trace.ts
+++ b/src/scripts/logging/submodules/trace.ts
@@ -4,7 +4,8 @@ export module Trace {
 	export enum Label {
 		DefaultingToConsoleLogger,
 		DebugMode,
-		RequestForClipperInstalledPageUrl
+		RequestForClipperInstalledPageUrl,
+		General
 	}
 
 	export enum Level {

--- a/src/strings.json
+++ b/src/strings.json
@@ -130,6 +130,8 @@
 	"WebClipper.Preview.NoFullPageScreenshotFound": "No content found. Try another clipping mode.",
 	"WebClipper.Preview.NoContentFound": "No article found. Try another clipping mode.",
 	"WebClipper.Preview.UnableToClipLocalFile": "Local files can only be clipped using Region mode.",
+	"WebClipper.Preview.RemoveSelectedRegion": "Remove selected region",
+	"WebClipper.Preview.SelectedRegion": "Selected region",
 	"WebClipper.Preview.Header.AddAnotherRegionButtonLabel": "Add another region",
 	"WebClipper.Preview.Header.SansSerifButtonLabel": "Sans-serif",
 	"WebClipper.Preview.Header.SerifButtonLabel": "Serif",


### PR DESCRIPTION
**VSO 4273295: SR doesn't announce font increase/decrease/style change when activating those buttons.**
Fix: Added an aria-live div and set announcement text in it whenever buttons are activated.

**VSO 4275612: SR doesn't say "Location" before "Notebook > Section" when tabbing to the Location control.**
Fix: Added a SR only div containing "Location: " as first child of the control container. 

Ideally this change would be in OneNotePicker, but that will take a lot more effort: OneNotePicker code has moved far ahead with breaking changes, so the change would have to be made in a much older version of Picker. Then a new version of picker will have to be `npm publish`ed and consumed here.

**VSO 4275225: No alt text for images in Region mode preview panel**
Added alt text for the Selected Region and Remove Selected Region images.

**Testing:**
Tested manually in Chrome.