### PR TITLE
Run Credential Scanner

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,11 @@ steps:
     versionSpec: '10.x'
   displayName: 'Install Node.js'
 
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@3
+  inputs:
+    debugMode: false
+  displayName: Run Credential Scanner
+
 - script: |
     npm install
     npm run build:prod


### PR DESCRIPTION
As part of the Security Review for OneNote Web Clipper, we need to ensure that Static Code Analysis (SCA) Tools are run on every release build.

[Task 750319](https://o365trustcompliance.visualstudio.com/Trust/_workitems/edit/750319): Run Static Code Analysis (SCA) Tools on Every Release Build

Pipeline: https://office.visualstudio.com/OneNote/_build?definitionId=18476&_a=summary