### PR TITLE
supporting 200% and 400% zoom scenarios

### DIFF
--- a/src/scripts/clipperUI/animations/expandFromRightAnimationStrategy.ts
+++ b/src/scripts/clipperUI/animations/expandFromRightAnimationStrategy.ts
@@ -38,8 +38,7 @@ export class ExpandFromRightAnimationStrategy extends TransitioningAnimationStra
 
 			Velocity.animate(el, {
 				opacity: 1,
-				right: 20,
-				width: Constants.Styles.clipperUiWidth
+				right: 20
 			}, {
 				complete: () => {
 					// The first transition is reversed; once it is done, do the normal transitions
@@ -58,8 +57,7 @@ export class ExpandFromRightAnimationStrategy extends TransitioningAnimationStra
 			this.animationTimeoutId = setTimeout(() => {
 				Velocity.animate(el, {
 					opacity: 0,
-					right: 0,
-					width: 0
+					right: 0
 				}, {
 					complete: () => {
 						resolve();

--- a/src/styles/clipper.less
+++ b/src/styles/clipper.less
@@ -131,7 +131,12 @@
 	position: fixed;
 	top: @ClipperUITopRightOffset;
 	right: @ClipperUITopRightOffset;
-	width: 100px;
+	// width: 100px;
+	width: 25%;
+	max-width: @ClipperUIWidth;
+	height: 70%;
+	max-height: 470px;
+	overflow: scroll;
 	background: @OneNotePurpleTransparent;
 	border-radius: @ClipperBorderRadius;
 	box-shadow: @ClipperBoxShadow;
@@ -143,6 +148,27 @@
 	-ms-user-select: none;
 	-o-user-select: none;
 	user-select: none;
+
+	::-webkit-scrollbar, ::-webkit-scrollbar-thumb:vertical, ::-webkit-scrollbar-thumb:horizontal {
+		-webkit-border-radius: @ClipperBorderRadius;
+		border-radius: @ClipperBorderRadius;
+	}
+
+	::-webkit-scrollbar {
+		// Corresponds to the vertical and horizontal scrollbars respectively
+		width: 10px;
+		height: 10px;
+	}
+
+	// The pointy ends of the scrollbar's bar
+	::-webkit-scrollbar-thumb:vertical, ::-webkit-scrollbar-thumb:horizontal {
+		background: @ClipperScrollbarDark;
+		-moz-background-clip: padding-box;
+		-webkit-background-clip: padding-box;
+		background-clip: padding-box;
+		border: 2px solid rgba(0, 0, 0, 0);
+		min-height: 10px;
+	}
 
 	#optionLabel {
 		margin: 5px;

--- a/src/styles/previewStyles.less
+++ b/src/styles/previewStyles.less
@@ -44,7 +44,8 @@
 
 	#previewInnerWrapper {
 		position: fixed;
-		width: @OneNotePageWidth;
+		width: 70%;
+		max-width: @OneNotePageWidth;
 		top: @ClipperUITopRightOffset;
 		bottom: @ClipperUITopRightOffset;
 		right: @ClipperUIWidth + @ClipperUITopRightOffset + @ClipperUITopRightOffset;


### PR DESCRIPTION
Earlier during 200% zoom, the panels were overlapping making the text hidden. Some options of the panel were getting out of the viewport and making then inaccessible.

Wrote the custom css for the components to support these scenarios and added a scrollbar to not let the content go out of the view port. 

Testing: With these changes I can support 200% zoom across all resolutions and 400% zoom across some resolutions.