### PR TITLE
Removing feedback button for MSA accounts

### DIFF
--- a/src/scripts/clipperUI/clipperStateUtilities.ts
+++ b/src/scripts/clipperUI/clipperStateUtilities.ts
@@ -10,6 +10,10 @@ export module ClipperStateUtilities {
 		return (state.userResult && state.userResult.status && state.userResult.data && !!state.userResult.data.user);
 	}
 
+	export function isMsaUser(state: ClipperState): boolean {
+		return state.userResult && state.userResult.data && state.userResult.data.user && state.userResult.data.user.authType && (state.userResult.data.user.authType.toLowerCase() === "msa");
+	}
+
 	export function clipButtonEnabled(clipperState: ClipperState): boolean {
 		let currentMode = clipperState.currentMode.get();
 		switch (currentMode) {

--- a/src/scripts/clipperUI/components/footer.tsx
+++ b/src/scripts/clipperUI/components/footer.tsx
@@ -69,16 +69,20 @@ class FooterClass extends ComponentBase<FooterState, FooterProps> {
 
 	render() {
 		let showUserInfo = ClipperStateUtilities.isUserLoggedIn(this.props.clipperState);
+		let isMsaUser = ClipperStateUtilities.isMsaUser(this.props.clipperState);
 
 		return (
 			<div id={Constants.Ids.clipperFooterContainer} className="footerFont"
 				style={Localization.getFontFamilyAsStyle(Localization.FontFamily.Regular)}>
 				<div className={Constants.Ids.footerButtonsContainer}>
 					<div className="footerButtonsLeft">
-						<a id={Constants.Ids.feedbackButton} role="button" {...this.enableInvoke({callback: this.handleFeedbackButton, tabIndex: 80})}>
-							<img id={Constants.Ids.feedbackImage} src={ExtensionUtils.getImageResourceUrl("feedback_smiley.svg")} aria-hidden="true"/>
-							<span id={Constants.Ids.feedbackLabel} class="buttonTextInHighContrast">{Localization.getLocalizedString("WebClipper.Action.Feedback") }</span>
-						</a>
+						{!isMsaUser
+							? (<a id={Constants.Ids.feedbackButton} role="button" {...this.enableInvoke({callback: this.handleFeedbackButton, tabIndex: 80})}>
+									<img id={Constants.Ids.feedbackImage} src={ExtensionUtils.getImageResourceUrl("feedback_smiley.svg")} aria-hidden="true"/>
+									<span id={Constants.Ids.feedbackLabel} class="buttonTextInHighContrast">{Localization.getLocalizedString("WebClipper.Action.Feedback") }</span>
+							</a>)
+							: undefined
+						}
 					</div>
 					{showUserInfo
 						? (<div className="footerButtonsRight">

--- a/src/tests/mockProps.ts
+++ b/src/tests/mockProps.ts
@@ -38,6 +38,7 @@ export module MockProps {
 						emailAddress: "mockEmail@hotmail.com",
 						fullName: "Mock Johnson",
 						accessToken: "mockToken",
+						authType: "OrgId",
 						accessTokenExpiration: 3000
 					},
 					lastUpdated: 10000000,


### PR DESCRIPTION
There is a privacy incident where users who are minor are also getting option for verbose feedback. Currently we are not able to parse the claims in the jwt token to check the users based on their age  since it is encrypted. So we are removing the feedback button for MSA accounts.
![image](https://user-images.githubusercontent.com/75728587/136546228-19d41884-65b7-411b-b8f8-a3f0489bd59a.png)
While the button will come for non-logged in users
![image](https://user-images.githubusercontent.com/75728587/136546345-446587f1-b142-4795-9afa-60f0478cc9bc.png)
It will be also visible for AAD users since all of them are considered as adults.
![image](https://user-images.githubusercontent.com/75728587/136548242-48a3b105-bfba-4e52-9ac4-03b188327f0f.png)
