### PR TITLE
Option to highlight through keyboard

### DIFF
--- a/src/scripts/clipperUI/components/previewViewer/editorPreviewComponentBase.tsx
+++ b/src/scripts/clipperUI/components/previewViewer/editorPreviewComponentBase.tsx
@@ -53,7 +53,7 @@ export abstract class EditorPreviewComponentBase<TState extends EditorPreviewSta
 	// Override
 	protected getContentBodyForCurrentStatus() {
 		return [
-			<div id={Constants.Ids.highlightablePreviewBody}>{this.getHighlightableContentBodyForCurrentStatus()}</div>
+			<div id={Constants.Ids.highlightablePreviewBody} tabindex="0">{this.getHighlightableContentBodyForCurrentStatus()}</div>
 		];
 	}
 
@@ -184,6 +184,7 @@ export abstract class EditorPreviewComponentBase<TState extends EditorPreviewSta
 					deleteHighlight.src = ExtensionUtils.getImageResourceUrl("editoroptions/delete_button.png");
 					deleteHighlight.className = Constants.Classes.deleteHighlightButton;
 					deleteHighlight.setAttribute("data-timestamp", "" + timestamp);
+					deleteHighlight.setAttribute("tabindex", "0");
 					firstHighlighted.insertBefore(deleteHighlight, firstHighlighted.childNodes[0]);
 				}
 

--- a/src/scripts/highlighting/textHighlighter.js
+++ b/src/scripts/highlighting/textHighlighter.js
@@ -504,15 +504,19 @@ THE SOFTWARE.
     };
 
     TextHighlighter.prototype.bindEvents = function (el) {
+        el.addEventListener('keydown', this.boundStartDragHandler);
         el.addEventListener('mousedown', this.boundStartDragHandler);
         el.addEventListener('touchstart', this.boundStartDragHandler);
+        window.addEventListener('keyup', this.boundHighlightHandler);
         window.addEventListener('mouseup', this.boundHighlightHandler);
         window.addEventListener('touchend', this.boundHighlightHandler);
     }
 
     TextHighlighter.prototype.unbindEvents = function (el) {
+        el.removeEventListener('keydown', this.boundStartDragHandler);
         el.removeEventListener('mousedown', this.boundStartDragHandler);
         el.removeEventListener('touchstart', this.boundStartDragHandler);
+        window.removeEventListener('keyup', this.boundHighlightHandler);
         window.removeEventListener('mouseup', this.boundHighlightHandler);
         window.removeEventListener('touchend', this.boundHighlightHandler);
     }


### PR DESCRIPTION
Adding action handlers on keyup and keydown events to allow the highlighting through keyboard. Also tjhe delete button wasn't focusable, so added tab-index to make it focusbale.

Will do the changes for aria-label in next commit.

Tested working as expected.