### PR TITLE
Add border to buttons in selected state to resolve luminosity issue

### DIFF
--- a/src/styles/mainClassDefinitions.less
+++ b/src/styles/mainClassDefinitions.less
@@ -172,6 +172,9 @@
 
 	&.selected {
 		background: @DarkBackgroundColor;
+		border: white;
+		border-width: 1px;
+		border-style: solid;
 	}
 
 	.icon {


### PR DESCRIPTION
Issue: Full page/Article/Region/Bookmark buttons have a dark purple selection state on a light purple background which fails the contrast ratio test. 
Fix: Added a white 1px border as a barrier between selection state and background colour.
Test: Verified expected behaviour in chrome and edge 

[Bug 3716760](https://office.visualstudio.com/OneNote/_workitems/edit/3716760): [Visual Requirement - Change Clipper Mode]: Luminosity ratio is less than 3:1 for selected clipper "Article" control boundary.