### PR TITLE
EUDB DataBoundary check in WebClipper Client by getting Email ID of OrgID user

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,5 +84,9 @@
     },
     "overrides": {
         "graceful-fs": "4.2.2"
+    },
+    "dependencies": {
+        "jwt-decode": "^2.2.0",
+        "node-fetch": "^2.6.1"
     }
 }

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
         "graceful-fs": "4.2.2"
     },
     "dependencies": {
-        "jwt-decode": "^2.2.0",
-        "node-fetch": "^2.6.1"
+        "jwt-decode": "^2.2.0"
     }
 }

--- a/src/scripts/constants.ts
+++ b/src/scripts/constants.ts
@@ -381,6 +381,7 @@ export module Constants {
 
 		export var msaDomain = "https://login.live.com";
 		export var orgIdDomain = "https://login.microsoftonline.com";
+		export var userDataBoundaryDomain = "https://odc.officeapps.live.com/odc/v2.1/federationprovider";
 
 		export module Authentication {
 			export var authRedirectUrl = serviceDomain + "/webclipper/auth";
@@ -413,6 +414,7 @@ export module Constants {
 			export var url = "url";
 			export var userSessionId = "userSessionId";
 			export var wdFromClipper = "wdfromclipper"; // This naming convention is standard in OneNote Online
+			export var domain = "domain";
 		}
 	}
 

--- a/src/scripts/extensions/dataBoundary.ts
+++ b/src/scripts/extensions/dataBoundary.ts
@@ -1,0 +1,7 @@
+export enum DataBoundary {
+	PUBLIC,
+	GLOBAL,
+	EUDB,
+	EMEA,
+	UNKNOWN
+}

--- a/src/scripts/extensions/userDataBoundaryHelper.ts
+++ b/src/scripts/extensions/userDataBoundaryHelper.ts
@@ -1,0 +1,65 @@
+import { Clipper } from "../clipperUI/frontEndGlobals";
+import { Constants } from "../constants";
+import { HttpWithRetries } from "../http/HttpWithRetries";
+import { UrlUtils } from "../urlUtils";
+import { UserInfoData, AuthType } from "../userInfo";
+import { DataBoundary } from "./DataBoundary";
+
+export class UserDataBoundaryHelper {
+	/**
+	 * fetch the user data bounday from the emailAddress
+	 * @param userInfo 
+	 * @returns user data boudary
+	 */
+	public async getUserDataBoundary(userInfo: UserInfoData): Promise<string | undefined> {
+		try {
+			if (!userInfo) {
+				return undefined;
+			}
+			if (userInfo.authType === AuthType[AuthType.Msa]) {
+				return DataBoundary[DataBoundary.GLOBAL];
+			}
+			if (!userInfo.emailAddress) {
+				return undefined;
+			}
+			let dataBoundaryString: string = await this.getUserDataBoundaryInternal(userInfo);
+			return dataBoundaryString;
+		} catch (error) {
+			return error.message;
+		}
+	}
+
+	/**
+	 * fetch the user data bounday from the emailAddress
+	 * @param userInfo 
+	 * @returns user data boudary
+	 */
+	private async getUserDataBoundaryInternal(userInfo: UserInfoData): Promise<string | undefined> {
+		return new Promise<string | undefined>((resolve, reject) => {
+			let domainValue = userInfo.emailAddress.substring(
+				userInfo.emailAddress.indexOf("@") + 1);
+			const urlDataBoundaryDomain: string = UrlUtils.addUrlQueryValue(Constants.Urls.userDataBoundaryDomain, Constants.Urls.QueryParams.domain, domainValue);
+			HttpWithRetries.get(urlDataBoundaryDomain).then((request: XMLHttpRequest) => {
+				let expectedCodes = [200];
+				if (expectedCodes.indexOf(request.status) > -1) {
+					let parsedResponse: any;
+					try {
+						parsedResponse = JSON.parse(request.responseText);
+					} catch (error) {
+						Clipper.logger.logJsonParseUnexpected(request.response);
+						reject(error);
+					}
+					if (parsedResponse && parsedResponse.telemetryRegion) {
+						resolve(parsedResponse.telemetryRegion);
+					} else {
+						resolve(DataBoundary[DataBoundary.UNKNOWN]);
+					}
+				} else {
+					resolve(DataBoundary[DataBoundary.UNKNOWN]);
+				}
+			}, (error) => {
+				reject(error);
+			});
+		});
+	}
+}

--- a/src/scripts/http/cachedHttp.ts
+++ b/src/scripts/http/cachedHttp.ts
@@ -1,6 +1,8 @@
 import {ResponsePackage} from "../responsePackage";
 
-import {Storage} from "../storage/storage";
+import { Storage } from "../storage/storage";
+import { AuthType, JwtAcessTokenInfo } from "../userInfo";
+import * as jwt_decode from "jwt-decode";
 
 export interface TimeStampedData {
 	data: any;
@@ -102,6 +104,19 @@ export class CachedHttp {
 			valueAsJson = JSON.parse(value);
 		} catch (e) {
 			return undefined;
+		}
+
+		const userAuthType: string = valueAsJson.authType;
+		if (userAuthType === AuthType[AuthType.OrgId]) {
+			const token: string = valueAsJson.accessToken;
+			try {
+				const decodedToken: JwtAcessTokenInfo = jwt_decode(token);
+				if (decodedToken) {
+					valueAsJson.emailAddress = decodedToken.upn;
+				}
+			} catch (e) {
+				return undefined;
+			}
 		}
 
 		let timeStampedValue: TimeStampedData = { data: valueAsJson, lastUpdated: Date.now() };

--- a/src/scripts/logging/submodules/propertyName.ts
+++ b/src/scripts/logging/submodules/propertyName.ts
@@ -57,7 +57,8 @@ export module PropertyName {
 		UserUpdateReason,
 		Value,
 		Width,
-		WriteableCookies
+		WriteableCookies,
+		DataBoundary
 	}
 
 	/* tslint:disable:variable-name */

--- a/src/scripts/userInfo.ts
+++ b/src/scripts/userInfo.ts
@@ -19,6 +19,7 @@ export interface UserInfoData {
 	cookieInRequest?: boolean;
 	emailAddress?: string;
 	fullName?: string;
+	dataBoundary?: string;
 }
 
 export enum UpdateReason {
@@ -27,4 +28,13 @@ export enum UpdateReason {
 	SignInCancel,
 	SignOutAction,
 	TokenRefreshForPendingClip
+}
+
+export interface JwtAcessTokenInfo {
+	name: string;
+	upn: string;
+	exp: number;
+	tid: string;
+	oid: string;
+	puid: string;
 }


### PR DESCRIPTION
There are two changes done in this PR:
1. For an OrgID User, the email address info was not present in the UserInfoData returned by the Service. The email address is filled by decoding the token using jwt-decode and assigning the upn value of the decoded value to the email address.
2. Later on,for a valid user information the corresponding telemetry region is filled as the dataBoundary by using the function getDataBoundary().
3. The getDataBoundary uses the federation provider url https://odc.officeapps.live.com/odc/v2.1/federationprovider with a query parameter being domain. This query param value is set with domainValue extracted from the user's email address. The telemetry region value is the Data boundary that is needed from response to the url.
4. For EUDB, it will be provided with EMEA and for others it provided with GLOBAL as telemetry regions.

Tested locally to verify the email address extraction from the token and telemetry region 
![MicrosoftTeams-image (1)](https://user-images.githubusercontent.com/125361438/233313132-dbbe8ade-2897-4436-9abd-ed33d1106681.png)
![MicrosoftTeams-image](https://user-images.githubusercontent.com/125361438/233313140-b2abdf76-b823-4abb-95a4-ccfec2985675.png)
