### PR TITLE
[Successfully clip each clipper mode type - Full Page]: Screen reader is not announcing Role as button for 'Full page' control.

### DIFF
--- a/src/scripts/clipperUI/components/modeButton.tsx
+++ b/src/scripts/clipperUI/components/modeButton.tsx
@@ -37,7 +37,7 @@ class ModeButtonClass extends ComponentBase<{}, PropsForModeButton> {
 		let idName: string = clipMode + "Button";
 
 		return (
-			<a className={className} role="option" aria-selected={this.props.selected}
+			<a className={className} role="button" aria-selected={this.props.selected}
 				id={idName} title={this.props.tooltipText ? this.props.tooltipText : ""}
 				aria-setsize={this.props["aria-setsize"]} aria-posinset={this.props["aria-posinset"]}
 				{...this.onElementFirstDraw(this.initiallySetFocus)}


### PR DESCRIPTION

https://office.visualstudio.com/OneNote/_workitems/edit/6216258

1. In the options menu, there are various modes of clipper which are interactive and clickable, so it should announce button also along with the label name.

1. Added role as button so that narrator starts announing button also.

**Testing**: Tested with narrator, and it works as expected.