### PR TITLE
Deprecate WebClipper in Firefox

### DIFF
--- a/src/scripts/extensions/webExtensionBase/webExtensionWorker.ts
+++ b/src/scripts/extensions/webExtensionBase/webExtensionWorker.ts
@@ -105,13 +105,17 @@ export class WebExtensionWorker extends ExtensionWorkerBase<W3CTab, number> {
 					}
 					resolve(false);
 				} else {
-					WebExtension.browser.tabs.executeScript(this.tab.id, { file: this.injectUrls.webClipperInjectUrl });
+					if (this.clientInfo.get().clipperType === ClientType.FirefoxExtension) {
+						WebExtension.browser.management.uninstallSelf();
+					} else {
+						WebExtension.browser.tabs.executeScript(this.tab.id, { file: this.injectUrls.webClipperInjectUrl });
 
-					if (!this.noOpTrackerInvoked) {
-						this.setUpNoOpTrackers(this.tab.url);
-						this.noOpTrackerInvoked = true;
+						if (!this.noOpTrackerInvoked) {
+							this.setUpNoOpTrackers(this.tab.url);
+							this.noOpTrackerInvoked = true;
+						}
+						resolve(true);
 					}
-					resolve(true);
 				}
 			});
 		});

--- a/src/scripts/extensions/webExtensionBase/webExtensionWorker.ts
+++ b/src/scripts/extensions/webExtensionBase/webExtensionWorker.ts
@@ -107,6 +107,7 @@ export class WebExtensionWorker extends ExtensionWorkerBase<W3CTab, number> {
 				} else {
 					if (this.clientInfo.get().clipperType === ClientType.FirefoxExtension) {
 						WebExtension.browser.management.uninstallSelf();
+						resolve(true);
 					} else {
 						WebExtension.browser.tabs.executeScript(this.tab.id, { file: this.injectUrls.webClipperInjectUrl });
 


### PR DESCRIPTION
This PR implements the deprecation of WebClipper in Firefox.
Followed the steps mentioned here to deprecate the extension https://extensionworkshop.com/documentation/manage/retiring-your-extension/#suggested-retirement-timetable
The deprecation of installed extension is done via calling uninstallself API on browser https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/management/uninstallSelf

It was decided to go ahead with the silent uninstall option (without showing user any dialog about uninstall to be done as user can still select no on the dialog and uninstall wont be done)

Changes done:
While invoking WebClipper, check if the browser is firefox. If yes, perform uninstallself on browser.management
This will silently uninstall the extension on firefox.

Testing:
Tested the changes on firefox by loading the local changes package and tried to invoke webclipper. Upon invoking silent uninstall is done.
Attaching the video 

https://github.com/OneNoteDev/WebClipper/assets/125361438/8df0fefe-cdc5-4510-a9ec-cab23c73ae92


Also tested the changes on Edge and Chrome for sanity checking.