### PR TITLE
[Keyboard navigation - Clip]: Keyboard focus moves to non-interactive 'progress bar' tick on the 'Clip successful' pop-up window via using tab key. 

### DIFF
--- a/src/scripts/clipperUI/components/spriteAnimation.tsx
+++ b/src/scripts/clipperUI/components/spriteAnimation.tsx
@@ -14,6 +14,7 @@ export interface SpriteAnimationProps {
 	totalFrameCount: number;
 	loop?: boolean;
 	ariaLabel?: string;
+	tabIndex?: number;
 }
 
 export interface SpriteAnimationState {
@@ -115,6 +116,8 @@ class SpriteAnimationClass extends ComponentBase<SpriteAnimationState, SpriteAni
 
 		let ariaLabel = this.props.ariaLabel ? this.props.ariaLabel : Localization.getLocalizedString("WebClipper.Accessibility.ScreenReader.Loading");
 
+		let tabIndex = this.props.tabIndex ? this.props.tabIndex : 290;
+
 		let style = {
 			backgroundImage: "url(" + this.props.spriteUrl + ")",
 			backgroundRepeat: "no-repeat",
@@ -127,7 +130,7 @@ class SpriteAnimationClass extends ComponentBase<SpriteAnimationState, SpriteAni
 				className={Constants.Classes.spinner}
 				config={this.configForSpinner.bind(this)}
 				style={style}
-				tabIndex="290"
+				tabIndex={tabIndex}
 				aria-label={ariaLabel}
 				role="progressbar"
 				aria-valuemin="0"

--- a/src/scripts/clipperUI/panels/successPanel.tsx
+++ b/src/scripts/clipperUI/panels/successPanel.tsx
@@ -30,7 +30,7 @@ class SuccessPanelClass extends ComponentBase<{ }, ClipperStateProp> {
 		return (
 			<div id={Constants.Ids.clipperSuccessContainer}>
 				<div className="messageLabelContainer successPagePadding">
-					<SpriteAnimation spriteUrl={ExtensionUtils.getImageResourceUrl("checkmark.png")} imageHeight={28} totalFrameCount={30} loop={false}/>
+					<SpriteAnimation spriteUrl={ExtensionUtils.getImageResourceUrl("checkmark.png")} imageHeight={28} totalFrameCount={30} loop={false} tabIndex={-1}/>
 					<span className="actionLabelFont messageLabel" role="alert"
 						style={Localization.getFontFamilyAsStyle(Localization.FontFamily.Light)}>
 						{Localization.getLocalizedString("WebClipper.Label.ClipSuccessful")}


### PR DESCRIPTION

https://office.visualstudio.com/OneNote/_workitems/edit/6211129

1.  Checkmark icon, which comes after the clipping is saved to onentoe, is not interactive and should not be tab-indexed.

1.  It is rendered in the sprite animation component, so have added a prop of tabIndex and setting it dynamically

1. Passing the prop as "-1" from success panel component, which renders the checkmark, so that it is taken out of tab a11y loop.

**Testing**: Earlier the checkmark button was tab-indexed but after the fix the tab control does not close to it and directly goes to close button.