### PR TITLE
Restore 'default augmentation mode icon' test

### DIFF
--- a/src/tests/clipperUI/components/modeButtonSelector_tests.tsx
+++ b/src/tests/clipperUI/components/modeButtonSelector_tests.tsx
@@ -325,17 +325,17 @@ export class ModeButtonSelectorTests extends TestModule {
 			strictEqual(label.textContent, this.stringsJson["WebClipper.ClipType.Recipe.Button"]);
 		});
 
-		// test("The augmentation button should have its image set to the article icon by default", () => {
-		// 	MithrilUtils.mountToFixture(this.defaultComponent);
+		test("The augmentation button should have its image set to the article icon by default", () => {
+			MithrilUtils.mountToFixture(this.defaultComponent);
 
-		// 	let modeButtonSelector = MithrilUtils.getFixture().firstElementChild;
-		// 	let buttonElements = modeButtonSelector.getElementsByClassName(TestConstants.Classes.modeButton);
-		// 	let augmentationButton = buttonElements[2];
-		// 	let icon = augmentationButton.getElementsByClassName(TestConstants.Classes.icon)[0] as HTMLImageElement;
+			let modeButtonSelector = MithrilUtils.getFixture().firstElementChild;
+			let buttonElements = modeButtonSelector.getElementsByClassName(TestConstants.Classes.modeButton);
+			let augmentationButton = buttonElements[2];
+			let icon = augmentationButton.getElementsByClassName(TestConstants.Classes.icon)[0] as HTMLImageElement;
 
-		// 	// endsWith is polyfilled
-		// 	ok((icon.src.toLowerCase() as any).endsWith("article.png"));
-		// });
+			// endsWith is polyfilled
+			ok((icon.src.toLowerCase() as any).endsWith("article.svg"));
+		});
 
 		test("The augmentation button should have its image set according to the content model of the augmentation result", () => {
 			let startingState = MockProps.getMockClipperState();


### PR DESCRIPTION
The test was removed in a previous PR and logic corrected in PR 485. Restoring it as all tests execute fine now. 

WI: [Bug 5197568](https://office.visualstudio.com/OneNote/_workitems/edit/5197568) Update unit test to verify default icon for augmentation mode in Web Clipper