### PR TITLE
Bump clipper version to 3.8.4 for a new store release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change Log
+## 3.8.4 (July 22, 2021)
+* Improvement: Added a11y improvements
+
 ## 3.8.3 (June 20, 2021)
 * Improvement: Added a11y improvements
 * Improvement: Updated icons from PNG to SVG

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webclipper",
-  "version": "3.8.3",
+  "version": "3.8.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -81,8 +81,5 @@
     "velocity-animate": "1.4.2",
     "vinyl-source-stream": "1.1.0",
     "yargs": "6.6.0"
-  },
-  "dependencies": {
-    "natives": "^1.1.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.8.3",
+  "version": "3.8.4",
   "name": "webclipper",
   "private": true,
   "description": "The core of the OneNote Web Clipper found at https://www.onenote.com/clipper",
@@ -81,5 +81,8 @@
     "velocity-animate": "1.4.2",
     "vinyl-source-stream": "1.1.0",
     "yargs": "6.6.0"
+  },
+  "dependencies": {
+    "natives": "^1.1.6"
   }
 }

--- a/src/scripts/extensions/chrome/manifest.json
+++ b/src/scripts/extensions/chrome/manifest.json
@@ -3,7 +3,7 @@
 	"name": "OneNote Web Clipper",
 	"description": "__MSG_appDesc__",
 	"default_locale": "en",
-	"version": "3.8.3",
+	"version": "3.8.4",
 	"background": {
 		"scripts": [ "chromeExtension.js" ]
 	},

--- a/src/scripts/extensions/edge/manifest.json
+++ b/src/scripts/extensions/edge/manifest.json
@@ -4,7 +4,7 @@
 	"name": "OneNote Web Clipper",
 	"description": "__MSG_appDesc__",
 	"default_locale": "en",
-	"version": "3.8.3",
+	"version": "3.8.4",
 	"background": {
 		"scripts": [ "edgeExtension.js" ],
 		"persistent": true

--- a/src/scripts/extensions/edge/package/AppXManifest.xml
+++ b/src/scripts/extensions/edge/package/AppXManifest.xml
@@ -7,7 +7,7 @@
 	<Identity 
 		Name="Microsoft.OneNoteWebClipper" 
 		Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" 
-		Version="3.8.3.0" />
+		Version="3.8.4.0" />
 
 	<Properties> 
 		<DisplayName>OneNote Web Clipper</DisplayName> 

--- a/src/scripts/extensions/extensionBase.ts
+++ b/src/scripts/extensions/extensionBase.ts
@@ -42,7 +42,7 @@ export abstract class ExtensionBase<TWorker extends ExtensionWorkerBase<TTab, TT
 	protected auth: AuthenticationHelper;
 	protected tooltip: TooltipHelper;
 	protected clientInfo: SmartValue<ClientInfo>;
-	protected static version = "3.8.3";
+	protected static version = "3.8.4";
 
 	constructor(clipperType: ClientType, clipperData: ClipperData) {
 		this.setUnhandledExceptionLogging();

--- a/src/scripts/extensions/firefox/manifest.json
+++ b/src/scripts/extensions/firefox/manifest.json
@@ -3,7 +3,7 @@
 	"name": "OneNote Web Clipper",
 	"description": "__MSG_appDesc__",
 	"default_locale": "en",
-	"version": "3.8.3",
+	"version": "3.8.4",
 	"background": {
 		"scripts": [ "firefoxExtension.js" ]
 	},

--- a/src/scripts/extensions/safari/Info.plist
+++ b/src/scripts/extensions/safari/Info.plist
@@ -13,9 +13,9 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.8.3</string>
+	<string>3.8.4</string>
 	<key>CFBundleVersion</key>
-	<string>3.8.3</string>
+	<string>3.8.4</string>
 	<key>Chrome</key>
 	<dict>
 		<key>Global Page</key>


### PR DESCRIPTION
Updated WebClipper version across manifests to 3.8.4 to accommodate the latest changes. 

Test notes:
Verified expected behaviour in all browsers.