### PR TITLE
Removed feedback buttton

### DIFF
--- a/src/scripts/clipperUI/components/footer.tsx
+++ b/src/scripts/clipperUI/components/footer.tsx
@@ -75,10 +75,10 @@ class FooterClass extends ComponentBase<FooterState, FooterProps> {
 				style={Localization.getFontFamilyAsStyle(Localization.FontFamily.Regular)}>
 				<div className={Constants.Ids.footerButtonsContainer}>
 					<div className="footerButtonsLeft">
-						<a id={Constants.Ids.feedbackButton} role="button" {...this.enableInvoke({callback: this.handleFeedbackButton, tabIndex: 80})}>
+						{/* <a id={Constants.Ids.feedbackButton} role="button" {...this.enableInvoke({callback: this.handleFeedbackButton, tabIndex: 80})}>
 							<img id={Constants.Ids.feedbackImage} src={ExtensionUtils.getImageResourceUrl("feedback_smiley.svg")} aria-hidden="true"/>
 							<span id={Constants.Ids.feedbackLabel} class="buttonTextInHighContrast">{Localization.getLocalizedString("WebClipper.Action.Feedback") }</span>
-						</a>
+						</a> */}
 					</div>
 					{showUserInfo
 						? (<div className="footerButtonsRight">

--- a/src/tests/clipperUI/components/footer_tests.tsx
+++ b/src/tests/clipperUI/components/footer_tests.tsx
@@ -142,7 +142,7 @@ export class FooterTests extends TestModule {
 				"Popup should not be opened by default");
 		});
 
-		test("On clicking the feedback button, a popup should open", () => {
+		/* test("On clicking the feedback button, a popup should open", () => {
 			let controllerInstance = MithrilUtils.mountToFixture(this.defaultComponent);
 
 			MithrilUtils.simulateAction(() => {
@@ -151,7 +151,7 @@ export class FooterTests extends TestModule {
 
 			ok(!controllerInstance.getFeedbackWindowRef().closed,
 				"Popup should open when feedback button is clicked");
-		});
+		}); */
 
 		test("The tabbing should flow from the feedback to dropdown to sign out buttons", () => {
 			let controllerInstance = MithrilUtils.mountToFixture(this.defaultComponent);
@@ -161,7 +161,7 @@ export class FooterTests extends TestModule {
 				dropdown.click();
 			});
 
-			Assert.tabOrderIsIncremental([Constants.Ids.feedbackButton, Constants.Ids.currentUserControl, Constants.Ids.signOutButton]);
+			Assert.tabOrderIsIncremental([/*Constants.Ids.feedbackButton, */Constants.Ids.currentUserControl, Constants.Ids.signOutButton]);
 		});
 	}
 }

--- a/src/tests/clipperUI/mainController_tests.tsx
+++ b/src/tests/clipperUI/mainController_tests.tsx
@@ -69,7 +69,7 @@ export class MainControllerTests extends TestModule {
 				controllerInstance.state.currentPanel = PanelType.ClipOptions;
 			});
 
-			Assert.tabOrderIsIncremental([Constants.Ids.clipButton, Constants.Ids.feedbackButton, Constants.Ids.currentUserControl, Constants.Ids.closeButton]);
+			Assert.tabOrderIsIncremental([Constants.Ids.clipButton/*, Constants.Ids.feedbackButton*/, Constants.Ids.currentUserControl, Constants.Ids.closeButton]);
 		});
 
 		test("On the pdf clip options panel, tab order should flow linearly between pdf options with the page range radio button appearing only when selected", () => {
@@ -82,14 +82,14 @@ export class MainControllerTests extends TestModule {
 			});
 
 			Assert.tabOrderIsIncremental([Constants.Ids.clipButton,
-				Constants.Ids.radioAllPagesLabel, TestConstants.Ids.sectionLocationContainer, Constants.Ids.feedbackButton,
+				Constants.Ids.radioAllPagesLabel, TestConstants.Ids.sectionLocationContainer, /*Constants.Ids.feedbackButton,*/
 				Constants.Ids.currentUserControl, Constants.Ids.closeButton]);
 
 			MithrilUtils.simulateAction(() => {
 				document.getElementById(Constants.Ids.radioPageRangeLabel).click();
 			});
 			Assert.tabOrderIsIncremental([Constants.Ids.clipButton,
-				Constants.Ids.radioPageRangeLabel, TestConstants.Ids.sectionLocationContainer, Constants.Ids.feedbackButton,
+				Constants.Ids.radioPageRangeLabel, TestConstants.Ids.sectionLocationContainer, /*Constants.Ids.feedbackButton,*/
 				Constants.Ids.currentUserControl, Constants.Ids.closeButton]);
 		});
 
@@ -105,13 +105,13 @@ export class MainControllerTests extends TestModule {
 				document.getElementById(Constants.Ids.moreClipOptions).click();
 			});
 			Assert.tabOrderIsIncremental([Constants.Ids.clipButton, Constants.Ids.radioAllPagesLabel, Constants.Ids.checkboxToDistributePages, Constants.Ids.checkboxToAttachPdf,
-				Constants.Ids.feedbackButton, Constants.Ids.currentUserControl, Constants.Ids.closeButton]);
+				/*Constants.Ids.feedbackButton,*/ Constants.Ids.currentUserControl, Constants.Ids.closeButton]);
 
 			MithrilUtils.simulateAction(() => {
 				document.getElementById(Constants.Ids.radioPageRangeLabel).click();
 			});
 			Assert.tabOrderIsIncremental([Constants.Ids.clipButton, Constants.Ids.radioPageRangeLabel, Constants.Ids.checkboxToDistributePages, Constants.Ids.checkboxToAttachPdf,
-				Constants.Ids.feedbackButton, Constants.Ids.currentUserControl, Constants.Ids.closeButton]);
+				/*Constants.Ids.feedbackButton,*/ Constants.Ids.currentUserControl, Constants.Ids.closeButton]);
 		});
 
 		test("On the region instructions panel, the tab order is correct", () => {


### PR DESCRIPTION
Due to compliance reasons, feedback button can only be displayed after checking the age of the user, so for now removing feedback button.

Tested and verified that the feedback button does not show up on the sign page and main page for both work account and MSA accounts.