### PR TITLE
Updating the accessibility for mode buttons in Clipper

### DIFF
--- a/src/scripts/clipperUI/components/modeButtonSelector.tsx
+++ b/src/scripts/clipperUI/components/modeButtonSelector.tsx
@@ -15,13 +15,11 @@ class ModeButtonSelectorClass extends ComponentBase<{}, ClipperStateProp> {
 		});
 	};
 
-	private getScreenReaderThatAnnouncesCurrentModeProps(currentMode: ClipMode) {
+	private getScreenReaderThatAnnouncesCurrentModeProps(currentMode: ClipMode): string {
 		let stringToTellUserModeHasChanged = Localization.getLocalizedString("WebClipper.Accessibility.ScreenReader.CurrentModeHasChanged");
 		stringToTellUserModeHasChanged = stringToTellUserModeHasChanged.replace("{0}", ClipMode[currentMode]);
 
-		return (
-			<div aria-live="polite" aria-relevant="text" className={Constants.Classes.srOnly}>{stringToTellUserModeHasChanged}</div>
-		);
+		return stringToTellUserModeHasChanged;
 	}
 
 	private getPdfButtonProps(currentMode: ClipMode): PropsForModeElementNoAriaGrouping {
@@ -143,7 +141,8 @@ class ModeButtonSelectorClass extends ComponentBase<{}, ClipperStateProp> {
 		for (let i = 0; i < propsForVisibleButtons.length; i++) {
 			let attributes = propsForVisibleButtons[i];
 			let ariaPos = i + 1;
-			visibleButtons.push(<ModeButton {...attributes} aria-setsize={propsForVisibleButtons.length} aria-posinset={ariaPos} tabIndex={attributes.selected ? 40 : -1 } />);
+			visibleButtons.push(<ModeButton {...attributes} aria-setsize={propsForVisibleButtons.length}
+				aria-posinset={ariaPos} aria-selected={attributes.selected} />);
 		}
 		return visibleButtons;
 	}
@@ -152,9 +151,10 @@ class ModeButtonSelectorClass extends ComponentBase<{}, ClipperStateProp> {
 		let currentMode = this.props.clipperState.currentMode.get();
 
 		return (
-			<div>
-				{this.getScreenReaderThatAnnouncesCurrentModeProps(currentMode)}
-				<div style={Localization.getFontFamilyAsStyle(Localization.FontFamily.Semilight)} role="listbox" className="modeButtonContainer">
+			<div aria-live="polite" aria-relevant="text" role="group"
+				aria-label={ this.getScreenReaderThatAnnouncesCurrentModeProps(currentMode) }>
+				<div style={Localization.getFontFamilyAsStyle(Localization.FontFamily.Semilight)}
+					role="listbox" className="modeButtonContainer" aria-hidden="true">
 					{ this.getListOfButtons() }
 				</div>
 			</div>


### PR DESCRIPTION
VSO 7396201
Problem: In narrator mode when we move to the whole button group, we get the announcement "selected, selection contains 0 items". There is a view which announces the state but by tab we cannot reach that view. Moreover, only the button which was selected had tabIndex set as 40, rest all -1. This causes them to be hidden via the tab navigation.

Fix: Made all the buttons for different modes accessible via tab by removing the tabIndex option. 
Removed the extra view which had the state of the selection into the outlying div which contained the buttons and marked its role as a Group - this will announce "The current clipping mode is now '{0}'. Group".
Note: I did try to move the announcement to the listbox but it announced the selection state followed by "selected, selection contains 0 items". So went with the current approach. 
Verified with the accessibility PoC that solution is acceptable.

Testing: Tested on edge and chrome. When the focus goes to the Group of buttons it now announces "The current clipping mode is now '{0}'. Group". Then we can tab through the remaining buttons.