### PR TITLE
Fixing Header title for Selection Item

### DIFF
--- a/src/scripts/clipperUI/components/previewViewer/editorPreviewComponentBase.tsx
+++ b/src/scripts/clipperUI/components/previewViewer/editorPreviewComponentBase.tsx
@@ -75,7 +75,8 @@ export abstract class EditorPreviewComponentBase<TState extends EditorPreviewSta
 			changeFontFamily={this.changeFontFamily.bind(this)}
 			changeFontSize={this.changeFontSize.bind(this)}
 			serif={this.props.clipperState.previewGlobalInfo.serif}
-			textHighlighterEnabled={this.props.clipperState.previewGlobalInfo.highlighterEnabled} />;
+			textHighlighterEnabled={this.props.clipperState.previewGlobalInfo.highlighterEnabled}
+			currentMode={this.props.clipperState.currentMode} />;
 	}
 
 	// Override

--- a/src/scripts/clipperUI/components/previewViewer/previewViewerAugmentationHeader.tsx
+++ b/src/scripts/clipperUI/components/previewViewer/previewViewerAugmentationHeader.tsx
@@ -1,6 +1,8 @@
-﻿import {Constants} from "../../../constants";
+﻿import { SmartValue } from "../../../communicator/smartValue";
+import {Constants} from "../../../constants";
 import {ExtensionUtils} from "../../../extensions/extensionUtils";
 import {Localization} from "../../../localization/localization";
+import { ClipMode } from "../../clipMode";
 import {ControlGroup, HeaderClasses, PreviewViewerHeaderComponentBase} from "./previewViewerHeaderComponentBase";
 
 export interface PreviewViewerAugmentationHeaderProp {
@@ -9,6 +11,7 @@ export interface PreviewViewerAugmentationHeaderProp {
 	changeFontSize: (increase: boolean) => void;
 	serif: boolean;
 	textHighlighterEnabled: boolean;
+	currentMode?: SmartValue<ClipMode>;
 }
 
 class PreviewViewerAugmentationHeaderClass extends PreviewViewerHeaderComponentBase<{}, PreviewViewerAugmentationHeaderProp> {
@@ -31,7 +34,10 @@ class PreviewViewerAugmentationHeaderClass extends PreviewViewerHeaderComponentB
 	}
 
 	private getTitleGroup() {
-		return this.getTitleGroupPrivate("augmentationHeaderControlGroupId", Localization.getLocalizedString("WebClipper.ClipType.Article.Button"), "augmentationHeaderTitle");
+		let headerTitle: string = this.props.currentMode.get() === ClipMode.Selection ?
+			Localization.getLocalizedString("WebClipper.ClipType.Selection.Button") :
+			Localization.getLocalizedString("WebClipper.ClipType.Article.Button");
+		return this.getTitleGroupPrivate("augmentationHeaderControlGroupId", headerTitle, "augmentationHeaderTitle");
 	}
 
 	private getHighlightGroup(): ControlGroup {

--- a/src/tests/clipperUI/components/previewViewer/previewViewerAugmentationHeader_tests.tsx
+++ b/src/tests/clipperUI/components/previewViewer/previewViewerAugmentationHeader_tests.tsx
@@ -6,6 +6,8 @@ import {Assert} from "../../../assert";
 import {MithrilUtils} from "../../../mithrilUtils";
 import {TestModule} from "../../../testModule";
 import {StubSessionLogger} from "../../../../scripts/logging/stubSessionLogger";
+import { ClipMode } from "../../../../scripts/clipperUI/clipMode";
+import { SmartValue } from "../../../../scripts/communicator/smartValue";
 
 export class PreviewViewerAugmentationHeaderTests extends TestModule {
 	private defaultComponent;
@@ -21,15 +23,17 @@ export class PreviewViewerAugmentationHeaderTests extends TestModule {
 			changeFontFamily: sinon.spy((serif: boolean) => { }),
 			changeFontSize: sinon.spy((increase: boolean) => { }),
 			serif: false,
-			textHighlighterEnabled: false
+			textHighlighterEnabled: false,
+			currentMode: new SmartValue<ClipMode>(ClipMode.Augmentation)
 		} as PreviewViewerAugmentationHeaderProp;
 		this.defaultComponent =
 			<PreviewViewerAugmentationHeader
-				toggleHighlight={this.mockProp.toggleHighlight}
-				changeFontFamily={this.mockProp.changeFontFamily}
-				changeFontSize={this.mockProp.changeFontSize}
-				serif={this.mockProp.serif}
-				textHighlighterEnabled={this.mockProp.textHighlighterEnabled} />;
+			toggleHighlight={this.mockProp.toggleHighlight}
+			changeFontFamily={this.mockProp.changeFontFamily}
+			changeFontSize={this.mockProp.changeFontSize}
+			serif={this.mockProp.serif}
+			textHighlighterEnabled={this.mockProp.textHighlighterEnabled}
+			currentMode={this.mockProp.currentMode} />;
 		Clipper.logger = new StubSessionLogger();
 	}
 


### PR DESCRIPTION
Bug : In webclipper pane for both Article and Selection options, only Article title is appearing at header.
Problem : Article option is previewed with the help of AugmentationPreview class and Selection Option is previewed with the help of selectionPreview class. Both of these options are derived from the common base class EditorPreviewComponentBase.  This base class is used to set the header using getHeader function for both of them. The getHeader function uses PreviewViewerAugmentationHeader class to display all things related to Header for both of these options.  The PreviewViewerAugmentationHeader class has getTitle which is used to display header tile for both of these options. This function is common and uses the localization of Article for both the options. Hence in Selection option, Article is shown in header as title.

Solution : The Current mode of the Clipper State is set in getHeader function of EditorPreviewComponentBase class. This property is later used in getTitle of PreviewViewerAugmentationHeader class to differentiate between Article and Selection and use the respective Localization title.

Testing : tested the changes locally. Following are the screenshots before and after the changes.
Before : 
![MicrosoftTeams-image (4)](https://user-images.githubusercontent.com/125361438/234022609-c6d2eecd-e7b5-4f9f-8797-c020acbc3475.png)

After : 
![MicrosoftTeams-image (2)](https://user-images.githubusercontent.com/125361438/234022694-f885a274-c210-41da-8d63-5bc9846542c8.png)

![MicrosoftTeams-image (3)](https://user-images.githubusercontent.com/125361438/234022736-dadf1916-07ad-47ba-853d-bc4c8bd2c985.png)
