### PR TITLE
Reinitializing Aria Logger with the DataBoundary Pipeline config

### DIFF
--- a/src/scripts/extensions/authenticationHelper.ts
+++ b/src/scripts/extensions/authenticationHelper.ts
@@ -75,7 +75,7 @@ export class AuthenticationHelper {
 					// The default logging has been configured to EU Pipeline. Once we find the
 					// userdataboundary and if it is different from EUDB , reinit the logger with WW Pipeline
 					if (userDataBoundary === DataBoundary[DataBoundary.GLOBAL] || userDataBoundary === DataBoundary[DataBoundary.PUBLIC]) {
-						LogManager.reInitLoggerForDataBoundaryChange();
+						LogManager.reInitLoggerForDataBoundaryChange(userDataBoundary);
 					}
 					getInfoEvent.setCustomProperty(Log.PropertyName.Custom.DataBoundary, userDataBoundary);
 					response.data.dataBoundary = userDataBoundary;

--- a/src/scripts/extensions/authenticationHelper.ts
+++ b/src/scripts/extensions/authenticationHelper.ts
@@ -17,6 +17,7 @@ import {StringUtils} from "../stringUtils";
 import {UserInfoData} from "../userInfo";
 import { UrlUtils } from "../urlUtils";
 import { UserDataBoundaryHelper } from "./userDataBoundaryHelper";
+import { DataBoundary } from "./DataBoundary";
 
 declare var browser;
 
@@ -71,6 +72,11 @@ export class AuthenticationHelper {
 				if (isValidUser) {
 					const dataBoundaryHelper = new UserDataBoundaryHelper();
 					let userDataBoundary: string = await dataBoundaryHelper.getUserDataBoundary(response.data);
+					// The default logging has been configured to EU Pipeline. Once we find the
+					// userdataboundary and if it is different from EUDB , reinit the logger with WW Pipeline
+					if (userDataBoundary === DataBoundary[DataBoundary.GLOBAL] || userDataBoundary === DataBoundary[DataBoundary.PUBLIC]) {
+						LogManager.reInitLoggerForDataBoundaryChange();
+					}
 					getInfoEvent.setCustomProperty(Log.PropertyName.Custom.DataBoundary, userDataBoundary);
 					response.data.dataBoundary = userDataBoundary;
 					this.user.set({ user: response.data, lastUpdated: response.lastUpdated, updateReason: updateReason, writeableCookies: writeableCookies });

--- a/src/scripts/logging/logManager.d.ts
+++ b/src/scripts/logging/logManager.d.ts
@@ -9,5 +9,5 @@ declare module LogManager {
 		properties: { [key: string]: string };
 	}
 
-	export function reInitLoggerForDataBoundaryChange();
+	export function reInitLoggerForDataBoundaryChange(userDataBoundary: string);
 }

--- a/src/scripts/logging/logManager.d.ts
+++ b/src/scripts/logging/logManager.d.ts
@@ -8,4 +8,6 @@ declare module LogManager {
 		category: string;
 		properties: { [key: string]: string };
 	}
+
+	export function reInitLoggerForDataBoundaryChange();
 }

--- a/src/scripts/logging/logManager.ts
+++ b/src/scripts/logging/logManager.ts
@@ -42,3 +42,8 @@ function createDebugLogger(uiCommunicator: Communicator, sessionId: SmartValue<s
 export function sendMiscLogRequest(data: LogManager.MiscLogEventData, keysToCamelCase: boolean): void {
 	console.warn(JSON.stringify({ label: data.label, category: data.category, properties: data.properties }));
 }
+
+export function reInitLoggerForDataBoundaryChange(userDataBoundary: string): void {
+	let message: string = "DataBoundary different than default logging boundary :" + userDataBoundary;
+	console.log(message);
+}


### PR DESCRIPTION
Currently the default config pipeline for the Aria logging is done through EU route. This way we usually log to EU route before signing in. Once we sign in and get to know about the user data boundary, if the user data boundary is different from EUDB , Reinitialization of Aria Logger on LogManager is done. The changes related to reinit are part of WebClipper internal repo.