### PR TITLE
Adding aria-label to highlighter button

### DIFF
--- a/src/scripts/clipperUI/components/previewViewer/previewViewerAugmentationHeader.tsx
+++ b/src/scripts/clipperUI/components/previewViewer/previewViewerAugmentationHeader.tsx
@@ -44,8 +44,8 @@ class PreviewViewerAugmentationHeaderClass extends PreviewViewerHeaderComponentB
 			innerElements: [
 				<img
 					role="button"
-					aria-label={Localization.getLocalizedString("WebClipper.Accessibility.ScreenReader.ToggleHighlighterForArticleMode")}
-					title={Localization.getLocalizedString("WebClipper.Accessibility.ScreenReader.ToggleHighlighterForArticleMode")}
+					aria-label={Localization.getLocalizedString("WebClipper.Accessibility.ScreenReader.ToggleHighlighterModeForArticle")}
+					title={Localization.getLocalizedString("WebClipper.Accessibility.ScreenReader.ToggleHighlighterModeForArticle")}
 					aria-pressed={highlighterEnabled ? "true" : "false"}
 					id={Constants.Ids.highlightButton}
 					{...this.enableInvoke({callback: this.props.toggleHighlight, tabIndex: 100})}

--- a/src/strings.json
+++ b/src/strings.json
@@ -5,7 +5,7 @@
 	"WebClipper.Accessibility.ScreenReader.ChangeFontToSerif": "Change font to Serif",
 	"WebClipper.Accessibility.ScreenReader.DecreaseFontSize": "Decrease font size",
 	"WebClipper.Accessibility.ScreenReader.IncreaseFontSize": "Increase font size",
-	"WebClipper.Accessibility.ScreenReader.ToggleHighlighterForArticleMode": "Toggle Highlighter Mode For Article",
+	"WebClipper.Accessibility.ScreenReader.ToggleHighlighterModeForArticle": "Toggle Highlighter Mode For Article. To highlight using keyboard, enter Caret Mode using F7",
 	"WebClipper.Accessibility.ScreenReader.InputBoxToChangeTitleOfOneNotePage": "Text input to edit the title of the page you want to save",
 	"WebClipper.Accessibility.ScreenReader.InputBoxToChangeNotesToAddToPage": "Text input to edit the notes to save along with this page",
 	"WebClipper.Accessibility.ScreenReader.PagePreview": "Page Preview",


### PR DESCRIPTION
Adding aria-label to let users know to switch to caret mode if they want to highlight using keyboard. Changing the name of the variable to make it coherent with string, it is highlighter mode not article mode.

Testing: tested locally using narrator in edge and chrome, working as expected.