### PR TITLE
[Location - Dropdown]: Keyboard boundary is not visible properly inside "location dropdown" control.

### DIFF
--- a/src/styles/clipper.less
+++ b/src/styles/clipper.less
@@ -232,6 +232,18 @@
 	padding-left: 5px;
 }
 
+.Notebook:focus {
+	border: 1px solid black !important;
+}
+
+.Section:focus {
+	border: 1px solid black !important;
+}
+
+.region-selection-remove-button:focus {
+	border: 1px solid black !important;
+}
+
 @media (forced-colors: active) {
 	.buttonTextInHighContrast{
 		forced-color-adjust: none;


### PR DESCRIPTION
https://office.visualstudio.com/OneNote/_workitems/edit/6210695

This bug has two issues:
**Issue 1:** The boundary of notebook and section cell in notebook picker is not clearly visible when the focus goes to it.

1. We pick the notebook picker from this repo [GitHub - OneNoteDev/OneNotePicker-JS: A JavaScript UI component that allows a user to choose a section from a list of their notebooks.](https://github.com/OneNoteDev/OneNotePicker-JS) and its version is not updated for a long time and updating it causes a lot of side issues.

1.  So in order to get this bug fixed, I have overriden the css of it, in the clipper.less file which gets loaded as a assets in the js engine of the browser and hence it can be used by notebook picker as well.

1. Added border around it, so that it is visible properly.

**Issue 2:** The boundary of remove button when focused is not visible.

1. Added the border css to its respective class.


**Testing**: Tested the focus and it is clear now at both places. Following are the before and after screenshots
|    Before    |    After     |
| :----------: | :----------: |
| ![image](https://user-images.githubusercontent.com/75728587/201106445-117c3de3-7102-42eb-aad2-910987603639.png) | ![image](https://user-images.githubusercontent.com/75728587/201106296-0b1afd6e-8d07-498c-adf4-f73545276108.png) |
| :----------: | :----------: |
| ![image](https://user-images.githubusercontent.com/75728587/201106605-2136aadb-9224-4ebe-b133-d0cde050724b.png) | ![image](https://user-images.githubusercontent.com/75728587/201106654-d3bb69a5-f507-43d5-af92-565efc828b4c.png) |