### PR TITLE
Migrate XMLHttpRequest to fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11961,7 +11961,7 @@
         "node_modules/onenoteapi": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/onenoteapi/-/onenoteapi-1.1.0.tgz",
-            "integrity": "sha1-CiRqOzQenGNAzaj9JBsCCbzyNes=",
+            "integrity": "sha512-b+1dZFnM/yloRX0ydK6RNjuKUxuKojPHe0cOqmjZh3aoJkphUMtBdiQKlrp94ihCgpxtb6pOEvV04zBSqBpU/g==",
             "dev": true
         },
         "node_modules/onenotepicker": {
@@ -25888,7 +25888,7 @@
         "onenoteapi": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/onenoteapi/-/onenoteapi-1.1.0.tgz",
-            "integrity": "sha1-CiRqOzQenGNAzaj9JBsCCbzyNes=",
+            "integrity": "sha512-b+1dZFnM/yloRX0ydK6RNjuKUxuKojPHe0cOqmjZh3aoJkphUMtBdiQKlrp94ihCgpxtb6pOEvV04zBSqBpU/g==",
             "dev": true
         },
         "onenotepicker": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
             "name": "webclipper",
             "version": "3.9.5",
             "license": "MIT",
+            "dependencies": {
+                "jwt-decode": "^2.2.0"
+            },
             "devDependencies": {
                 "@types/chrome": "0.0.40",
                 "@types/es6-promise": "0.0.32",
@@ -64,7 +67,7 @@
                 "sinon-qunit": "2.0.0",
                 "ssl-root-cas": "1.2.3",
                 "tslint": "3.15.1",
-                "typescript": "2.1.6",
+                "typescript": "2.3.4",
                 "urijs": "1.19.6",
                 "velocity-animate": "1.4.2",
                 "vinyl-source-stream": "1.1.0",
@@ -343,18 +346,6 @@
             "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
             "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
             "dev": true
-        },
-        "node_modules/ansi-colors": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
-            "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
-            "dev": true,
-            "dependencies": {
-                "ansi-wrap": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/ansi-gray": {
             "version": "0.1.1",
@@ -2926,6 +2917,8 @@
         },
         "node_modules/cordova-lib/node_modules/ansi": {
             "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+            "integrity": "sha512-iFY7JCgHbepc0b82yLaw4IMortylNb6wG4kL+4R0C3iv6i+RHGHux/yUX5BTiRvSX/shMnngjR1YyNMnXEFh5A==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
@@ -2971,6 +2964,8 @@
         },
         "node_modules/cordova-lib/node_modules/base64-js": {
             "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+            "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -3002,6 +2997,8 @@
         },
         "node_modules/cordova-lib/node_modules/bplist-parser": {
             "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
+            "integrity": "sha512-2AEM0FXy8ZxVLBuqX0hqt1gDwcnz2zygEkQ6zaD5Wko/sB9paUNwlpawrFtKeHUAQUOzjVy9AO4oeonqIHKA9Q==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -3039,12 +3036,16 @@
         },
         "node_modules/cordova-lib/node_modules/concat-map": {
             "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/cordova-lib/node_modules/cordova-common": {
             "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/cordova-common/-/cordova-common-1.1.1.tgz",
+            "integrity": "sha512-tiWwGmi2T29N6oNS5Xd2ouCMq3v7z0yTwRmheMatpsCGjGZv/Q018T7CiEDorFKNIP4sXpa40yZ3NWK5QYgUDQ==",
             "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
@@ -3066,6 +3067,20 @@
                 "node": ">=0.9.9"
             }
         },
+        "node_modules/cordova-lib/node_modules/cordova-common/node_modules/elementtree": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/elementtree/-/elementtree-0.1.7.tgz",
+            "integrity": "sha512-wkgGT6kugeQk/P6VZ/f4T+4HB41BVgNBq5CDIZVbQ02nvTVqAiVTbskxxu3eA/X96lMlfYOwnLQpN2v5E1zDEg==",
+            "dev": true,
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "sax": "1.1.4"
+            },
+            "engines": {
+                "node": ">= 0.4.0"
+            }
+        },
         "node_modules/cordova-lib/node_modules/cordova-common/node_modules/q": {
             "version": "1.4.1",
             "dev": true,
@@ -3075,6 +3090,14 @@
                 "node": ">=0.6.0",
                 "teleport": ">=0.2.0"
             }
+        },
+        "node_modules/cordova-lib/node_modules/cordova-common/node_modules/sax": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
+            "integrity": "sha512-5f3k2PbGGp+YtKJjOItpg3P99IMD84E4HOvcfleTb5joCHNXYLsR9yWFPOYGgaeMPDubQILTCMdsFb2OMeOjtg==",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC"
         },
         "node_modules/cordova-lib/node_modules/cordova-common/node_modules/semver": {
             "version": "5.1.0",
@@ -3087,6 +3110,8 @@
         },
         "node_modules/cordova-lib/node_modules/cordova-common/node_modules/shelljs": {
             "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
+            "integrity": "sha512-C2FisSSW8S6TIYHHiMHN0NqzdjWfTekdMpA2FJTbRWnQMLO1RRIXEB9eVZYOlofYmjZA7fY3ChoFu09MeI3wlQ==",
             "dev": true,
             "inBundle": true,
             "license": "BSD*",
@@ -3103,8 +3128,21 @@
             "inBundle": true,
             "license": "MIT"
         },
+        "node_modules/cordova-lib/node_modules/cordova-common/node_modules/unorm": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
+            "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT or GPL-2.0",
+            "engines": {
+                "node": ">= 0.4.0"
+            }
+        },
         "node_modules/cordova-lib/node_modules/cordova-registry-mapper": {
             "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/cordova-registry-mapper/-/cordova-registry-mapper-1.1.15.tgz",
+            "integrity": "sha512-QHpSMAhaF7Zo5y2zddIJP/hWNJXvLTiIo81PdEfBQEvePCtUKRXBQLcYRfuSGetTZbT6sJFG7Djm2iZo7iZ3sQ==",
             "dev": true,
             "inBundle": true,
             "license": "Apache version 2.0"
@@ -3134,7 +3172,6 @@
         "node_modules/cordova-lib/node_modules/elementtree": {
             "version": "0.1.6",
             "dev": true,
-            "inBundle": true,
             "dependencies": {
                 "sax": "0.3.5"
             },
@@ -3167,6 +3204,8 @@
         },
         "node_modules/cordova-lib/node_modules/glob": {
             "version": "5.0.15",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+            "integrity": "sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -3239,6 +3278,8 @@
         },
         "node_modules/cordova-lib/node_modules/lodash": {
             "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+            "integrity": "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
@@ -3349,6 +3390,8 @@
         },
         "node_modules/cordova-lib/node_modules/plist": {
             "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/plist/-/plist-1.2.0.tgz",
+            "integrity": "sha512-dL9Xc2Aj3YyBnwvCNuHmFl2LWvQacm/HEAsoVwLiuu0POboMChETt5wexpU1P6F6MnibIucXlVsMFFgNUT2IyA==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -3406,7 +3449,6 @@
         "node_modules/cordova-lib/node_modules/sax": {
             "version": "0.3.5",
             "dev": true,
-            "inBundle": true,
             "license": "MIT",
             "engines": {
                 "node": "*"
@@ -3449,13 +3491,14 @@
         "node_modules/cordova-lib/node_modules/unorm": {
             "version": "1.3.3",
             "dev": true,
-            "inBundle": true,
             "engines": {
                 "node": ">= 0.4.0"
             }
         },
         "node_modules/cordova-lib/node_modules/util-deprecate": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
@@ -3468,6 +3511,8 @@
         },
         "node_modules/cordova-lib/node_modules/xmlbuilder": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.0.0.tgz",
+            "integrity": "sha512-wrG9gc6hCFDd5STt+6fsjP2aGSkjkNSewH+1K6s0KVOd94vXAUyTwlxWVnMFVtLdMf+q0QRZN1z9hTOKgoEdMg==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -6586,6 +6631,15 @@
                 "through": "^2.3.8"
             }
         },
+        "node_modules/gulp-merge-json/node_modules/json5": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+            "integrity": "sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==",
+            "dev": true,
+            "bin": {
+                "json5": "lib/cli.js"
+            }
+        },
         "node_modules/gulp-msx": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/gulp-msx/-/gulp-msx-0.4.0.tgz",
@@ -8133,18 +8187,6 @@
             "deprecated": "Please use the native JSON object instead of JSON 3",
             "dev": true
         },
-        "node_modules/json5": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-            "dev": true,
-            "bin": {
-                "json5": "lib/cli.js"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/jsonfile": {
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
@@ -8250,6 +8292,11 @@
             "engines": {
                 "node": ">=0.8.0"
             }
+        },
+        "node_modules/jwt-decode": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
+            "integrity": "sha512-86GgN2vzfUu7m9Wcj63iUkuDzFNYFVmjeDm2GzWpUk+opB0pEpMsw6ePCMrhYkumz2C1ihqtZzOMAg7FiXcNoQ=="
         },
         "node_modules/kew": {
             "version": "0.7.0",
@@ -8556,12 +8603,6 @@
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-            "dev": true
-        },
-        "node_modules/lodash.mergewith": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-            "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
             "dev": true
         },
         "node_modules/lodash.partialright": {
@@ -9729,12 +9770,16 @@
         },
         "node_modules/npm/node_modules/abbrev": {
             "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+            "integrity": "sha512-LEyx4aLEC3x6T0UguF6YILf+ntvmOaWsVfENmIW0E9H09vKlLDGelMjjSm0jkDHALj8A8quZ/HapKNigzwge+Q==",
             "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/ansi": {
             "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+            "integrity": "sha512-iFY7JCgHbepc0b82yLaw4IMortylNb6wG4kL+4R0C3iv6i+RHGHux/yUX5BTiRvSX/shMnngjR1YyNMnXEFh5A==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
@@ -9750,24 +9795,32 @@
         },
         "node_modules/npm/node_modules/ansicolors": {
             "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+            "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/ansistyles": {
             "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
+            "integrity": "sha512-6QWEyvMgIXX0eO972y7YPBLSBsq7UWKFAoNNTLGaOJ9bstcEL9sCbcjf96dVfNDdUsRoGOK82vWFJlKApXds7g==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/archy": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+            "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/async-some": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/async-some/-/async-some-1.0.2.tgz",
+            "integrity": "sha512-VbEsqdl4ztEqzb3Cgpk9L81Q4eyMl3XFdA0i+12Qmyw/bNx4aDAJqmIMKXh1mKGJ2IaPvGvN682YKZDaJMLUdA==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -9777,6 +9830,8 @@
         },
         "node_modules/npm/node_modules/block-stream": {
             "version": "0.0.9",
+            "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+            "integrity": "sha512-OorbnJVPII4DuUKbjARAe8u8EfqOmkEEaSFIyoQ7OjTHn6kafxWl0wLgoZ2rXaYd7MyLcDaU4TmhfxtwgcccMQ==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -9789,24 +9844,32 @@
         },
         "node_modules/npm/node_modules/char-spinner": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/char-spinner/-/char-spinner-1.0.1.tgz",
+            "integrity": "sha512-acv43vqJ0+N0rD+Uw3pDHSxP30FHrywu2NO6/wBaHChJIizpDeBUd6NjqhNhy9LGaEAhZAXn46QzmlAvIWd16g==",
             "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/chmodr": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-1.0.2.tgz",
+            "integrity": "sha512-oHosCxCZpaI/Db320r8M5SHHZuVfnFJVwkSGkI81QLnnVg25pDw//NgD4fy1WvvydhZNi2G+jrbNSprRkfbRYA==",
             "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/chownr": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+            "integrity": "sha512-cKnqUJAC8G6cuN1DiRRTifu+s1BlAQNtalzGphFEV0pl0p46dsxJD4l1AOlyKJeLZOFzo3c34R7F3djxaCu8Kw==",
             "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/cmd-shim": {
             "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
+            "integrity": "sha512-NLt0ntM0kvuSNrToO0RTFiNRHdioWsLW+OgDAEVDvIivsYwR+AjlzvLaMJ2Z+SNRpV3vdsDrHp1WI00eetDYzw==",
             "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
@@ -9817,6 +9880,8 @@
         },
         "node_modules/npm/node_modules/columnify": {
             "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+            "integrity": "sha512-rFl+iXVT1nhLQPfGDw+3WcS8rmm7XsLKUmhsGE3ihzzpIikeGrTaZPIRKYWeLsLBypsHzjXIvYEltVUZS84XxQ==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -9885,6 +9950,8 @@
         },
         "node_modules/npm/node_modules/editor": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
+            "integrity": "sha512-SoRmbGStwNYHgKfjOrX2L0mUvp9bUVv0uPppZSOMAntEbcFtoC3MKF5b3T6HQPXKIV+QGY3xPO3JK5it5lVkuw==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
@@ -9935,6 +10002,8 @@
         },
         "node_modules/npm/node_modules/fstream-npm": {
             "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.1.1.tgz",
+            "integrity": "sha512-zKZuzxog3e6wPg22PC1UoI+efTOCtngC2b6qAZpUZu3t9oB3A+MuLIUosVPPFVmq6+WZsHZ3h1bhGazc4E9a7Q==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -9956,18 +10025,24 @@
         },
         "node_modules/npm/node_modules/github-url-from-git": {
             "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.4.0.tgz",
+            "integrity": "sha512-Vd1uAwEIbUaaYodSvEZRgMOdLUvY7+kZ+PuJNPVBXldTuVcHFtcLENvl2Ds9KKO9q6Ld2o+eVmA/wabaN3/2mQ==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/github-url-from-username-repo": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/github-url-from-username-repo/-/github-url-from-username-repo-1.0.2.tgz",
+            "integrity": "sha512-Tj8CQqRoFVTglGdQ8FQmfq8gOOoOYZX7tnOKP8jq8Hdz2OTDhxvtlkLAbrqMYZ7X/YdaYQoUG1IBWxISBfqZ+Q==",
             "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause"
         },
         "node_modules/npm/node_modules/glob": {
             "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+            "integrity": "sha512-f8c0rE8JiCxpa52kWPAOa3ZaYEnzofDzCQLCn3Vdk0Z5OVLq3BsRFJI4S4ykpeVW6QMGBUkMeUpoEgWnMTnw5Q==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -10009,12 +10084,16 @@
         },
         "node_modules/npm/node_modules/hosted-git-info": {
             "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
+            "integrity": "sha512-5sLwVGWIA8493A2PzG/py8s+uBrYqrwmLp6C6U5+Gpw5Ll49OOigsuD4LKbUTExbgedTNPvPb/0GV5ohHYYNBg==",
             "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/imurmurhash": {
             "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -10215,6 +10294,8 @@
         },
         "node_modules/npm/node_modules/nopt": {
             "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+            "integrity": "sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -10227,6 +10308,8 @@
         },
         "node_modules/npm/node_modules/normalize-git-url": {
             "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/normalize-git-url/-/normalize-git-url-3.0.2.tgz",
+            "integrity": "sha512-UEmKT33ssKLLoLCsFJ4Si4fmNQsedNwivXpuNTR4V1I97jU9WZlicTV1xn5QAG5itE5B3Z9zhl8OItP6wIGkRA==",
             "dev": true,
             "inBundle": true,
             "license": "ISC"
@@ -10266,12 +10349,16 @@
         },
         "node_modules/npm/node_modules/npm-cache-filename": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
+            "integrity": "sha512-5v2y1KG06izpGvZJDSBR5q1Ej+NaPDO05yAAWBJE6+3eiId0R176Gz3Qc2vEmJnE+VGul84g6Qpq8fXzD82/JA==",
             "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/npm-install-checks": {
             "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-1.0.7.tgz",
+            "integrity": "sha512-IyaSpkt3NMXaXezbnHxwEZ6HBWpQFlKBUZ0ZEoUCyq3LoAaZEWJ2mchhJPauuvevhkvi8SNW67FiWZLpUhJ82w==",
             "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
@@ -10292,6 +10379,8 @@
         },
         "node_modules/npm/node_modules/npm-registry-client": {
             "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-7.2.1.tgz",
+            "integrity": "sha512-igXKTHWr0ipuL+pKNRBV2p2H4xqfnpVtYiWQmTKfq5/eFmZxKh9U+PyoqdKzqyvPTFLNQVqMGy5W5GjOr1Ukeg==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -10385,12 +10474,16 @@
         },
         "node_modules/npm/node_modules/npm-user-validate": {
             "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-0.1.5.tgz",
+            "integrity": "sha512-86IbFCunHe+6drSd71Aafs8H8xg55lHE9O1/6VS4s+OsBh53xEtQNY1lspkgoaO2b3hhfvDW2FA0eS47inrs1w==",
             "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause"
         },
         "node_modules/npm/node_modules/npmlog": {
             "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
+            "integrity": "sha512-DaL6RTb8Qh4tMe2ttPT1qWccETy2Vi5/8p+htMpLBeXJTr2CAqnF5WQtSP2eFpvaNbhLZ5uilDb98mRm4Q+lZQ==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -10488,6 +10581,8 @@
         },
         "node_modules/npm/node_modules/once": {
             "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -10540,6 +10635,8 @@
         },
         "node_modules/npm/node_modules/read": {
             "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+            "integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -10552,6 +10649,8 @@
         },
         "node_modules/npm/node_modules/read-installed": {
             "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
+            "integrity": "sha512-O03wg/IYuV/VtnK2h/KXEt9VIbMUFbk3ERG0Iu4FhLZw0EP0T9znqrYDGn6ncbEsXUFaUjiVAWXHzxwt3lhRPQ==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -10569,6 +10668,8 @@
         },
         "node_modules/npm/node_modules/read-installed/node_modules/debuglog": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+            "integrity": "sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -10656,6 +10757,8 @@
         },
         "node_modules/npm/node_modules/readable-stream": {
             "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+            "integrity": "sha512-NkXT2AER7VKXeXtJNSaWLpWIhmtSE3K2PguaLEeWr4JILghcIKqoLt1A3wHrnpDC5+ekf8gfk1GKWkFXe4odMw==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -10717,6 +10820,8 @@
         },
         "node_modules/npm/node_modules/request": {
             "version": "2.74.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
+            "integrity": "sha512-m3uMovC42y63jXe/Sr49/qJdqpSYwQAgYIc487l0zSXI6Z6f5cV/V4a86h2Z+AAwKpt5bfB66KrZxOfOSdh6FQ==",
             "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
@@ -11057,6 +11162,8 @@
         },
         "node_modules/npm/node_modules/request/node_modules/hawk/node_modules/boom": {
             "version": "2.10.1",
+            "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+            "integrity": "sha512-KbiZEa9/vofNcVJXGwdWWn25reQ3V3dHBWbS07FTF3/TOehLnm9GEhJV4T6ZvGPkShRpmUqYwnaCrkj0mRnP6Q==",
             "dev": true,
             "inBundle": true,
             "license": "BSD-3-Clause",
@@ -11081,6 +11188,8 @@
         },
         "node_modules/npm/node_modules/request/node_modules/hawk/node_modules/hoek": {
             "version": "2.16.3",
+            "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+            "integrity": "sha512-V6Yw1rIcYV/4JsnggjBU0l4Kr+EXhpwqXRusENU1Xx6ro00IHPHYNynCuBTOZAPlr3AAmLvchH9I7N/VUdvOwQ==",
             "dev": true,
             "inBundle": true,
             "license": "BSD-3-Clause",
@@ -11133,7 +11242,7 @@
             "license": "MIT",
             "dependencies": {
                 "extsprintf": "1.0.2",
-                "json-schema": "0.4.0",
+                "json-schema": "0.2.2",
                 "verror": "1.3.6"
             }
         },
@@ -11146,7 +11255,7 @@
             "inBundle": true
         },
         "node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/jsprim/node_modules/json-schema": {
-            "version": "0.4.0",
+            "version": "0.2.2",
             "dev": true,
             "inBundle": true
         },
@@ -11195,6 +11304,8 @@
         },
         "node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/node_modules/assert-plus": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -11357,6 +11468,8 @@
         },
         "node_modules/npm/node_modules/rimraf": {
             "version": "2.5.4",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+            "integrity": "sha512-Lw7SHMjssciQb/rRz7JyPIy9+bbUshEucPoLRvWqy09vC5zQixl8Uet+Zl+SROBB/JMWHJRdCk1qdxNWHNMvlQ==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -11378,6 +11491,8 @@
         },
         "node_modules/npm/node_modules/sha": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
+            "integrity": "sha512-Lj/GiNro+/4IIvhDvTo2HDqTmQkbqgg/O3lbkM5lMgagriGPpWamxtq1KJPx7mCvyF1/HG6Hs7zaYaj4xpfXbA==",
             "dev": true,
             "inBundle": true,
             "license": "(BSD-2-Clause OR MIT)",
@@ -11432,6 +11547,8 @@
         },
         "node_modules/npm/node_modules/slide": {
             "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+            "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -11447,12 +11564,16 @@
         },
         "node_modules/npm/node_modules/spdx-license-ids": {
             "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+            "integrity": "sha512-qIBFhkh6ILCWNeWEe3ODFPKDYhPJrZpqdNCI2Z+w9lNdH5hoVEkfRLLbRfoIi8fb4xRYmpEOaaMH4G2pwYp/iQ==",
             "dev": true,
             "inBundle": true,
             "license": "Unlicense"
         },
         "node_modules/npm/node_modules/strip-ansi": {
             "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -11476,12 +11597,16 @@
         },
         "node_modules/npm/node_modules/text-table": {
             "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+            "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/uid-number": {
             "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+            "integrity": "sha512-c461FXIljswCuscZn67xq9PpszkPT6RjheWFQTgCyabJrTUozElanb0YEqv2UGgk247YpcJkFBuSGNvBlpXM9w==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -11491,6 +11616,8 @@
         },
         "node_modules/npm/node_modules/umask": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
+            "integrity": "sha512-lE/rxOhmiScJu9L6RTNVgB/zZbF+vGC0/p6D3xnkAePI2o0sMyFG966iR5Ki50OI/0mNi2yaRnxfLsPmEZF/JA==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
@@ -11532,6 +11659,8 @@
         },
         "node_modules/npm/node_modules/validate-npm-package-name": {
             "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-2.2.2.tgz",
+            "integrity": "sha512-zt38kWHt0j/tv8ZKqZB5lEVT3A41JarczU/ib7L+OXZFAjC2l9kPeujQI1m4smU1nmSwF06MqEetltqVkDmnuQ==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -11565,12 +11694,16 @@
         },
         "node_modules/npm/node_modules/wrappy": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/write-file-atomic": {
             "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz",
+            "integrity": "sha512-c5qespPIeoD/YQTLgdOTe9mcjhK0MhK/URjnIlpuF+4Hoec1flfMRcZY+SWrqGHHRC1oGY1VyNC44wiLQgJMiw==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -12276,30 +12409,6 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/plugin-error": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
-            "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
-            "dev": true,
-            "dependencies": {
-                "ansi-colors": "^1.0.1",
-                "arr-diff": "^4.0.0",
-                "arr-union": "^3.1.0",
-                "extend-shallow": "^3.0.2"
-            },
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/plugin-error/node_modules/arr-diff": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-            "integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/popper.js": {
@@ -14872,9 +14981,9 @@
             "dev": true
         },
         "node_modules/typescript": {
-            "version": "2.1.6",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.1.6.tgz",
-            "integrity": "sha1-QMfm6eXaeWG3cYtVUF+crJSHpgc=",
+            "version": "2.3.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.3.4.tgz",
+            "integrity": "sha512-+3YA3hpUsl9lWPPsPQshiyXvU9EgJhvMoG2V74b6D2BddGePqRbQWNztTvpoUjlpf+3TUIL14C4Cad4QNvOVfQ==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -16052,15 +16161,6 @@
             "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
             "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
             "dev": true
-        },
-        "ansi-colors": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
-            "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
-            "dev": true,
-            "requires": {
-                "ansi-wrap": "^0.1.0"
-            }
         },
         "ansi-gray": {
             "version": "0.1.1",
@@ -18321,6 +18421,8 @@
             "dependencies": {
                 "ansi": {
                     "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+                    "integrity": "sha512-iFY7JCgHbepc0b82yLaw4IMortylNb6wG4kL+4R0C3iv6i+RHGHux/yUX5BTiRvSX/shMnngjR1YyNMnXEFh5A==",
                     "bundled": true,
                     "dev": true
                 },
@@ -18355,6 +18457,8 @@
                 },
                 "base64-js": {
                     "version": "0.0.8",
+                    "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+                    "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
                     "bundled": true,
                     "dev": true
                 },
@@ -18374,6 +18478,8 @@
                 },
                 "bplist-parser": {
                     "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
+                    "integrity": "sha512-2AEM0FXy8ZxVLBuqX0hqt1gDwcnz2zygEkQ6zaD5Wko/sB9paUNwlpawrFtKeHUAQUOzjVy9AO4oeonqIHKA9Q==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -18406,11 +18512,15 @@
                 },
                 "concat-map": {
                     "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                    "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
                     "bundled": true,
                     "dev": true
                 },
                 "cordova-common": {
                     "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/cordova-common/-/cordova-common-1.1.1.tgz",
+                    "integrity": "sha512-tiWwGmi2T29N6oNS5Xd2ouCMq3v7z0yTwRmheMatpsCGjGZv/Q018T7CiEDorFKNIP4sXpa40yZ3NWK5QYgUDQ==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -18428,8 +18538,25 @@
                         "unorm": "^1.3.3"
                     },
                     "dependencies": {
+                        "elementtree": {
+                            "version": "0.1.7",
+                            "resolved": "https://registry.npmjs.org/elementtree/-/elementtree-0.1.7.tgz",
+                            "integrity": "sha512-wkgGT6kugeQk/P6VZ/f4T+4HB41BVgNBq5CDIZVbQ02nvTVqAiVTbskxxu3eA/X96lMlfYOwnLQpN2v5E1zDEg==",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "sax": "1.1.4"
+                            }
+                        },
                         "q": {
                             "version": "1.4.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "sax": {
+                            "version": "1.1.4",
+                            "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
+                            "integrity": "sha512-5f3k2PbGGp+YtKJjOItpg3P99IMD84E4HOvcfleTb5joCHNXYLsR9yWFPOYGgaeMPDubQILTCMdsFb2OMeOjtg==",
                             "bundled": true,
                             "dev": true
                         },
@@ -18440,6 +18567,8 @@
                         },
                         "shelljs": {
                             "version": "0.5.3",
+                            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
+                            "integrity": "sha512-C2FisSSW8S6TIYHHiMHN0NqzdjWfTekdMpA2FJTbRWnQMLO1RRIXEB9eVZYOlofYmjZA7fY3ChoFu09MeI3wlQ==",
                             "bundled": true,
                             "dev": true
                         },
@@ -18447,11 +18576,20 @@
                             "version": "1.8.3",
                             "bundled": true,
                             "dev": true
+                        },
+                        "unorm": {
+                            "version": "1.6.0",
+                            "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
+                            "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==",
+                            "bundled": true,
+                            "dev": true
                         }
                     }
                 },
                 "cordova-registry-mapper": {
                     "version": "1.1.15",
+                    "resolved": "https://registry.npmjs.org/cordova-registry-mapper/-/cordova-registry-mapper-1.1.15.tgz",
+                    "integrity": "sha512-QHpSMAhaF7Zo5y2zddIJP/hWNJXvLTiIo81PdEfBQEvePCtUKRXBQLcYRfuSGetTZbT6sJFG7Djm2iZo7iZ3sQ==",
                     "bundled": true,
                     "dev": true
                 },
@@ -18472,7 +18610,6 @@
                 },
                 "elementtree": {
                     "version": "0.1.6",
-                    "bundled": true,
                     "dev": true,
                     "requires": {
                         "sax": "0.3.5"
@@ -18497,6 +18634,8 @@
                 },
                 "glob": {
                     "version": "5.0.15",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                    "integrity": "sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -18552,6 +18691,8 @@
                 },
                 "lodash": {
                     "version": "3.10.1",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                    "integrity": "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ==",
                     "bundled": true,
                     "dev": true
                 },
@@ -18630,6 +18771,8 @@
                 },
                 "plist": {
                     "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/plist/-/plist-1.2.0.tgz",
+                    "integrity": "sha512-dL9Xc2Aj3YyBnwvCNuHmFl2LWvQacm/HEAsoVwLiuu0POboMChETt5wexpU1P6F6MnibIucXlVsMFFgNUT2IyA==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -18677,7 +18820,6 @@
                 },
                 "sax": {
                     "version": "0.3.5",
-                    "bundled": true,
                     "dev": true
                 },
                 "shelljs": {
@@ -18703,11 +18845,12 @@
                 },
                 "unorm": {
                     "version": "1.3.3",
-                    "bundled": true,
                     "dev": true
                 },
                 "util-deprecate": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                    "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
                     "bundled": true,
                     "dev": true
                 },
@@ -18718,6 +18861,8 @@
                 },
                 "xmlbuilder": {
                     "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.0.0.tgz",
+                    "integrity": "sha512-wrG9gc6hCFDd5STt+6fsjP2aGSkjkNSewH+1K6s0KVOd94vXAUyTwlxWVnMFVtLdMf+q0QRZN1z9hTOKgoEdMg==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -21330,6 +21475,14 @@
                 "json5": "^0.5.0",
                 "lodash": "^4.6.1",
                 "through": "^2.3.8"
+            },
+            "dependencies": {
+                "json5": {
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+                    "integrity": "sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==",
+                    "dev": true
+                }
             }
         },
         "gulp-msx": {
@@ -22622,12 +22775,6 @@
             "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
             "dev": true
         },
-        "json5": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-            "dev": true
-        },
         "jsonfile": {
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
@@ -22706,6 +22853,11 @@
                     }
                 }
             }
+        },
+        "jwt-decode": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
+            "integrity": "sha512-86GgN2vzfUu7m9Wcj63iUkuDzFNYFVmjeDm2GzWpUk+opB0pEpMsw6ePCMrhYkumz2C1ihqtZzOMAg7FiXcNoQ=="
         },
         "kew": {
             "version": "0.7.0",
@@ -22980,12 +23132,6 @@
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-            "dev": true
-        },
-        "lodash.mergewith": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-            "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
             "dev": true
         },
         "lodash.partialright": {
@@ -23903,11 +24049,15 @@
             "dependencies": {
                 "abbrev": {
                     "version": "1.0.9",
+                    "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+                    "integrity": "sha512-LEyx4aLEC3x6T0UguF6YILf+ntvmOaWsVfENmIW0E9H09vKlLDGelMjjSm0jkDHALj8A8quZ/HapKNigzwge+Q==",
                     "bundled": true,
                     "dev": true
                 },
                 "ansi": {
                     "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+                    "integrity": "sha512-iFY7JCgHbepc0b82yLaw4IMortylNb6wG4kL+4R0C3iv6i+RHGHux/yUX5BTiRvSX/shMnngjR1YyNMnXEFh5A==",
                     "bundled": true,
                     "dev": true
                 },
@@ -23918,21 +24068,29 @@
                 },
                 "ansicolors": {
                     "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+                    "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==",
                     "bundled": true,
                     "dev": true
                 },
                 "ansistyles": {
                     "version": "0.1.3",
+                    "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
+                    "integrity": "sha512-6QWEyvMgIXX0eO972y7YPBLSBsq7UWKFAoNNTLGaOJ9bstcEL9sCbcjf96dVfNDdUsRoGOK82vWFJlKApXds7g==",
                     "bundled": true,
                     "dev": true
                 },
                 "archy": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+                    "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
                     "bundled": true,
                     "dev": true
                 },
                 "async-some": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/async-some/-/async-some-1.0.2.tgz",
+                    "integrity": "sha512-VbEsqdl4ztEqzb3Cgpk9L81Q4eyMl3XFdA0i+12Qmyw/bNx4aDAJqmIMKXh1mKGJ2IaPvGvN682YKZDaJMLUdA==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -23941,6 +24099,8 @@
                 },
                 "block-stream": {
                     "version": "0.0.9",
+                    "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+                    "integrity": "sha512-OorbnJVPII4DuUKbjARAe8u8EfqOmkEEaSFIyoQ7OjTHn6kafxWl0wLgoZ2rXaYd7MyLcDaU4TmhfxtwgcccMQ==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -23949,21 +24109,29 @@
                 },
                 "char-spinner": {
                     "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/char-spinner/-/char-spinner-1.0.1.tgz",
+                    "integrity": "sha512-acv43vqJ0+N0rD+Uw3pDHSxP30FHrywu2NO6/wBaHChJIizpDeBUd6NjqhNhy9LGaEAhZAXn46QzmlAvIWd16g==",
                     "bundled": true,
                     "dev": true
                 },
                 "chmodr": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-1.0.2.tgz",
+                    "integrity": "sha512-oHosCxCZpaI/Db320r8M5SHHZuVfnFJVwkSGkI81QLnnVg25pDw//NgD4fy1WvvydhZNi2G+jrbNSprRkfbRYA==",
                     "bundled": true,
                     "dev": true
                 },
                 "chownr": {
                     "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+                    "integrity": "sha512-cKnqUJAC8G6cuN1DiRRTifu+s1BlAQNtalzGphFEV0pl0p46dsxJD4l1AOlyKJeLZOFzo3c34R7F3djxaCu8Kw==",
                     "bundled": true,
                     "dev": true
                 },
                 "cmd-shim": {
                     "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
+                    "integrity": "sha512-NLt0ntM0kvuSNrToO0RTFiNRHdioWsLW+OgDAEVDvIivsYwR+AjlzvLaMJ2Z+SNRpV3vdsDrHp1WI00eetDYzw==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -23973,6 +24141,8 @@
                 },
                 "columnify": {
                     "version": "1.5.4",
+                    "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+                    "integrity": "sha512-rFl+iXVT1nhLQPfGDw+3WcS8rmm7XsLKUmhsGE3ihzzpIikeGrTaZPIRKYWeLsLBypsHzjXIvYEltVUZS84XxQ==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24041,6 +24211,8 @@
                 },
                 "editor": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
+                    "integrity": "sha512-SoRmbGStwNYHgKfjOrX2L0mUvp9bUVv0uPppZSOMAntEbcFtoC3MKF5b3T6HQPXKIV+QGY3xPO3JK5it5lVkuw==",
                     "bundled": true,
                     "dev": true
                 },
@@ -24085,6 +24257,8 @@
                 },
                 "fstream-npm": {
                     "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.1.1.tgz",
+                    "integrity": "sha512-zKZuzxog3e6wPg22PC1UoI+efTOCtngC2b6qAZpUZu3t9oB3A+MuLIUosVPPFVmq6+WZsHZ3h1bhGazc4E9a7Q==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24106,16 +24280,22 @@
                 },
                 "github-url-from-git": {
                     "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.4.0.tgz",
+                    "integrity": "sha512-Vd1uAwEIbUaaYodSvEZRgMOdLUvY7+kZ+PuJNPVBXldTuVcHFtcLENvl2Ds9KKO9q6Ld2o+eVmA/wabaN3/2mQ==",
                     "bundled": true,
                     "dev": true
                 },
                 "github-url-from-username-repo": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/github-url-from-username-repo/-/github-url-from-username-repo-1.0.2.tgz",
+                    "integrity": "sha512-Tj8CQqRoFVTglGdQ8FQmfq8gOOoOYZX7tnOKP8jq8Hdz2OTDhxvtlkLAbrqMYZ7X/YdaYQoUG1IBWxISBfqZ+Q==",
                     "bundled": true,
                     "dev": true
                 },
                 "glob": {
                     "version": "7.0.6",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+                    "integrity": "sha512-f8c0rE8JiCxpa52kWPAOa3ZaYEnzofDzCQLCn3Vdk0Z5OVLq3BsRFJI4S4ykpeVW6QMGBUkMeUpoEgWnMTnw5Q==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24146,11 +24326,15 @@
                 },
                 "hosted-git-info": {
                     "version": "2.1.5",
+                    "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
+                    "integrity": "sha512-5sLwVGWIA8493A2PzG/py8s+uBrYqrwmLp6C6U5+Gpw5Ll49OOigsuD4LKbUTExbgedTNPvPb/0GV5ohHYYNBg==",
                     "bundled": true,
                     "dev": true
                 },
                 "imurmurhash": {
                     "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+                    "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
                     "bundled": true,
                     "dev": true
                 },
@@ -24318,6 +24502,8 @@
                 },
                 "nopt": {
                     "version": "3.0.6",
+                    "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+                    "integrity": "sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24326,6 +24512,8 @@
                 },
                 "normalize-git-url": {
                     "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/normalize-git-url/-/normalize-git-url-3.0.2.tgz",
+                    "integrity": "sha512-UEmKT33ssKLLoLCsFJ4Si4fmNQsedNwivXpuNTR4V1I97jU9WZlicTV1xn5QAG5itE5B3Z9zhl8OItP6wIGkRA==",
                     "bundled": true,
                     "dev": true
                 },
@@ -24359,11 +24547,15 @@
                 },
                 "npm-cache-filename": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
+                    "integrity": "sha512-5v2y1KG06izpGvZJDSBR5q1Ej+NaPDO05yAAWBJE6+3eiId0R176Gz3Qc2vEmJnE+VGul84g6Qpq8fXzD82/JA==",
                     "bundled": true,
                     "dev": true
                 },
                 "npm-install-checks": {
                     "version": "1.0.7",
+                    "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-1.0.7.tgz",
+                    "integrity": "sha512-IyaSpkt3NMXaXezbnHxwEZ6HBWpQFlKBUZ0ZEoUCyq3LoAaZEWJ2mchhJPauuvevhkvi8SNW67FiWZLpUhJ82w==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24382,6 +24574,8 @@
                 },
                 "npm-registry-client": {
                     "version": "7.2.1",
+                    "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-7.2.1.tgz",
+                    "integrity": "sha512-igXKTHWr0ipuL+pKNRBV2p2H4xqfnpVtYiWQmTKfq5/eFmZxKh9U+PyoqdKzqyvPTFLNQVqMGy5W5GjOr1Ukeg==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24463,11 +24657,15 @@
                 },
                 "npm-user-validate": {
                     "version": "0.1.5",
+                    "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-0.1.5.tgz",
+                    "integrity": "sha512-86IbFCunHe+6drSd71Aafs8H8xg55lHE9O1/6VS4s+OsBh53xEtQNY1lspkgoaO2b3hhfvDW2FA0eS47inrs1w==",
                     "bundled": true,
                     "dev": true
                 },
                 "npmlog": {
                     "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
+                    "integrity": "sha512-DaL6RTb8Qh4tMe2ttPT1qWccETy2Vi5/8p+htMpLBeXJTr2CAqnF5WQtSP2eFpvaNbhLZ5uilDb98mRm4Q+lZQ==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24560,6 +24758,8 @@
                 },
                 "once": {
                     "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                    "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24599,6 +24799,8 @@
                 },
                 "read": {
                     "version": "1.0.7",
+                    "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+                    "integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24614,6 +24816,8 @@
                 },
                 "read-installed": {
                     "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
+                    "integrity": "sha512-O03wg/IYuV/VtnK2h/KXEt9VIbMUFbk3ERG0Iu4FhLZw0EP0T9znqrYDGn6ncbEsXUFaUjiVAWXHzxwt3lhRPQ==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24628,6 +24832,8 @@
                     "dependencies": {
                         "debuglog": {
                             "version": "1.0.1",
+                            "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+                            "integrity": "sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==",
                             "bundled": true,
                             "dev": true
                         },
@@ -24698,6 +24904,8 @@
                 },
                 "readable-stream": {
                     "version": "2.1.5",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+                    "integrity": "sha512-NkXT2AER7VKXeXtJNSaWLpWIhmtSE3K2PguaLEeWr4JILghcIKqoLt1A3wHrnpDC5+ekf8gfk1GKWkFXe4odMw==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24753,6 +24961,8 @@
                 },
                 "request": {
                     "version": "2.74.0",
+                    "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
+                    "integrity": "sha512-m3uMovC42y63jXe/Sr49/qJdqpSYwQAgYIc487l0zSXI6Z6f5cV/V4a86h2Z+AAwKpt5bfB66KrZxOfOSdh6FQ==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -25022,6 +25232,8 @@
                             "dependencies": {
                                 "boom": {
                                     "version": "2.10.1",
+                                    "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                                    "integrity": "sha512-KbiZEa9/vofNcVJXGwdWWn25reQ3V3dHBWbS07FTF3/TOehLnm9GEhJV4T6ZvGPkShRpmUqYwnaCrkj0mRnP6Q==",
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
@@ -25038,6 +25250,8 @@
                                 },
                                 "hoek": {
                                     "version": "2.16.3",
+                                    "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                                    "integrity": "sha512-V6Yw1rIcYV/4JsnggjBU0l4Kr+EXhpwqXRusENU1Xx6ro00IHPHYNynCuBTOZAPlr3AAmLvchH9I7N/VUdvOwQ==",
                                     "bundled": true,
                                     "dev": true
                                 },
@@ -25072,7 +25286,7 @@
                                     "dev": true,
                                     "requires": {
                                         "extsprintf": "1.0.2",
-                                        "json-schema": "0.4.0",
+                                        "json-schema": "0.2.2",
                                         "verror": "1.3.6"
                                     },
                                     "dependencies": {
@@ -25082,7 +25296,7 @@
                                             "dev": true
                                         },
                                         "json-schema": {
-                                            "version": "0.4.0",
+                                            "version": "0.2.2",
                                             "bundled": true,
                                             "dev": true
                                         },
@@ -25118,6 +25332,8 @@
                                         },
                                         "assert-plus": {
                                             "version": "1.0.0",
+                                            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                                            "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
                                             "bundled": true,
                                             "dev": true
                                         },
@@ -25240,6 +25456,8 @@
                 },
                 "rimraf": {
                     "version": "2.5.4",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+                    "integrity": "sha512-Lw7SHMjssciQb/rRz7JyPIy9+bbUshEucPoLRvWqy09vC5zQixl8Uet+Zl+SROBB/JMWHJRdCk1qdxNWHNMvlQ==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -25253,6 +25471,8 @@
                 },
                 "sha": {
                     "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
+                    "integrity": "sha512-Lj/GiNro+/4IIvhDvTo2HDqTmQkbqgg/O3lbkM5lMgagriGPpWamxtq1KJPx7mCvyF1/HG6Hs7zaYaj4xpfXbA==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -25304,6 +25524,8 @@
                 },
                 "slide": {
                     "version": "1.1.6",
+                    "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+                    "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
                     "bundled": true,
                     "dev": true
                 },
@@ -25314,11 +25536,15 @@
                 },
                 "spdx-license-ids": {
                     "version": "1.2.2",
+                    "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+                    "integrity": "sha512-qIBFhkh6ILCWNeWEe3ODFPKDYhPJrZpqdNCI2Z+w9lNdH5hoVEkfRLLbRfoIi8fb4xRYmpEOaaMH4G2pwYp/iQ==",
                     "bundled": true,
                     "dev": true
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -25337,16 +25563,22 @@
                 },
                 "text-table": {
                     "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+                    "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
                     "bundled": true,
                     "dev": true
                 },
                 "uid-number": {
                     "version": "0.0.6",
+                    "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+                    "integrity": "sha512-c461FXIljswCuscZn67xq9PpszkPT6RjheWFQTgCyabJrTUozElanb0YEqv2UGgk247YpcJkFBuSGNvBlpXM9w==",
                     "bundled": true,
                     "dev": true
                 },
                 "umask": {
                     "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
+                    "integrity": "sha512-lE/rxOhmiScJu9L6RTNVgB/zZbF+vGC0/p6D3xnkAePI2o0sMyFG966iR5Ki50OI/0mNi2yaRnxfLsPmEZF/JA==",
                     "bundled": true,
                     "dev": true
                 },
@@ -25387,6 +25619,8 @@
                 },
                 "validate-npm-package-name": {
                     "version": "2.2.2",
+                    "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-2.2.2.tgz",
+                    "integrity": "sha512-zt38kWHt0j/tv8ZKqZB5lEVT3A41JarczU/ib7L+OXZFAjC2l9kPeujQI1m4smU1nmSwF06MqEetltqVkDmnuQ==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -25417,11 +25651,15 @@
                 },
                 "wrappy": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                    "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
                     "bundled": true,
                     "dev": true
                 },
                 "write-file-atomic": {
                     "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz",
+                    "integrity": "sha512-c5qespPIeoD/YQTLgdOTe9mcjhK0MhK/URjnIlpuF+4Hoec1flfMRcZY+SWrqGHHRC1oGY1VyNC44wiLQgJMiw==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -26014,26 +26252,6 @@
                     "version": "0.0.8",
                     "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
                     "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg=",
-                    "dev": true
-                }
-            }
-        },
-        "plugin-error": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
-            "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
-            "dev": true,
-            "requires": {
-                "ansi-colors": "^1.0.1",
-                "arr-diff": "^4.0.0",
-                "arr-union": "^3.1.0",
-                "extend-shallow": "^3.0.2"
-            },
-            "dependencies": {
-                "arr-diff": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-                    "integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==",
                     "dev": true
                 }
             }
@@ -28221,9 +28439,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "2.1.6",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.1.6.tgz",
-            "integrity": "sha1-QMfm6eXaeWG3cYtVUF+crJSHpgc=",
+            "version": "2.3.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.3.4.tgz",
+            "integrity": "sha512-+3YA3hpUsl9lWPPsPQshiyXvU9EgJhvMoG2V74b6D2BddGePqRbQWNztTvpoUjlpf+3TUIL14C4Cad4QNvOVfQ==",
             "dev": true
         },
         "uglify-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2917,8 +2917,6 @@
         },
         "node_modules/cordova-lib/node_modules/ansi": {
             "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
-            "integrity": "sha512-iFY7JCgHbepc0b82yLaw4IMortylNb6wG4kL+4R0C3iv6i+RHGHux/yUX5BTiRvSX/shMnngjR1YyNMnXEFh5A==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
@@ -2964,8 +2962,6 @@
         },
         "node_modules/cordova-lib/node_modules/base64-js": {
             "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-            "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -2997,8 +2993,6 @@
         },
         "node_modules/cordova-lib/node_modules/bplist-parser": {
             "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
-            "integrity": "sha512-2AEM0FXy8ZxVLBuqX0hqt1gDwcnz2zygEkQ6zaD5Wko/sB9paUNwlpawrFtKeHUAQUOzjVy9AO4oeonqIHKA9Q==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -3036,16 +3030,12 @@
         },
         "node_modules/cordova-lib/node_modules/concat-map": {
             "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/cordova-lib/node_modules/cordova-common": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/cordova-common/-/cordova-common-1.1.1.tgz",
-            "integrity": "sha512-tiWwGmi2T29N6oNS5Xd2ouCMq3v7z0yTwRmheMatpsCGjGZv/Q018T7CiEDorFKNIP4sXpa40yZ3NWK5QYgUDQ==",
             "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
@@ -3067,20 +3057,6 @@
                 "node": ">=0.9.9"
             }
         },
-        "node_modules/cordova-lib/node_modules/cordova-common/node_modules/elementtree": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/elementtree/-/elementtree-0.1.7.tgz",
-            "integrity": "sha512-wkgGT6kugeQk/P6VZ/f4T+4HB41BVgNBq5CDIZVbQ02nvTVqAiVTbskxxu3eA/X96lMlfYOwnLQpN2v5E1zDEg==",
-            "dev": true,
-            "inBundle": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "sax": "1.1.4"
-            },
-            "engines": {
-                "node": ">= 0.4.0"
-            }
-        },
         "node_modules/cordova-lib/node_modules/cordova-common/node_modules/q": {
             "version": "1.4.1",
             "dev": true,
@@ -3090,14 +3066,6 @@
                 "node": ">=0.6.0",
                 "teleport": ">=0.2.0"
             }
-        },
-        "node_modules/cordova-lib/node_modules/cordova-common/node_modules/sax": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
-            "integrity": "sha512-5f3k2PbGGp+YtKJjOItpg3P99IMD84E4HOvcfleTb5joCHNXYLsR9yWFPOYGgaeMPDubQILTCMdsFb2OMeOjtg==",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC"
         },
         "node_modules/cordova-lib/node_modules/cordova-common/node_modules/semver": {
             "version": "5.1.0",
@@ -3110,8 +3078,6 @@
         },
         "node_modules/cordova-lib/node_modules/cordova-common/node_modules/shelljs": {
             "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
-            "integrity": "sha512-C2FisSSW8S6TIYHHiMHN0NqzdjWfTekdMpA2FJTbRWnQMLO1RRIXEB9eVZYOlofYmjZA7fY3ChoFu09MeI3wlQ==",
             "dev": true,
             "inBundle": true,
             "license": "BSD*",
@@ -3128,21 +3094,8 @@
             "inBundle": true,
             "license": "MIT"
         },
-        "node_modules/cordova-lib/node_modules/cordova-common/node_modules/unorm": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
-            "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT or GPL-2.0",
-            "engines": {
-                "node": ">= 0.4.0"
-            }
-        },
         "node_modules/cordova-lib/node_modules/cordova-registry-mapper": {
             "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/cordova-registry-mapper/-/cordova-registry-mapper-1.1.15.tgz",
-            "integrity": "sha512-QHpSMAhaF7Zo5y2zddIJP/hWNJXvLTiIo81PdEfBQEvePCtUKRXBQLcYRfuSGetTZbT6sJFG7Djm2iZo7iZ3sQ==",
             "dev": true,
             "inBundle": true,
             "license": "Apache version 2.0"
@@ -3172,6 +3125,7 @@
         "node_modules/cordova-lib/node_modules/elementtree": {
             "version": "0.1.6",
             "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "sax": "0.3.5"
             },
@@ -3204,8 +3158,6 @@
         },
         "node_modules/cordova-lib/node_modules/glob": {
             "version": "5.0.15",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-            "integrity": "sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -3278,8 +3230,6 @@
         },
         "node_modules/cordova-lib/node_modules/lodash": {
             "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-            "integrity": "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
@@ -3390,8 +3340,6 @@
         },
         "node_modules/cordova-lib/node_modules/plist": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/plist/-/plist-1.2.0.tgz",
-            "integrity": "sha512-dL9Xc2Aj3YyBnwvCNuHmFl2LWvQacm/HEAsoVwLiuu0POboMChETt5wexpU1P6F6MnibIucXlVsMFFgNUT2IyA==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -3449,6 +3397,7 @@
         "node_modules/cordova-lib/node_modules/sax": {
             "version": "0.3.5",
             "dev": true,
+            "inBundle": true,
             "license": "MIT",
             "engines": {
                 "node": "*"
@@ -3491,14 +3440,13 @@
         "node_modules/cordova-lib/node_modules/unorm": {
             "version": "1.3.3",
             "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">= 0.4.0"
             }
         },
         "node_modules/cordova-lib/node_modules/util-deprecate": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
@@ -3511,8 +3459,6 @@
         },
         "node_modules/cordova-lib/node_modules/xmlbuilder": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.0.0.tgz",
-            "integrity": "sha512-wrG9gc6hCFDd5STt+6fsjP2aGSkjkNSewH+1K6s0KVOd94vXAUyTwlxWVnMFVtLdMf+q0QRZN1z9hTOKgoEdMg==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -9770,16 +9716,12 @@
         },
         "node_modules/npm/node_modules/abbrev": {
             "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-            "integrity": "sha512-LEyx4aLEC3x6T0UguF6YILf+ntvmOaWsVfENmIW0E9H09vKlLDGelMjjSm0jkDHALj8A8quZ/HapKNigzwge+Q==",
             "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/ansi": {
             "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
-            "integrity": "sha512-iFY7JCgHbepc0b82yLaw4IMortylNb6wG4kL+4R0C3iv6i+RHGHux/yUX5BTiRvSX/shMnngjR1YyNMnXEFh5A==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
@@ -9795,32 +9737,24 @@
         },
         "node_modules/npm/node_modules/ansicolors": {
             "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-            "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/ansistyles": {
             "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
-            "integrity": "sha512-6QWEyvMgIXX0eO972y7YPBLSBsq7UWKFAoNNTLGaOJ9bstcEL9sCbcjf96dVfNDdUsRoGOK82vWFJlKApXds7g==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/archy": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-            "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/async-some": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/async-some/-/async-some-1.0.2.tgz",
-            "integrity": "sha512-VbEsqdl4ztEqzb3Cgpk9L81Q4eyMl3XFdA0i+12Qmyw/bNx4aDAJqmIMKXh1mKGJ2IaPvGvN682YKZDaJMLUdA==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -9830,8 +9764,6 @@
         },
         "node_modules/npm/node_modules/block-stream": {
             "version": "0.0.9",
-            "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-            "integrity": "sha512-OorbnJVPII4DuUKbjARAe8u8EfqOmkEEaSFIyoQ7OjTHn6kafxWl0wLgoZ2rXaYd7MyLcDaU4TmhfxtwgcccMQ==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -9844,32 +9776,24 @@
         },
         "node_modules/npm/node_modules/char-spinner": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/char-spinner/-/char-spinner-1.0.1.tgz",
-            "integrity": "sha512-acv43vqJ0+N0rD+Uw3pDHSxP30FHrywu2NO6/wBaHChJIizpDeBUd6NjqhNhy9LGaEAhZAXn46QzmlAvIWd16g==",
             "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/chmodr": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-1.0.2.tgz",
-            "integrity": "sha512-oHosCxCZpaI/Db320r8M5SHHZuVfnFJVwkSGkI81QLnnVg25pDw//NgD4fy1WvvydhZNi2G+jrbNSprRkfbRYA==",
             "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/chownr": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-            "integrity": "sha512-cKnqUJAC8G6cuN1DiRRTifu+s1BlAQNtalzGphFEV0pl0p46dsxJD4l1AOlyKJeLZOFzo3c34R7F3djxaCu8Kw==",
             "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/cmd-shim": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
-            "integrity": "sha512-NLt0ntM0kvuSNrToO0RTFiNRHdioWsLW+OgDAEVDvIivsYwR+AjlzvLaMJ2Z+SNRpV3vdsDrHp1WI00eetDYzw==",
             "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
@@ -9880,8 +9804,6 @@
         },
         "node_modules/npm/node_modules/columnify": {
             "version": "1.5.4",
-            "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
-            "integrity": "sha512-rFl+iXVT1nhLQPfGDw+3WcS8rmm7XsLKUmhsGE3ihzzpIikeGrTaZPIRKYWeLsLBypsHzjXIvYEltVUZS84XxQ==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -9950,8 +9872,6 @@
         },
         "node_modules/npm/node_modules/editor": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
-            "integrity": "sha512-SoRmbGStwNYHgKfjOrX2L0mUvp9bUVv0uPppZSOMAntEbcFtoC3MKF5b3T6HQPXKIV+QGY3xPO3JK5it5lVkuw==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
@@ -10002,8 +9922,6 @@
         },
         "node_modules/npm/node_modules/fstream-npm": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.1.1.tgz",
-            "integrity": "sha512-zKZuzxog3e6wPg22PC1UoI+efTOCtngC2b6qAZpUZu3t9oB3A+MuLIUosVPPFVmq6+WZsHZ3h1bhGazc4E9a7Q==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -10025,24 +9943,18 @@
         },
         "node_modules/npm/node_modules/github-url-from-git": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.4.0.tgz",
-            "integrity": "sha512-Vd1uAwEIbUaaYodSvEZRgMOdLUvY7+kZ+PuJNPVBXldTuVcHFtcLENvl2Ds9KKO9q6Ld2o+eVmA/wabaN3/2mQ==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/github-url-from-username-repo": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/github-url-from-username-repo/-/github-url-from-username-repo-1.0.2.tgz",
-            "integrity": "sha512-Tj8CQqRoFVTglGdQ8FQmfq8gOOoOYZX7tnOKP8jq8Hdz2OTDhxvtlkLAbrqMYZ7X/YdaYQoUG1IBWxISBfqZ+Q==",
             "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause"
         },
         "node_modules/npm/node_modules/glob": {
             "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
-            "integrity": "sha512-f8c0rE8JiCxpa52kWPAOa3ZaYEnzofDzCQLCn3Vdk0Z5OVLq3BsRFJI4S4ykpeVW6QMGBUkMeUpoEgWnMTnw5Q==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -10084,16 +9996,12 @@
         },
         "node_modules/npm/node_modules/hosted-git-info": {
             "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-            "integrity": "sha512-5sLwVGWIA8493A2PzG/py8s+uBrYqrwmLp6C6U5+Gpw5Ll49OOigsuD4LKbUTExbgedTNPvPb/0GV5ohHYYNBg==",
             "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/imurmurhash": {
             "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-            "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -10294,8 +10202,6 @@
         },
         "node_modules/npm/node_modules/nopt": {
             "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-            "integrity": "sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -10308,8 +10214,6 @@
         },
         "node_modules/npm/node_modules/normalize-git-url": {
             "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/normalize-git-url/-/normalize-git-url-3.0.2.tgz",
-            "integrity": "sha512-UEmKT33ssKLLoLCsFJ4Si4fmNQsedNwivXpuNTR4V1I97jU9WZlicTV1xn5QAG5itE5B3Z9zhl8OItP6wIGkRA==",
             "dev": true,
             "inBundle": true,
             "license": "ISC"
@@ -10349,16 +10253,12 @@
         },
         "node_modules/npm/node_modules/npm-cache-filename": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
-            "integrity": "sha512-5v2y1KG06izpGvZJDSBR5q1Ej+NaPDO05yAAWBJE6+3eiId0R176Gz3Qc2vEmJnE+VGul84g6Qpq8fXzD82/JA==",
             "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/npm-install-checks": {
             "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-1.0.7.tgz",
-            "integrity": "sha512-IyaSpkt3NMXaXezbnHxwEZ6HBWpQFlKBUZ0ZEoUCyq3LoAaZEWJ2mchhJPauuvevhkvi8SNW67FiWZLpUhJ82w==",
             "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
@@ -10379,8 +10279,6 @@
         },
         "node_modules/npm/node_modules/npm-registry-client": {
             "version": "7.2.1",
-            "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-7.2.1.tgz",
-            "integrity": "sha512-igXKTHWr0ipuL+pKNRBV2p2H4xqfnpVtYiWQmTKfq5/eFmZxKh9U+PyoqdKzqyvPTFLNQVqMGy5W5GjOr1Ukeg==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -10474,16 +10372,12 @@
         },
         "node_modules/npm/node_modules/npm-user-validate": {
             "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-0.1.5.tgz",
-            "integrity": "sha512-86IbFCunHe+6drSd71Aafs8H8xg55lHE9O1/6VS4s+OsBh53xEtQNY1lspkgoaO2b3hhfvDW2FA0eS47inrs1w==",
             "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause"
         },
         "node_modules/npm/node_modules/npmlog": {
             "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
-            "integrity": "sha512-DaL6RTb8Qh4tMe2ttPT1qWccETy2Vi5/8p+htMpLBeXJTr2CAqnF5WQtSP2eFpvaNbhLZ5uilDb98mRm4Q+lZQ==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -10581,8 +10475,6 @@
         },
         "node_modules/npm/node_modules/once": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -10635,8 +10527,6 @@
         },
         "node_modules/npm/node_modules/read": {
             "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-            "integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -10649,8 +10539,6 @@
         },
         "node_modules/npm/node_modules/read-installed": {
             "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
-            "integrity": "sha512-O03wg/IYuV/VtnK2h/KXEt9VIbMUFbk3ERG0Iu4FhLZw0EP0T9znqrYDGn6ncbEsXUFaUjiVAWXHzxwt3lhRPQ==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -10668,8 +10556,6 @@
         },
         "node_modules/npm/node_modules/read-installed/node_modules/debuglog": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
-            "integrity": "sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -10757,8 +10643,6 @@
         },
         "node_modules/npm/node_modules/readable-stream": {
             "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-            "integrity": "sha512-NkXT2AER7VKXeXtJNSaWLpWIhmtSE3K2PguaLEeWr4JILghcIKqoLt1A3wHrnpDC5+ekf8gfk1GKWkFXe4odMw==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -10820,8 +10704,6 @@
         },
         "node_modules/npm/node_modules/request": {
             "version": "2.74.0",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
-            "integrity": "sha512-m3uMovC42y63jXe/Sr49/qJdqpSYwQAgYIc487l0zSXI6Z6f5cV/V4a86h2Z+AAwKpt5bfB66KrZxOfOSdh6FQ==",
             "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
@@ -11162,8 +11044,6 @@
         },
         "node_modules/npm/node_modules/request/node_modules/hawk/node_modules/boom": {
             "version": "2.10.1",
-            "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-            "integrity": "sha512-KbiZEa9/vofNcVJXGwdWWn25reQ3V3dHBWbS07FTF3/TOehLnm9GEhJV4T6ZvGPkShRpmUqYwnaCrkj0mRnP6Q==",
             "dev": true,
             "inBundle": true,
             "license": "BSD-3-Clause",
@@ -11188,8 +11068,6 @@
         },
         "node_modules/npm/node_modules/request/node_modules/hawk/node_modules/hoek": {
             "version": "2.16.3",
-            "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-            "integrity": "sha512-V6Yw1rIcYV/4JsnggjBU0l4Kr+EXhpwqXRusENU1Xx6ro00IHPHYNynCuBTOZAPlr3AAmLvchH9I7N/VUdvOwQ==",
             "dev": true,
             "inBundle": true,
             "license": "BSD-3-Clause",
@@ -11304,8 +11182,6 @@
         },
         "node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/node_modules/assert-plus": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-            "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -11468,8 +11344,6 @@
         },
         "node_modules/npm/node_modules/rimraf": {
             "version": "2.5.4",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-            "integrity": "sha512-Lw7SHMjssciQb/rRz7JyPIy9+bbUshEucPoLRvWqy09vC5zQixl8Uet+Zl+SROBB/JMWHJRdCk1qdxNWHNMvlQ==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -11491,8 +11365,6 @@
         },
         "node_modules/npm/node_modules/sha": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
-            "integrity": "sha512-Lj/GiNro+/4IIvhDvTo2HDqTmQkbqgg/O3lbkM5lMgagriGPpWamxtq1KJPx7mCvyF1/HG6Hs7zaYaj4xpfXbA==",
             "dev": true,
             "inBundle": true,
             "license": "(BSD-2-Clause OR MIT)",
@@ -11547,8 +11419,6 @@
         },
         "node_modules/npm/node_modules/slide": {
             "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-            "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -11564,16 +11434,12 @@
         },
         "node_modules/npm/node_modules/spdx-license-ids": {
             "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-            "integrity": "sha512-qIBFhkh6ILCWNeWEe3ODFPKDYhPJrZpqdNCI2Z+w9lNdH5hoVEkfRLLbRfoIi8fb4xRYmpEOaaMH4G2pwYp/iQ==",
             "dev": true,
             "inBundle": true,
             "license": "Unlicense"
         },
         "node_modules/npm/node_modules/strip-ansi": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -11597,16 +11463,12 @@
         },
         "node_modules/npm/node_modules/text-table": {
             "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-            "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/uid-number": {
             "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-            "integrity": "sha512-c461FXIljswCuscZn67xq9PpszkPT6RjheWFQTgCyabJrTUozElanb0YEqv2UGgk247YpcJkFBuSGNvBlpXM9w==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -11616,8 +11478,6 @@
         },
         "node_modules/npm/node_modules/umask": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
-            "integrity": "sha512-lE/rxOhmiScJu9L6RTNVgB/zZbF+vGC0/p6D3xnkAePI2o0sMyFG966iR5Ki50OI/0mNi2yaRnxfLsPmEZF/JA==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
@@ -11659,8 +11519,6 @@
         },
         "node_modules/npm/node_modules/validate-npm-package-name": {
             "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-2.2.2.tgz",
-            "integrity": "sha512-zt38kWHt0j/tv8ZKqZB5lEVT3A41JarczU/ib7L+OXZFAjC2l9kPeujQI1m4smU1nmSwF06MqEetltqVkDmnuQ==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -11694,16 +11552,12 @@
         },
         "node_modules/npm/node_modules/wrappy": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/write-file-atomic": {
             "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz",
-            "integrity": "sha512-c5qespPIeoD/YQTLgdOTe9mcjhK0MhK/URjnIlpuF+4Hoec1flfMRcZY+SWrqGHHRC1oGY1VyNC44wiLQgJMiw==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -18421,8 +18275,6 @@
             "dependencies": {
                 "ansi": {
                     "version": "0.3.1",
-                    "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
-                    "integrity": "sha512-iFY7JCgHbepc0b82yLaw4IMortylNb6wG4kL+4R0C3iv6i+RHGHux/yUX5BTiRvSX/shMnngjR1YyNMnXEFh5A==",
                     "bundled": true,
                     "dev": true
                 },
@@ -18457,8 +18309,6 @@
                 },
                 "base64-js": {
                     "version": "0.0.8",
-                    "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-                    "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
                     "bundled": true,
                     "dev": true
                 },
@@ -18478,8 +18328,6 @@
                 },
                 "bplist-parser": {
                     "version": "0.1.1",
-                    "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
-                    "integrity": "sha512-2AEM0FXy8ZxVLBuqX0hqt1gDwcnz2zygEkQ6zaD5Wko/sB9paUNwlpawrFtKeHUAQUOzjVy9AO4oeonqIHKA9Q==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -18512,15 +18360,11 @@
                 },
                 "concat-map": {
                     "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                    "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
                     "bundled": true,
                     "dev": true
                 },
                 "cordova-common": {
                     "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/cordova-common/-/cordova-common-1.1.1.tgz",
-                    "integrity": "sha512-tiWwGmi2T29N6oNS5Xd2ouCMq3v7z0yTwRmheMatpsCGjGZv/Q018T7CiEDorFKNIP4sXpa40yZ3NWK5QYgUDQ==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -18538,25 +18382,8 @@
                         "unorm": "^1.3.3"
                     },
                     "dependencies": {
-                        "elementtree": {
-                            "version": "0.1.7",
-                            "resolved": "https://registry.npmjs.org/elementtree/-/elementtree-0.1.7.tgz",
-                            "integrity": "sha512-wkgGT6kugeQk/P6VZ/f4T+4HB41BVgNBq5CDIZVbQ02nvTVqAiVTbskxxu3eA/X96lMlfYOwnLQpN2v5E1zDEg==",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "sax": "1.1.4"
-                            }
-                        },
                         "q": {
                             "version": "1.4.1",
-                            "bundled": true,
-                            "dev": true
-                        },
-                        "sax": {
-                            "version": "1.1.4",
-                            "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
-                            "integrity": "sha512-5f3k2PbGGp+YtKJjOItpg3P99IMD84E4HOvcfleTb5joCHNXYLsR9yWFPOYGgaeMPDubQILTCMdsFb2OMeOjtg==",
                             "bundled": true,
                             "dev": true
                         },
@@ -18567,8 +18394,6 @@
                         },
                         "shelljs": {
                             "version": "0.5.3",
-                            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
-                            "integrity": "sha512-C2FisSSW8S6TIYHHiMHN0NqzdjWfTekdMpA2FJTbRWnQMLO1RRIXEB9eVZYOlofYmjZA7fY3ChoFu09MeI3wlQ==",
                             "bundled": true,
                             "dev": true
                         },
@@ -18576,20 +18401,11 @@
                             "version": "1.8.3",
                             "bundled": true,
                             "dev": true
-                        },
-                        "unorm": {
-                            "version": "1.6.0",
-                            "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
-                            "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==",
-                            "bundled": true,
-                            "dev": true
                         }
                     }
                 },
                 "cordova-registry-mapper": {
                     "version": "1.1.15",
-                    "resolved": "https://registry.npmjs.org/cordova-registry-mapper/-/cordova-registry-mapper-1.1.15.tgz",
-                    "integrity": "sha512-QHpSMAhaF7Zo5y2zddIJP/hWNJXvLTiIo81PdEfBQEvePCtUKRXBQLcYRfuSGetTZbT6sJFG7Djm2iZo7iZ3sQ==",
                     "bundled": true,
                     "dev": true
                 },
@@ -18610,6 +18426,7 @@
                 },
                 "elementtree": {
                     "version": "0.1.6",
+                    "bundled": true,
                     "dev": true,
                     "requires": {
                         "sax": "0.3.5"
@@ -18634,8 +18451,6 @@
                 },
                 "glob": {
                     "version": "5.0.15",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                    "integrity": "sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -18691,8 +18506,6 @@
                 },
                 "lodash": {
                     "version": "3.10.1",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-                    "integrity": "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ==",
                     "bundled": true,
                     "dev": true
                 },
@@ -18771,8 +18584,6 @@
                 },
                 "plist": {
                     "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/plist/-/plist-1.2.0.tgz",
-                    "integrity": "sha512-dL9Xc2Aj3YyBnwvCNuHmFl2LWvQacm/HEAsoVwLiuu0POboMChETt5wexpU1P6F6MnibIucXlVsMFFgNUT2IyA==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -18820,6 +18631,7 @@
                 },
                 "sax": {
                     "version": "0.3.5",
+                    "bundled": true,
                     "dev": true
                 },
                 "shelljs": {
@@ -18845,12 +18657,11 @@
                 },
                 "unorm": {
                     "version": "1.3.3",
+                    "bundled": true,
                     "dev": true
                 },
                 "util-deprecate": {
                     "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                    "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
                     "bundled": true,
                     "dev": true
                 },
@@ -18861,8 +18672,6 @@
                 },
                 "xmlbuilder": {
                     "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.0.0.tgz",
-                    "integrity": "sha512-wrG9gc6hCFDd5STt+6fsjP2aGSkjkNSewH+1K6s0KVOd94vXAUyTwlxWVnMFVtLdMf+q0QRZN1z9hTOKgoEdMg==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24049,15 +23858,11 @@
             "dependencies": {
                 "abbrev": {
                     "version": "1.0.9",
-                    "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-                    "integrity": "sha512-LEyx4aLEC3x6T0UguF6YILf+ntvmOaWsVfENmIW0E9H09vKlLDGelMjjSm0jkDHALj8A8quZ/HapKNigzwge+Q==",
                     "bundled": true,
                     "dev": true
                 },
                 "ansi": {
                     "version": "0.3.1",
-                    "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
-                    "integrity": "sha512-iFY7JCgHbepc0b82yLaw4IMortylNb6wG4kL+4R0C3iv6i+RHGHux/yUX5BTiRvSX/shMnngjR1YyNMnXEFh5A==",
                     "bundled": true,
                     "dev": true
                 },
@@ -24068,29 +23873,21 @@
                 },
                 "ansicolors": {
                     "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-                    "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==",
                     "bundled": true,
                     "dev": true
                 },
                 "ansistyles": {
                     "version": "0.1.3",
-                    "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
-                    "integrity": "sha512-6QWEyvMgIXX0eO972y7YPBLSBsq7UWKFAoNNTLGaOJ9bstcEL9sCbcjf96dVfNDdUsRoGOK82vWFJlKApXds7g==",
                     "bundled": true,
                     "dev": true
                 },
                 "archy": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-                    "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
                     "bundled": true,
                     "dev": true
                 },
                 "async-some": {
                     "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/async-some/-/async-some-1.0.2.tgz",
-                    "integrity": "sha512-VbEsqdl4ztEqzb3Cgpk9L81Q4eyMl3XFdA0i+12Qmyw/bNx4aDAJqmIMKXh1mKGJ2IaPvGvN682YKZDaJMLUdA==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24099,8 +23896,6 @@
                 },
                 "block-stream": {
                     "version": "0.0.9",
-                    "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-                    "integrity": "sha512-OorbnJVPII4DuUKbjARAe8u8EfqOmkEEaSFIyoQ7OjTHn6kafxWl0wLgoZ2rXaYd7MyLcDaU4TmhfxtwgcccMQ==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24109,29 +23904,21 @@
                 },
                 "char-spinner": {
                     "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/char-spinner/-/char-spinner-1.0.1.tgz",
-                    "integrity": "sha512-acv43vqJ0+N0rD+Uw3pDHSxP30FHrywu2NO6/wBaHChJIizpDeBUd6NjqhNhy9LGaEAhZAXn46QzmlAvIWd16g==",
                     "bundled": true,
                     "dev": true
                 },
                 "chmodr": {
                     "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-1.0.2.tgz",
-                    "integrity": "sha512-oHosCxCZpaI/Db320r8M5SHHZuVfnFJVwkSGkI81QLnnVg25pDw//NgD4fy1WvvydhZNi2G+jrbNSprRkfbRYA==",
                     "bundled": true,
                     "dev": true
                 },
                 "chownr": {
                     "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-                    "integrity": "sha512-cKnqUJAC8G6cuN1DiRRTifu+s1BlAQNtalzGphFEV0pl0p46dsxJD4l1AOlyKJeLZOFzo3c34R7F3djxaCu8Kw==",
                     "bundled": true,
                     "dev": true
                 },
                 "cmd-shim": {
                     "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
-                    "integrity": "sha512-NLt0ntM0kvuSNrToO0RTFiNRHdioWsLW+OgDAEVDvIivsYwR+AjlzvLaMJ2Z+SNRpV3vdsDrHp1WI00eetDYzw==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24141,8 +23928,6 @@
                 },
                 "columnify": {
                     "version": "1.5.4",
-                    "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
-                    "integrity": "sha512-rFl+iXVT1nhLQPfGDw+3WcS8rmm7XsLKUmhsGE3ihzzpIikeGrTaZPIRKYWeLsLBypsHzjXIvYEltVUZS84XxQ==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24211,8 +23996,6 @@
                 },
                 "editor": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
-                    "integrity": "sha512-SoRmbGStwNYHgKfjOrX2L0mUvp9bUVv0uPppZSOMAntEbcFtoC3MKF5b3T6HQPXKIV+QGY3xPO3JK5it5lVkuw==",
                     "bundled": true,
                     "dev": true
                 },
@@ -24257,8 +24040,6 @@
                 },
                 "fstream-npm": {
                     "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.1.1.tgz",
-                    "integrity": "sha512-zKZuzxog3e6wPg22PC1UoI+efTOCtngC2b6qAZpUZu3t9oB3A+MuLIUosVPPFVmq6+WZsHZ3h1bhGazc4E9a7Q==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24280,22 +24061,16 @@
                 },
                 "github-url-from-git": {
                     "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.4.0.tgz",
-                    "integrity": "sha512-Vd1uAwEIbUaaYodSvEZRgMOdLUvY7+kZ+PuJNPVBXldTuVcHFtcLENvl2Ds9KKO9q6Ld2o+eVmA/wabaN3/2mQ==",
                     "bundled": true,
                     "dev": true
                 },
                 "github-url-from-username-repo": {
                     "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/github-url-from-username-repo/-/github-url-from-username-repo-1.0.2.tgz",
-                    "integrity": "sha512-Tj8CQqRoFVTglGdQ8FQmfq8gOOoOYZX7tnOKP8jq8Hdz2OTDhxvtlkLAbrqMYZ7X/YdaYQoUG1IBWxISBfqZ+Q==",
                     "bundled": true,
                     "dev": true
                 },
                 "glob": {
                     "version": "7.0.6",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
-                    "integrity": "sha512-f8c0rE8JiCxpa52kWPAOa3ZaYEnzofDzCQLCn3Vdk0Z5OVLq3BsRFJI4S4ykpeVW6QMGBUkMeUpoEgWnMTnw5Q==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24326,15 +24101,11 @@
                 },
                 "hosted-git-info": {
                     "version": "2.1.5",
-                    "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-                    "integrity": "sha512-5sLwVGWIA8493A2PzG/py8s+uBrYqrwmLp6C6U5+Gpw5Ll49OOigsuD4LKbUTExbgedTNPvPb/0GV5ohHYYNBg==",
                     "bundled": true,
                     "dev": true
                 },
                 "imurmurhash": {
                     "version": "0.1.4",
-                    "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-                    "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
                     "bundled": true,
                     "dev": true
                 },
@@ -24502,8 +24273,6 @@
                 },
                 "nopt": {
                     "version": "3.0.6",
-                    "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-                    "integrity": "sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24512,8 +24281,6 @@
                 },
                 "normalize-git-url": {
                     "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/normalize-git-url/-/normalize-git-url-3.0.2.tgz",
-                    "integrity": "sha512-UEmKT33ssKLLoLCsFJ4Si4fmNQsedNwivXpuNTR4V1I97jU9WZlicTV1xn5QAG5itE5B3Z9zhl8OItP6wIGkRA==",
                     "bundled": true,
                     "dev": true
                 },
@@ -24547,15 +24314,11 @@
                 },
                 "npm-cache-filename": {
                     "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
-                    "integrity": "sha512-5v2y1KG06izpGvZJDSBR5q1Ej+NaPDO05yAAWBJE6+3eiId0R176Gz3Qc2vEmJnE+VGul84g6Qpq8fXzD82/JA==",
                     "bundled": true,
                     "dev": true
                 },
                 "npm-install-checks": {
                     "version": "1.0.7",
-                    "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-1.0.7.tgz",
-                    "integrity": "sha512-IyaSpkt3NMXaXezbnHxwEZ6HBWpQFlKBUZ0ZEoUCyq3LoAaZEWJ2mchhJPauuvevhkvi8SNW67FiWZLpUhJ82w==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24574,8 +24337,6 @@
                 },
                 "npm-registry-client": {
                     "version": "7.2.1",
-                    "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-7.2.1.tgz",
-                    "integrity": "sha512-igXKTHWr0ipuL+pKNRBV2p2H4xqfnpVtYiWQmTKfq5/eFmZxKh9U+PyoqdKzqyvPTFLNQVqMGy5W5GjOr1Ukeg==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24657,15 +24418,11 @@
                 },
                 "npm-user-validate": {
                     "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-0.1.5.tgz",
-                    "integrity": "sha512-86IbFCunHe+6drSd71Aafs8H8xg55lHE9O1/6VS4s+OsBh53xEtQNY1lspkgoaO2b3hhfvDW2FA0eS47inrs1w==",
                     "bundled": true,
                     "dev": true
                 },
                 "npmlog": {
                     "version": "2.0.4",
-                    "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
-                    "integrity": "sha512-DaL6RTb8Qh4tMe2ttPT1qWccETy2Vi5/8p+htMpLBeXJTr2CAqnF5WQtSP2eFpvaNbhLZ5uilDb98mRm4Q+lZQ==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24758,8 +24515,6 @@
                 },
                 "once": {
                     "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                    "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24799,8 +24554,6 @@
                 },
                 "read": {
                     "version": "1.0.7",
-                    "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-                    "integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24816,8 +24569,6 @@
                 },
                 "read-installed": {
                     "version": "4.0.3",
-                    "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
-                    "integrity": "sha512-O03wg/IYuV/VtnK2h/KXEt9VIbMUFbk3ERG0Iu4FhLZw0EP0T9znqrYDGn6ncbEsXUFaUjiVAWXHzxwt3lhRPQ==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24832,8 +24583,6 @@
                     "dependencies": {
                         "debuglog": {
                             "version": "1.0.1",
-                            "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
-                            "integrity": "sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==",
                             "bundled": true,
                             "dev": true
                         },
@@ -24904,8 +24653,6 @@
                 },
                 "readable-stream": {
                     "version": "2.1.5",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-                    "integrity": "sha512-NkXT2AER7VKXeXtJNSaWLpWIhmtSE3K2PguaLEeWr4JILghcIKqoLt1A3wHrnpDC5+ekf8gfk1GKWkFXe4odMw==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24961,8 +24708,6 @@
                 },
                 "request": {
                     "version": "2.74.0",
-                    "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
-                    "integrity": "sha512-m3uMovC42y63jXe/Sr49/qJdqpSYwQAgYIc487l0zSXI6Z6f5cV/V4a86h2Z+AAwKpt5bfB66KrZxOfOSdh6FQ==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -25232,8 +24977,6 @@
                             "dependencies": {
                                 "boom": {
                                     "version": "2.10.1",
-                                    "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                                    "integrity": "sha512-KbiZEa9/vofNcVJXGwdWWn25reQ3V3dHBWbS07FTF3/TOehLnm9GEhJV4T6ZvGPkShRpmUqYwnaCrkj0mRnP6Q==",
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
@@ -25250,8 +24993,6 @@
                                 },
                                 "hoek": {
                                     "version": "2.16.3",
-                                    "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                                    "integrity": "sha512-V6Yw1rIcYV/4JsnggjBU0l4Kr+EXhpwqXRusENU1Xx6ro00IHPHYNynCuBTOZAPlr3AAmLvchH9I7N/VUdvOwQ==",
                                     "bundled": true,
                                     "dev": true
                                 },
@@ -25332,8 +25073,6 @@
                                         },
                                         "assert-plus": {
                                             "version": "1.0.0",
-                                            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                                            "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
                                             "bundled": true,
                                             "dev": true
                                         },
@@ -25456,8 +25195,6 @@
                 },
                 "rimraf": {
                     "version": "2.5.4",
-                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-                    "integrity": "sha512-Lw7SHMjssciQb/rRz7JyPIy9+bbUshEucPoLRvWqy09vC5zQixl8Uet+Zl+SROBB/JMWHJRdCk1qdxNWHNMvlQ==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -25471,8 +25208,6 @@
                 },
                 "sha": {
                     "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
-                    "integrity": "sha512-Lj/GiNro+/4IIvhDvTo2HDqTmQkbqgg/O3lbkM5lMgagriGPpWamxtq1KJPx7mCvyF1/HG6Hs7zaYaj4xpfXbA==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -25524,8 +25259,6 @@
                 },
                 "slide": {
                     "version": "1.1.6",
-                    "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-                    "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
                     "bundled": true,
                     "dev": true
                 },
@@ -25536,15 +25269,11 @@
                 },
                 "spdx-license-ids": {
                     "version": "1.2.2",
-                    "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-                    "integrity": "sha512-qIBFhkh6ILCWNeWEe3ODFPKDYhPJrZpqdNCI2Z+w9lNdH5hoVEkfRLLbRfoIi8fb4xRYmpEOaaMH4G2pwYp/iQ==",
                     "bundled": true,
                     "dev": true
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -25563,22 +25292,16 @@
                 },
                 "text-table": {
                     "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-                    "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
                     "bundled": true,
                     "dev": true
                 },
                 "uid-number": {
                     "version": "0.0.6",
-                    "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-                    "integrity": "sha512-c461FXIljswCuscZn67xq9PpszkPT6RjheWFQTgCyabJrTUozElanb0YEqv2UGgk247YpcJkFBuSGNvBlpXM9w==",
                     "bundled": true,
                     "dev": true
                 },
                 "umask": {
                     "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
-                    "integrity": "sha512-lE/rxOhmiScJu9L6RTNVgB/zZbF+vGC0/p6D3xnkAePI2o0sMyFG966iR5Ki50OI/0mNi2yaRnxfLsPmEZF/JA==",
                     "bundled": true,
                     "dev": true
                 },
@@ -25619,8 +25342,6 @@
                 },
                 "validate-npm-package-name": {
                     "version": "2.2.2",
-                    "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-2.2.2.tgz",
-                    "integrity": "sha512-zt38kWHt0j/tv8ZKqZB5lEVT3A41JarczU/ib7L+OXZFAjC2l9kPeujQI1m4smU1nmSwF06MqEetltqVkDmnuQ==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -25651,15 +25372,11 @@
                 },
                 "wrappy": {
                     "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                    "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
                     "bundled": true,
                     "dev": true
                 },
                 "write-file-atomic": {
                     "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz",
-                    "integrity": "sha512-c5qespPIeoD/YQTLgdOTe9mcjhK0MhK/URjnIlpuF+4Hoec1flfMRcZY+SWrqGHHRC1oGY1VyNC44wiLQgJMiw==",
                     "bundled": true,
                     "dev": true,
                     "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2917,6 +2917,8 @@
         },
         "node_modules/cordova-lib/node_modules/ansi": {
             "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+            "integrity": "sha512-iFY7JCgHbepc0b82yLaw4IMortylNb6wG4kL+4R0C3iv6i+RHGHux/yUX5BTiRvSX/shMnngjR1YyNMnXEFh5A==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
@@ -2962,6 +2964,8 @@
         },
         "node_modules/cordova-lib/node_modules/base64-js": {
             "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+            "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -2993,6 +2997,8 @@
         },
         "node_modules/cordova-lib/node_modules/bplist-parser": {
             "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
+            "integrity": "sha512-2AEM0FXy8ZxVLBuqX0hqt1gDwcnz2zygEkQ6zaD5Wko/sB9paUNwlpawrFtKeHUAQUOzjVy9AO4oeonqIHKA9Q==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -3030,12 +3036,16 @@
         },
         "node_modules/cordova-lib/node_modules/concat-map": {
             "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/cordova-lib/node_modules/cordova-common": {
             "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/cordova-common/-/cordova-common-1.1.1.tgz",
+            "integrity": "sha512-tiWwGmi2T29N6oNS5Xd2ouCMq3v7z0yTwRmheMatpsCGjGZv/Q018T7CiEDorFKNIP4sXpa40yZ3NWK5QYgUDQ==",
             "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
@@ -3057,6 +3067,20 @@
                 "node": ">=0.9.9"
             }
         },
+        "node_modules/cordova-lib/node_modules/cordova-common/node_modules/elementtree": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/elementtree/-/elementtree-0.1.7.tgz",
+            "integrity": "sha512-wkgGT6kugeQk/P6VZ/f4T+4HB41BVgNBq5CDIZVbQ02nvTVqAiVTbskxxu3eA/X96lMlfYOwnLQpN2v5E1zDEg==",
+            "dev": true,
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "sax": "1.1.4"
+            },
+            "engines": {
+                "node": ">= 0.4.0"
+            }
+        },
         "node_modules/cordova-lib/node_modules/cordova-common/node_modules/q": {
             "version": "1.4.1",
             "dev": true,
@@ -3066,6 +3090,14 @@
                 "node": ">=0.6.0",
                 "teleport": ">=0.2.0"
             }
+        },
+        "node_modules/cordova-lib/node_modules/cordova-common/node_modules/sax": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
+            "integrity": "sha512-5f3k2PbGGp+YtKJjOItpg3P99IMD84E4HOvcfleTb5joCHNXYLsR9yWFPOYGgaeMPDubQILTCMdsFb2OMeOjtg==",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC"
         },
         "node_modules/cordova-lib/node_modules/cordova-common/node_modules/semver": {
             "version": "5.1.0",
@@ -3078,6 +3110,8 @@
         },
         "node_modules/cordova-lib/node_modules/cordova-common/node_modules/shelljs": {
             "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
+            "integrity": "sha512-C2FisSSW8S6TIYHHiMHN0NqzdjWfTekdMpA2FJTbRWnQMLO1RRIXEB9eVZYOlofYmjZA7fY3ChoFu09MeI3wlQ==",
             "dev": true,
             "inBundle": true,
             "license": "BSD*",
@@ -3094,8 +3128,21 @@
             "inBundle": true,
             "license": "MIT"
         },
+        "node_modules/cordova-lib/node_modules/cordova-common/node_modules/unorm": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
+            "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT or GPL-2.0",
+            "engines": {
+                "node": ">= 0.4.0"
+            }
+        },
         "node_modules/cordova-lib/node_modules/cordova-registry-mapper": {
             "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/cordova-registry-mapper/-/cordova-registry-mapper-1.1.15.tgz",
+            "integrity": "sha512-QHpSMAhaF7Zo5y2zddIJP/hWNJXvLTiIo81PdEfBQEvePCtUKRXBQLcYRfuSGetTZbT6sJFG7Djm2iZo7iZ3sQ==",
             "dev": true,
             "inBundle": true,
             "license": "Apache version 2.0"
@@ -3125,7 +3172,6 @@
         "node_modules/cordova-lib/node_modules/elementtree": {
             "version": "0.1.6",
             "dev": true,
-            "inBundle": true,
             "dependencies": {
                 "sax": "0.3.5"
             },
@@ -3158,6 +3204,8 @@
         },
         "node_modules/cordova-lib/node_modules/glob": {
             "version": "5.0.15",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+            "integrity": "sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -3230,6 +3278,8 @@
         },
         "node_modules/cordova-lib/node_modules/lodash": {
             "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+            "integrity": "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
@@ -3340,6 +3390,8 @@
         },
         "node_modules/cordova-lib/node_modules/plist": {
             "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/plist/-/plist-1.2.0.tgz",
+            "integrity": "sha512-dL9Xc2Aj3YyBnwvCNuHmFl2LWvQacm/HEAsoVwLiuu0POboMChETt5wexpU1P6F6MnibIucXlVsMFFgNUT2IyA==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -3397,7 +3449,6 @@
         "node_modules/cordova-lib/node_modules/sax": {
             "version": "0.3.5",
             "dev": true,
-            "inBundle": true,
             "license": "MIT",
             "engines": {
                 "node": "*"
@@ -3440,13 +3491,14 @@
         "node_modules/cordova-lib/node_modules/unorm": {
             "version": "1.3.3",
             "dev": true,
-            "inBundle": true,
             "engines": {
                 "node": ">= 0.4.0"
             }
         },
         "node_modules/cordova-lib/node_modules/util-deprecate": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
@@ -3459,6 +3511,8 @@
         },
         "node_modules/cordova-lib/node_modules/xmlbuilder": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.0.0.tgz",
+            "integrity": "sha512-wrG9gc6hCFDd5STt+6fsjP2aGSkjkNSewH+1K6s0KVOd94vXAUyTwlxWVnMFVtLdMf+q0QRZN1z9hTOKgoEdMg==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -9716,12 +9770,16 @@
         },
         "node_modules/npm/node_modules/abbrev": {
             "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+            "integrity": "sha512-LEyx4aLEC3x6T0UguF6YILf+ntvmOaWsVfENmIW0E9H09vKlLDGelMjjSm0jkDHALj8A8quZ/HapKNigzwge+Q==",
             "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/ansi": {
             "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+            "integrity": "sha512-iFY7JCgHbepc0b82yLaw4IMortylNb6wG4kL+4R0C3iv6i+RHGHux/yUX5BTiRvSX/shMnngjR1YyNMnXEFh5A==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
@@ -9737,24 +9795,32 @@
         },
         "node_modules/npm/node_modules/ansicolors": {
             "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+            "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/ansistyles": {
             "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
+            "integrity": "sha512-6QWEyvMgIXX0eO972y7YPBLSBsq7UWKFAoNNTLGaOJ9bstcEL9sCbcjf96dVfNDdUsRoGOK82vWFJlKApXds7g==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/archy": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+            "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/async-some": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/async-some/-/async-some-1.0.2.tgz",
+            "integrity": "sha512-VbEsqdl4ztEqzb3Cgpk9L81Q4eyMl3XFdA0i+12Qmyw/bNx4aDAJqmIMKXh1mKGJ2IaPvGvN682YKZDaJMLUdA==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -9764,6 +9830,8 @@
         },
         "node_modules/npm/node_modules/block-stream": {
             "version": "0.0.9",
+            "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+            "integrity": "sha512-OorbnJVPII4DuUKbjARAe8u8EfqOmkEEaSFIyoQ7OjTHn6kafxWl0wLgoZ2rXaYd7MyLcDaU4TmhfxtwgcccMQ==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -9776,24 +9844,32 @@
         },
         "node_modules/npm/node_modules/char-spinner": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/char-spinner/-/char-spinner-1.0.1.tgz",
+            "integrity": "sha512-acv43vqJ0+N0rD+Uw3pDHSxP30FHrywu2NO6/wBaHChJIizpDeBUd6NjqhNhy9LGaEAhZAXn46QzmlAvIWd16g==",
             "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/chmodr": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-1.0.2.tgz",
+            "integrity": "sha512-oHosCxCZpaI/Db320r8M5SHHZuVfnFJVwkSGkI81QLnnVg25pDw//NgD4fy1WvvydhZNi2G+jrbNSprRkfbRYA==",
             "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/chownr": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+            "integrity": "sha512-cKnqUJAC8G6cuN1DiRRTifu+s1BlAQNtalzGphFEV0pl0p46dsxJD4l1AOlyKJeLZOFzo3c34R7F3djxaCu8Kw==",
             "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/cmd-shim": {
             "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
+            "integrity": "sha512-NLt0ntM0kvuSNrToO0RTFiNRHdioWsLW+OgDAEVDvIivsYwR+AjlzvLaMJ2Z+SNRpV3vdsDrHp1WI00eetDYzw==",
             "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
@@ -9804,6 +9880,8 @@
         },
         "node_modules/npm/node_modules/columnify": {
             "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+            "integrity": "sha512-rFl+iXVT1nhLQPfGDw+3WcS8rmm7XsLKUmhsGE3ihzzpIikeGrTaZPIRKYWeLsLBypsHzjXIvYEltVUZS84XxQ==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -9872,6 +9950,8 @@
         },
         "node_modules/npm/node_modules/editor": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
+            "integrity": "sha512-SoRmbGStwNYHgKfjOrX2L0mUvp9bUVv0uPppZSOMAntEbcFtoC3MKF5b3T6HQPXKIV+QGY3xPO3JK5it5lVkuw==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
@@ -9922,6 +10002,8 @@
         },
         "node_modules/npm/node_modules/fstream-npm": {
             "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.1.1.tgz",
+            "integrity": "sha512-zKZuzxog3e6wPg22PC1UoI+efTOCtngC2b6qAZpUZu3t9oB3A+MuLIUosVPPFVmq6+WZsHZ3h1bhGazc4E9a7Q==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -9943,18 +10025,24 @@
         },
         "node_modules/npm/node_modules/github-url-from-git": {
             "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.4.0.tgz",
+            "integrity": "sha512-Vd1uAwEIbUaaYodSvEZRgMOdLUvY7+kZ+PuJNPVBXldTuVcHFtcLENvl2Ds9KKO9q6Ld2o+eVmA/wabaN3/2mQ==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/github-url-from-username-repo": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/github-url-from-username-repo/-/github-url-from-username-repo-1.0.2.tgz",
+            "integrity": "sha512-Tj8CQqRoFVTglGdQ8FQmfq8gOOoOYZX7tnOKP8jq8Hdz2OTDhxvtlkLAbrqMYZ7X/YdaYQoUG1IBWxISBfqZ+Q==",
             "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause"
         },
         "node_modules/npm/node_modules/glob": {
             "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+            "integrity": "sha512-f8c0rE8JiCxpa52kWPAOa3ZaYEnzofDzCQLCn3Vdk0Z5OVLq3BsRFJI4S4ykpeVW6QMGBUkMeUpoEgWnMTnw5Q==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -9996,12 +10084,16 @@
         },
         "node_modules/npm/node_modules/hosted-git-info": {
             "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
+            "integrity": "sha512-5sLwVGWIA8493A2PzG/py8s+uBrYqrwmLp6C6U5+Gpw5Ll49OOigsuD4LKbUTExbgedTNPvPb/0GV5ohHYYNBg==",
             "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/imurmurhash": {
             "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -10202,6 +10294,8 @@
         },
         "node_modules/npm/node_modules/nopt": {
             "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+            "integrity": "sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -10214,6 +10308,8 @@
         },
         "node_modules/npm/node_modules/normalize-git-url": {
             "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/normalize-git-url/-/normalize-git-url-3.0.2.tgz",
+            "integrity": "sha512-UEmKT33ssKLLoLCsFJ4Si4fmNQsedNwivXpuNTR4V1I97jU9WZlicTV1xn5QAG5itE5B3Z9zhl8OItP6wIGkRA==",
             "dev": true,
             "inBundle": true,
             "license": "ISC"
@@ -10253,12 +10349,16 @@
         },
         "node_modules/npm/node_modules/npm-cache-filename": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
+            "integrity": "sha512-5v2y1KG06izpGvZJDSBR5q1Ej+NaPDO05yAAWBJE6+3eiId0R176Gz3Qc2vEmJnE+VGul84g6Qpq8fXzD82/JA==",
             "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/npm-install-checks": {
             "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-1.0.7.tgz",
+            "integrity": "sha512-IyaSpkt3NMXaXezbnHxwEZ6HBWpQFlKBUZ0ZEoUCyq3LoAaZEWJ2mchhJPauuvevhkvi8SNW67FiWZLpUhJ82w==",
             "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
@@ -10279,6 +10379,8 @@
         },
         "node_modules/npm/node_modules/npm-registry-client": {
             "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-7.2.1.tgz",
+            "integrity": "sha512-igXKTHWr0ipuL+pKNRBV2p2H4xqfnpVtYiWQmTKfq5/eFmZxKh9U+PyoqdKzqyvPTFLNQVqMGy5W5GjOr1Ukeg==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -10372,12 +10474,16 @@
         },
         "node_modules/npm/node_modules/npm-user-validate": {
             "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-0.1.5.tgz",
+            "integrity": "sha512-86IbFCunHe+6drSd71Aafs8H8xg55lHE9O1/6VS4s+OsBh53xEtQNY1lspkgoaO2b3hhfvDW2FA0eS47inrs1w==",
             "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause"
         },
         "node_modules/npm/node_modules/npmlog": {
             "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
+            "integrity": "sha512-DaL6RTb8Qh4tMe2ttPT1qWccETy2Vi5/8p+htMpLBeXJTr2CAqnF5WQtSP2eFpvaNbhLZ5uilDb98mRm4Q+lZQ==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -10475,6 +10581,8 @@
         },
         "node_modules/npm/node_modules/once": {
             "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -10527,6 +10635,8 @@
         },
         "node_modules/npm/node_modules/read": {
             "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+            "integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -10539,6 +10649,8 @@
         },
         "node_modules/npm/node_modules/read-installed": {
             "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
+            "integrity": "sha512-O03wg/IYuV/VtnK2h/KXEt9VIbMUFbk3ERG0Iu4FhLZw0EP0T9znqrYDGn6ncbEsXUFaUjiVAWXHzxwt3lhRPQ==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -10556,6 +10668,8 @@
         },
         "node_modules/npm/node_modules/read-installed/node_modules/debuglog": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+            "integrity": "sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -10643,6 +10757,8 @@
         },
         "node_modules/npm/node_modules/readable-stream": {
             "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+            "integrity": "sha512-NkXT2AER7VKXeXtJNSaWLpWIhmtSE3K2PguaLEeWr4JILghcIKqoLt1A3wHrnpDC5+ekf8gfk1GKWkFXe4odMw==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -10704,6 +10820,8 @@
         },
         "node_modules/npm/node_modules/request": {
             "version": "2.74.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
+            "integrity": "sha512-m3uMovC42y63jXe/Sr49/qJdqpSYwQAgYIc487l0zSXI6Z6f5cV/V4a86h2Z+AAwKpt5bfB66KrZxOfOSdh6FQ==",
             "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
@@ -11044,6 +11162,8 @@
         },
         "node_modules/npm/node_modules/request/node_modules/hawk/node_modules/boom": {
             "version": "2.10.1",
+            "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+            "integrity": "sha512-KbiZEa9/vofNcVJXGwdWWn25reQ3V3dHBWbS07FTF3/TOehLnm9GEhJV4T6ZvGPkShRpmUqYwnaCrkj0mRnP6Q==",
             "dev": true,
             "inBundle": true,
             "license": "BSD-3-Clause",
@@ -11068,6 +11188,8 @@
         },
         "node_modules/npm/node_modules/request/node_modules/hawk/node_modules/hoek": {
             "version": "2.16.3",
+            "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+            "integrity": "sha512-V6Yw1rIcYV/4JsnggjBU0l4Kr+EXhpwqXRusENU1Xx6ro00IHPHYNynCuBTOZAPlr3AAmLvchH9I7N/VUdvOwQ==",
             "dev": true,
             "inBundle": true,
             "license": "BSD-3-Clause",
@@ -11182,6 +11304,8 @@
         },
         "node_modules/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/node_modules/assert-plus": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -11344,6 +11468,8 @@
         },
         "node_modules/npm/node_modules/rimraf": {
             "version": "2.5.4",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+            "integrity": "sha512-Lw7SHMjssciQb/rRz7JyPIy9+bbUshEucPoLRvWqy09vC5zQixl8Uet+Zl+SROBB/JMWHJRdCk1qdxNWHNMvlQ==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -11365,6 +11491,8 @@
         },
         "node_modules/npm/node_modules/sha": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
+            "integrity": "sha512-Lj/GiNro+/4IIvhDvTo2HDqTmQkbqgg/O3lbkM5lMgagriGPpWamxtq1KJPx7mCvyF1/HG6Hs7zaYaj4xpfXbA==",
             "dev": true,
             "inBundle": true,
             "license": "(BSD-2-Clause OR MIT)",
@@ -11419,6 +11547,8 @@
         },
         "node_modules/npm/node_modules/slide": {
             "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+            "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -11434,12 +11564,16 @@
         },
         "node_modules/npm/node_modules/spdx-license-ids": {
             "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+            "integrity": "sha512-qIBFhkh6ILCWNeWEe3ODFPKDYhPJrZpqdNCI2Z+w9lNdH5hoVEkfRLLbRfoIi8fb4xRYmpEOaaMH4G2pwYp/iQ==",
             "dev": true,
             "inBundle": true,
             "license": "Unlicense"
         },
         "node_modules/npm/node_modules/strip-ansi": {
             "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -11463,12 +11597,16 @@
         },
         "node_modules/npm/node_modules/text-table": {
             "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+            "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/uid-number": {
             "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+            "integrity": "sha512-c461FXIljswCuscZn67xq9PpszkPT6RjheWFQTgCyabJrTUozElanb0YEqv2UGgk247YpcJkFBuSGNvBlpXM9w==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -11478,6 +11616,8 @@
         },
         "node_modules/npm/node_modules/umask": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
+            "integrity": "sha512-lE/rxOhmiScJu9L6RTNVgB/zZbF+vGC0/p6D3xnkAePI2o0sMyFG966iR5Ki50OI/0mNi2yaRnxfLsPmEZF/JA==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
@@ -11519,6 +11659,8 @@
         },
         "node_modules/npm/node_modules/validate-npm-package-name": {
             "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-2.2.2.tgz",
+            "integrity": "sha512-zt38kWHt0j/tv8ZKqZB5lEVT3A41JarczU/ib7L+OXZFAjC2l9kPeujQI1m4smU1nmSwF06MqEetltqVkDmnuQ==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -11552,12 +11694,16 @@
         },
         "node_modules/npm/node_modules/wrappy": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/write-file-atomic": {
             "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz",
+            "integrity": "sha512-c5qespPIeoD/YQTLgdOTe9mcjhK0MhK/URjnIlpuF+4Hoec1flfMRcZY+SWrqGHHRC1oGY1VyNC44wiLQgJMiw==",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -18275,6 +18421,8 @@
             "dependencies": {
                 "ansi": {
                     "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+                    "integrity": "sha512-iFY7JCgHbepc0b82yLaw4IMortylNb6wG4kL+4R0C3iv6i+RHGHux/yUX5BTiRvSX/shMnngjR1YyNMnXEFh5A==",
                     "bundled": true,
                     "dev": true
                 },
@@ -18309,6 +18457,8 @@
                 },
                 "base64-js": {
                     "version": "0.0.8",
+                    "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+                    "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
                     "bundled": true,
                     "dev": true
                 },
@@ -18328,6 +18478,8 @@
                 },
                 "bplist-parser": {
                     "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
+                    "integrity": "sha512-2AEM0FXy8ZxVLBuqX0hqt1gDwcnz2zygEkQ6zaD5Wko/sB9paUNwlpawrFtKeHUAQUOzjVy9AO4oeonqIHKA9Q==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -18360,11 +18512,15 @@
                 },
                 "concat-map": {
                     "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                    "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
                     "bundled": true,
                     "dev": true
                 },
                 "cordova-common": {
                     "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/cordova-common/-/cordova-common-1.1.1.tgz",
+                    "integrity": "sha512-tiWwGmi2T29N6oNS5Xd2ouCMq3v7z0yTwRmheMatpsCGjGZv/Q018T7CiEDorFKNIP4sXpa40yZ3NWK5QYgUDQ==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -18382,8 +18538,25 @@
                         "unorm": "^1.3.3"
                     },
                     "dependencies": {
+                        "elementtree": {
+                            "version": "0.1.7",
+                            "resolved": "https://registry.npmjs.org/elementtree/-/elementtree-0.1.7.tgz",
+                            "integrity": "sha512-wkgGT6kugeQk/P6VZ/f4T+4HB41BVgNBq5CDIZVbQ02nvTVqAiVTbskxxu3eA/X96lMlfYOwnLQpN2v5E1zDEg==",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "sax": "1.1.4"
+                            }
+                        },
                         "q": {
                             "version": "1.4.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "sax": {
+                            "version": "1.1.4",
+                            "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
+                            "integrity": "sha512-5f3k2PbGGp+YtKJjOItpg3P99IMD84E4HOvcfleTb5joCHNXYLsR9yWFPOYGgaeMPDubQILTCMdsFb2OMeOjtg==",
                             "bundled": true,
                             "dev": true
                         },
@@ -18394,6 +18567,8 @@
                         },
                         "shelljs": {
                             "version": "0.5.3",
+                            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
+                            "integrity": "sha512-C2FisSSW8S6TIYHHiMHN0NqzdjWfTekdMpA2FJTbRWnQMLO1RRIXEB9eVZYOlofYmjZA7fY3ChoFu09MeI3wlQ==",
                             "bundled": true,
                             "dev": true
                         },
@@ -18401,11 +18576,20 @@
                             "version": "1.8.3",
                             "bundled": true,
                             "dev": true
+                        },
+                        "unorm": {
+                            "version": "1.6.0",
+                            "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
+                            "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==",
+                            "bundled": true,
+                            "dev": true
                         }
                     }
                 },
                 "cordova-registry-mapper": {
                     "version": "1.1.15",
+                    "resolved": "https://registry.npmjs.org/cordova-registry-mapper/-/cordova-registry-mapper-1.1.15.tgz",
+                    "integrity": "sha512-QHpSMAhaF7Zo5y2zddIJP/hWNJXvLTiIo81PdEfBQEvePCtUKRXBQLcYRfuSGetTZbT6sJFG7Djm2iZo7iZ3sQ==",
                     "bundled": true,
                     "dev": true
                 },
@@ -18426,7 +18610,6 @@
                 },
                 "elementtree": {
                     "version": "0.1.6",
-                    "bundled": true,
                     "dev": true,
                     "requires": {
                         "sax": "0.3.5"
@@ -18451,6 +18634,8 @@
                 },
                 "glob": {
                     "version": "5.0.15",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                    "integrity": "sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -18506,6 +18691,8 @@
                 },
                 "lodash": {
                     "version": "3.10.1",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                    "integrity": "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ==",
                     "bundled": true,
                     "dev": true
                 },
@@ -18584,6 +18771,8 @@
                 },
                 "plist": {
                     "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/plist/-/plist-1.2.0.tgz",
+                    "integrity": "sha512-dL9Xc2Aj3YyBnwvCNuHmFl2LWvQacm/HEAsoVwLiuu0POboMChETt5wexpU1P6F6MnibIucXlVsMFFgNUT2IyA==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -18631,7 +18820,6 @@
                 },
                 "sax": {
                     "version": "0.3.5",
-                    "bundled": true,
                     "dev": true
                 },
                 "shelljs": {
@@ -18657,11 +18845,12 @@
                 },
                 "unorm": {
                     "version": "1.3.3",
-                    "bundled": true,
                     "dev": true
                 },
                 "util-deprecate": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                    "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
                     "bundled": true,
                     "dev": true
                 },
@@ -18672,6 +18861,8 @@
                 },
                 "xmlbuilder": {
                     "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.0.0.tgz",
+                    "integrity": "sha512-wrG9gc6hCFDd5STt+6fsjP2aGSkjkNSewH+1K6s0KVOd94vXAUyTwlxWVnMFVtLdMf+q0QRZN1z9hTOKgoEdMg==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -23858,11 +24049,15 @@
             "dependencies": {
                 "abbrev": {
                     "version": "1.0.9",
+                    "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+                    "integrity": "sha512-LEyx4aLEC3x6T0UguF6YILf+ntvmOaWsVfENmIW0E9H09vKlLDGelMjjSm0jkDHALj8A8quZ/HapKNigzwge+Q==",
                     "bundled": true,
                     "dev": true
                 },
                 "ansi": {
                     "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+                    "integrity": "sha512-iFY7JCgHbepc0b82yLaw4IMortylNb6wG4kL+4R0C3iv6i+RHGHux/yUX5BTiRvSX/shMnngjR1YyNMnXEFh5A==",
                     "bundled": true,
                     "dev": true
                 },
@@ -23873,21 +24068,29 @@
                 },
                 "ansicolors": {
                     "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+                    "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==",
                     "bundled": true,
                     "dev": true
                 },
                 "ansistyles": {
                     "version": "0.1.3",
+                    "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
+                    "integrity": "sha512-6QWEyvMgIXX0eO972y7YPBLSBsq7UWKFAoNNTLGaOJ9bstcEL9sCbcjf96dVfNDdUsRoGOK82vWFJlKApXds7g==",
                     "bundled": true,
                     "dev": true
                 },
                 "archy": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+                    "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
                     "bundled": true,
                     "dev": true
                 },
                 "async-some": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/async-some/-/async-some-1.0.2.tgz",
+                    "integrity": "sha512-VbEsqdl4ztEqzb3Cgpk9L81Q4eyMl3XFdA0i+12Qmyw/bNx4aDAJqmIMKXh1mKGJ2IaPvGvN682YKZDaJMLUdA==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -23896,6 +24099,8 @@
                 },
                 "block-stream": {
                     "version": "0.0.9",
+                    "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+                    "integrity": "sha512-OorbnJVPII4DuUKbjARAe8u8EfqOmkEEaSFIyoQ7OjTHn6kafxWl0wLgoZ2rXaYd7MyLcDaU4TmhfxtwgcccMQ==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -23904,21 +24109,29 @@
                 },
                 "char-spinner": {
                     "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/char-spinner/-/char-spinner-1.0.1.tgz",
+                    "integrity": "sha512-acv43vqJ0+N0rD+Uw3pDHSxP30FHrywu2NO6/wBaHChJIizpDeBUd6NjqhNhy9LGaEAhZAXn46QzmlAvIWd16g==",
                     "bundled": true,
                     "dev": true
                 },
                 "chmodr": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-1.0.2.tgz",
+                    "integrity": "sha512-oHosCxCZpaI/Db320r8M5SHHZuVfnFJVwkSGkI81QLnnVg25pDw//NgD4fy1WvvydhZNi2G+jrbNSprRkfbRYA==",
                     "bundled": true,
                     "dev": true
                 },
                 "chownr": {
                     "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+                    "integrity": "sha512-cKnqUJAC8G6cuN1DiRRTifu+s1BlAQNtalzGphFEV0pl0p46dsxJD4l1AOlyKJeLZOFzo3c34R7F3djxaCu8Kw==",
                     "bundled": true,
                     "dev": true
                 },
                 "cmd-shim": {
                     "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
+                    "integrity": "sha512-NLt0ntM0kvuSNrToO0RTFiNRHdioWsLW+OgDAEVDvIivsYwR+AjlzvLaMJ2Z+SNRpV3vdsDrHp1WI00eetDYzw==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -23928,6 +24141,8 @@
                 },
                 "columnify": {
                     "version": "1.5.4",
+                    "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+                    "integrity": "sha512-rFl+iXVT1nhLQPfGDw+3WcS8rmm7XsLKUmhsGE3ihzzpIikeGrTaZPIRKYWeLsLBypsHzjXIvYEltVUZS84XxQ==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -23996,6 +24211,8 @@
                 },
                 "editor": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
+                    "integrity": "sha512-SoRmbGStwNYHgKfjOrX2L0mUvp9bUVv0uPppZSOMAntEbcFtoC3MKF5b3T6HQPXKIV+QGY3xPO3JK5it5lVkuw==",
                     "bundled": true,
                     "dev": true
                 },
@@ -24040,6 +24257,8 @@
                 },
                 "fstream-npm": {
                     "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.1.1.tgz",
+                    "integrity": "sha512-zKZuzxog3e6wPg22PC1UoI+efTOCtngC2b6qAZpUZu3t9oB3A+MuLIUosVPPFVmq6+WZsHZ3h1bhGazc4E9a7Q==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24061,16 +24280,22 @@
                 },
                 "github-url-from-git": {
                     "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.4.0.tgz",
+                    "integrity": "sha512-Vd1uAwEIbUaaYodSvEZRgMOdLUvY7+kZ+PuJNPVBXldTuVcHFtcLENvl2Ds9KKO9q6Ld2o+eVmA/wabaN3/2mQ==",
                     "bundled": true,
                     "dev": true
                 },
                 "github-url-from-username-repo": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/github-url-from-username-repo/-/github-url-from-username-repo-1.0.2.tgz",
+                    "integrity": "sha512-Tj8CQqRoFVTglGdQ8FQmfq8gOOoOYZX7tnOKP8jq8Hdz2OTDhxvtlkLAbrqMYZ7X/YdaYQoUG1IBWxISBfqZ+Q==",
                     "bundled": true,
                     "dev": true
                 },
                 "glob": {
                     "version": "7.0.6",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+                    "integrity": "sha512-f8c0rE8JiCxpa52kWPAOa3ZaYEnzofDzCQLCn3Vdk0Z5OVLq3BsRFJI4S4ykpeVW6QMGBUkMeUpoEgWnMTnw5Q==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24101,11 +24326,15 @@
                 },
                 "hosted-git-info": {
                     "version": "2.1.5",
+                    "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
+                    "integrity": "sha512-5sLwVGWIA8493A2PzG/py8s+uBrYqrwmLp6C6U5+Gpw5Ll49OOigsuD4LKbUTExbgedTNPvPb/0GV5ohHYYNBg==",
                     "bundled": true,
                     "dev": true
                 },
                 "imurmurhash": {
                     "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+                    "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
                     "bundled": true,
                     "dev": true
                 },
@@ -24273,6 +24502,8 @@
                 },
                 "nopt": {
                     "version": "3.0.6",
+                    "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+                    "integrity": "sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24281,6 +24512,8 @@
                 },
                 "normalize-git-url": {
                     "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/normalize-git-url/-/normalize-git-url-3.0.2.tgz",
+                    "integrity": "sha512-UEmKT33ssKLLoLCsFJ4Si4fmNQsedNwivXpuNTR4V1I97jU9WZlicTV1xn5QAG5itE5B3Z9zhl8OItP6wIGkRA==",
                     "bundled": true,
                     "dev": true
                 },
@@ -24314,11 +24547,15 @@
                 },
                 "npm-cache-filename": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
+                    "integrity": "sha512-5v2y1KG06izpGvZJDSBR5q1Ej+NaPDO05yAAWBJE6+3eiId0R176Gz3Qc2vEmJnE+VGul84g6Qpq8fXzD82/JA==",
                     "bundled": true,
                     "dev": true
                 },
                 "npm-install-checks": {
                     "version": "1.0.7",
+                    "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-1.0.7.tgz",
+                    "integrity": "sha512-IyaSpkt3NMXaXezbnHxwEZ6HBWpQFlKBUZ0ZEoUCyq3LoAaZEWJ2mchhJPauuvevhkvi8SNW67FiWZLpUhJ82w==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24337,6 +24574,8 @@
                 },
                 "npm-registry-client": {
                     "version": "7.2.1",
+                    "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-7.2.1.tgz",
+                    "integrity": "sha512-igXKTHWr0ipuL+pKNRBV2p2H4xqfnpVtYiWQmTKfq5/eFmZxKh9U+PyoqdKzqyvPTFLNQVqMGy5W5GjOr1Ukeg==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24418,11 +24657,15 @@
                 },
                 "npm-user-validate": {
                     "version": "0.1.5",
+                    "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-0.1.5.tgz",
+                    "integrity": "sha512-86IbFCunHe+6drSd71Aafs8H8xg55lHE9O1/6VS4s+OsBh53xEtQNY1lspkgoaO2b3hhfvDW2FA0eS47inrs1w==",
                     "bundled": true,
                     "dev": true
                 },
                 "npmlog": {
                     "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
+                    "integrity": "sha512-DaL6RTb8Qh4tMe2ttPT1qWccETy2Vi5/8p+htMpLBeXJTr2CAqnF5WQtSP2eFpvaNbhLZ5uilDb98mRm4Q+lZQ==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24515,6 +24758,8 @@
                 },
                 "once": {
                     "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                    "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24554,6 +24799,8 @@
                 },
                 "read": {
                     "version": "1.0.7",
+                    "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+                    "integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24569,6 +24816,8 @@
                 },
                 "read-installed": {
                     "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
+                    "integrity": "sha512-O03wg/IYuV/VtnK2h/KXEt9VIbMUFbk3ERG0Iu4FhLZw0EP0T9znqrYDGn6ncbEsXUFaUjiVAWXHzxwt3lhRPQ==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24583,6 +24832,8 @@
                     "dependencies": {
                         "debuglog": {
                             "version": "1.0.1",
+                            "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+                            "integrity": "sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==",
                             "bundled": true,
                             "dev": true
                         },
@@ -24653,6 +24904,8 @@
                 },
                 "readable-stream": {
                     "version": "2.1.5",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+                    "integrity": "sha512-NkXT2AER7VKXeXtJNSaWLpWIhmtSE3K2PguaLEeWr4JILghcIKqoLt1A3wHrnpDC5+ekf8gfk1GKWkFXe4odMw==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24708,6 +24961,8 @@
                 },
                 "request": {
                     "version": "2.74.0",
+                    "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
+                    "integrity": "sha512-m3uMovC42y63jXe/Sr49/qJdqpSYwQAgYIc487l0zSXI6Z6f5cV/V4a86h2Z+AAwKpt5bfB66KrZxOfOSdh6FQ==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24977,6 +25232,8 @@
                             "dependencies": {
                                 "boom": {
                                     "version": "2.10.1",
+                                    "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                                    "integrity": "sha512-KbiZEa9/vofNcVJXGwdWWn25reQ3V3dHBWbS07FTF3/TOehLnm9GEhJV4T6ZvGPkShRpmUqYwnaCrkj0mRnP6Q==",
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
@@ -24993,6 +25250,8 @@
                                 },
                                 "hoek": {
                                     "version": "2.16.3",
+                                    "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                                    "integrity": "sha512-V6Yw1rIcYV/4JsnggjBU0l4Kr+EXhpwqXRusENU1Xx6ro00IHPHYNynCuBTOZAPlr3AAmLvchH9I7N/VUdvOwQ==",
                                     "bundled": true,
                                     "dev": true
                                 },
@@ -25073,6 +25332,8 @@
                                         },
                                         "assert-plus": {
                                             "version": "1.0.0",
+                                            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                                            "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
                                             "bundled": true,
                                             "dev": true
                                         },
@@ -25195,6 +25456,8 @@
                 },
                 "rimraf": {
                     "version": "2.5.4",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+                    "integrity": "sha512-Lw7SHMjssciQb/rRz7JyPIy9+bbUshEucPoLRvWqy09vC5zQixl8Uet+Zl+SROBB/JMWHJRdCk1qdxNWHNMvlQ==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -25208,6 +25471,8 @@
                 },
                 "sha": {
                     "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
+                    "integrity": "sha512-Lj/GiNro+/4IIvhDvTo2HDqTmQkbqgg/O3lbkM5lMgagriGPpWamxtq1KJPx7mCvyF1/HG6Hs7zaYaj4xpfXbA==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -25259,6 +25524,8 @@
                 },
                 "slide": {
                     "version": "1.1.6",
+                    "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+                    "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
                     "bundled": true,
                     "dev": true
                 },
@@ -25269,11 +25536,15 @@
                 },
                 "spdx-license-ids": {
                     "version": "1.2.2",
+                    "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+                    "integrity": "sha512-qIBFhkh6ILCWNeWEe3ODFPKDYhPJrZpqdNCI2Z+w9lNdH5hoVEkfRLLbRfoIi8fb4xRYmpEOaaMH4G2pwYp/iQ==",
                     "bundled": true,
                     "dev": true
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -25292,16 +25563,22 @@
                 },
                 "text-table": {
                     "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+                    "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
                     "bundled": true,
                     "dev": true
                 },
                 "uid-number": {
                     "version": "0.0.6",
+                    "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+                    "integrity": "sha512-c461FXIljswCuscZn67xq9PpszkPT6RjheWFQTgCyabJrTUozElanb0YEqv2UGgk247YpcJkFBuSGNvBlpXM9w==",
                     "bundled": true,
                     "dev": true
                 },
                 "umask": {
                     "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
+                    "integrity": "sha512-lE/rxOhmiScJu9L6RTNVgB/zZbF+vGC0/p6D3xnkAePI2o0sMyFG966iR5Ki50OI/0mNi2yaRnxfLsPmEZF/JA==",
                     "bundled": true,
                     "dev": true
                 },
@@ -25342,6 +25619,8 @@
                 },
                 "validate-npm-package-name": {
                     "version": "2.2.2",
+                    "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-2.2.2.tgz",
+                    "integrity": "sha512-zt38kWHt0j/tv8ZKqZB5lEVT3A41JarczU/ib7L+OXZFAjC2l9kPeujQI1m4smU1nmSwF06MqEetltqVkDmnuQ==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -25372,11 +25651,15 @@
                 },
                 "wrappy": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                    "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
                     "bundled": true,
                     "dev": true
                 },
                 "write-file-atomic": {
                     "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz",
+                    "integrity": "sha512-c5qespPIeoD/YQTLgdOTe9mcjhK0MhK/URjnIlpuF+4Hoec1flfMRcZY+SWrqGHHRC1oGY1VyNC44wiLQgJMiw==",
                     "bundled": true,
                     "dev": true,
                     "requires": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
         "sinon-qunit": "2.0.0",
         "ssl-root-cas": "1.2.3",
         "tslint": "3.15.1",
-        "typescript": "2.1.6",
+        "typescript": "2.3.4",
         "urijs": "1.19.6",
         "velocity-animate": "1.4.2",
         "vinyl-source-stream": "1.1.0",

--- a/src/scripts/clientInfo.ts
+++ b/src/scripts/clientInfo.ts
@@ -1,4 +1,4 @@
-import {ClientType} from "./ClientType";
+import {ClientType} from "./clientType";
 
 export interface ClientInfo {
 	clipperId: string;

--- a/src/scripts/clipperUI/frontEndGlobals.ts
+++ b/src/scripts/clipperUI/frontEndGlobals.ts
@@ -5,6 +5,7 @@ import {Constants} from "../constants";
 
 import {RemoteStorage} from "../storage/remoteStorage";
 import {StorageAsync} from "../storage/storageAsync";
+import { StringUtils } from "../stringUtils";
 
 export class Clipper {
 	private static injectCommunicator: Communicator;
@@ -25,9 +26,13 @@ export class Clipper {
 			if (sessionId) {
 				resolve(sessionId);
 			} else {
-				Clipper.sessionId.subscribe((definedSessionId: string) => {
+				sessionId = StringUtils.generateGuid();
+				Clipper.sessionId.set(sessionId);
+				resolve(sessionId);
+				// TODO: Check if we still need to use the following code
+				/* Clipper.sessionId.subscribe((definedSessionId: string) => {
 					resolve(definedSessionId);
-				}, { times: 1, callOnSubscribe: false });
+				}, { times: 1, callOnSubscribe: false }); */
 			}
 		});
 	}

--- a/src/scripts/clipperUI/frontEndGlobals.ts
+++ b/src/scripts/clipperUI/frontEndGlobals.ts
@@ -1,7 +1,6 @@
 import {SmartValue} from "../communicator/smartValue";
 import {Communicator} from "../communicator/communicator";
 import {Logger} from "../logging/logger";
-import {Constants} from "../constants";
 
 import {RemoteStorage} from "../storage/remoteStorage";
 import { StorageAsync } from "../storage/storageAsync";

--- a/src/scripts/clipperUI/frontEndGlobals.ts
+++ b/src/scripts/clipperUI/frontEndGlobals.ts
@@ -4,7 +4,6 @@ import {Logger} from "../logging/logger";
 
 import {RemoteStorage} from "../storage/remoteStorage";
 import { StorageAsync } from "../storage/storageAsync";
-import { StringUtils } from "../stringUtils";
 
 export class Clipper {
 	private static injectCommunicator: Communicator;

--- a/src/scripts/clipperUI/frontEndGlobals.ts
+++ b/src/scripts/clipperUI/frontEndGlobals.ts
@@ -5,7 +5,6 @@ import {Constants} from "../constants";
 
 import {RemoteStorage} from "../storage/remoteStorage";
 import {StorageAsync} from "../storage/storageAsync";
-import { StringUtils } from "../stringUtils";
 
 export class Clipper {
 	private static injectCommunicator: Communicator;
@@ -26,13 +25,10 @@ export class Clipper {
 			if (sessionId) {
 				resolve(sessionId);
 			} else {
-				sessionId = StringUtils.generateGuid();
-				Clipper.sessionId.set(sessionId);
-				resolve(sessionId);
 				// TODO: Check if we still need to use the following code
-				/* Clipper.sessionId.subscribe((definedSessionId: string) => {
+				Clipper.sessionId.subscribe((definedSessionId: string) => {
 					resolve(definedSessionId);
-				}, { times: 1, callOnSubscribe: false }); */
+				}, { times: 1, callOnSubscribe: false });
 			}
 		});
 	}

--- a/src/scripts/clipperUI/frontEndGlobals.ts
+++ b/src/scripts/clipperUI/frontEndGlobals.ts
@@ -25,13 +25,9 @@ export class Clipper {
 			if (sessionId) {
 				resolve(sessionId);
 			} else {
-				sessionId = StringUtils.generateGuid();
-				Clipper.sessionId.set(sessionId);
-				resolve(sessionId);
-				// TODO: Check if we still need to use the following code
-				/* Clipper.sessionId.subscribe((definedSessionId: string) => {
+				Clipper.sessionId.subscribe((definedSessionId: string) => {
 					resolve(definedSessionId);
-				}, { times: 1, callOnSubscribe: false }); */
+				}, { times: 1, callOnSubscribe: false });
 			}
 		});
 	}

--- a/src/scripts/clipperUI/frontEndGlobals.ts
+++ b/src/scripts/clipperUI/frontEndGlobals.ts
@@ -4,7 +4,8 @@ import {Logger} from "../logging/logger";
 import {Constants} from "../constants";
 
 import {RemoteStorage} from "../storage/remoteStorage";
-import {StorageAsync} from "../storage/storageAsync";
+import { StorageAsync } from "../storage/storageAsync";
+import { StringUtils } from "../stringUtils";
 
 export class Clipper {
 	private static injectCommunicator: Communicator;
@@ -25,10 +26,13 @@ export class Clipper {
 			if (sessionId) {
 				resolve(sessionId);
 			} else {
+				sessionId = StringUtils.generateGuid();
+				Clipper.sessionId.set(sessionId);
+				resolve(sessionId);
 				// TODO: Check if we still need to use the following code
-				Clipper.sessionId.subscribe((definedSessionId: string) => {
+				/* Clipper.sessionId.subscribe((definedSessionId: string) => {
 					resolve(definedSessionId);
-				}, { times: 1, callOnSubscribe: false });
+				}, { times: 1, callOnSubscribe: false }); */
 			}
 		});
 	}

--- a/src/scripts/contentCapture/augmentationHelper.ts
+++ b/src/scripts/contentCapture/augmentationHelper.ts
@@ -14,7 +14,7 @@ import {HttpWithRetries} from "../http/httpWithRetries";
 import * as Log from "../logging/log";
 
 import {CaptureFailureInfo} from "./captureFailureInfo";
-import { ResponsePackage } from "../responsePackage";
+import { ErrorUtils, ResponsePackage } from "../responsePackage";
 
 export enum AugmentationModel {
 	None,
@@ -118,7 +118,9 @@ export class AugmentationHelper {
 							parsedResponse = JSON.parse(responseText);
 						} catch (e) {
 							Clipper.logger.logJsonParseUnexpected(responseText);
-							reject(OneNoteApi.RequestErrorType.UNABLE_TO_PARSE_RESPONSE);
+							ErrorUtils.createRequestErrorObject(response, OneNoteApi.RequestErrorType.UNABLE_TO_PARSE_RESPONSE).then((error) => {
+								reject(error);
+							});
 						}
 
 						let responsePackage = {

--- a/src/scripts/contentCapture/augmentationHelper.ts
+++ b/src/scripts/contentCapture/augmentationHelper.ts
@@ -10,13 +10,14 @@ import {Status} from "../clipperUI/status";
 
 import {DomUtils, EmbeddedVideoIFrameSrcs} from "../domParsers/domUtils";
 
-import {HttpWithRetries} from "../http/HttpWithRetries";
+import {HttpWithRetries} from "../http/httpWithRetries";
 
 import {Localization} from "../localization/localization";
 
 import * as Log from "../logging/log";
 
 import {CaptureFailureInfo} from "./captureFailureInfo";
+import { ResponsePackage } from "../responsePackage";
 
 export enum AugmentationModel {
 	None,
@@ -44,11 +45,12 @@ export class AugmentationHelper {
 			let correlationId = StringUtils.generateGuid();
 			augmentationEvent.setCustomProperty(Log.PropertyName.Custom.CorrelationId, correlationId);
 
-			AugmentationHelper.makeAugmentationRequest(url, locale, pageContent, correlationId).then((responsePackage: { parsedResponse: AugmentationResult[], request: XMLHttpRequest }) => {
+			AugmentationHelper.makeAugmentationRequest(url, locale, pageContent, correlationId).then((responsePackage: { parsedResponse: AugmentationResult[] }) => {
 				let parsedResponse = responsePackage.parsedResponse;
 				let result: AugmentationResult = { ContentModel: AugmentationModel.None, ContentObjects: []	};
 
-				augmentationEvent.setCustomProperty(Log.PropertyName.Custom.CorrelationId, responsePackage.request.getResponseHeader(Constants.HeaderValues.correlationId));
+				// TODO: Check if the following line is necessary
+				/* augmentationEvent.setCustomProperty(Log.PropertyName.Custom.CorrelationId, responsePackage.request.getResponseHeader(Constants.HeaderValues.correlationId)); */
 
 				if (parsedResponse && parsedResponse.length > 0 && parsedResponse[0].ContentInHtml) {
 					result = parsedResponse[0];
@@ -102,30 +104,33 @@ export class AugmentationHelper {
 	/*
 	 * Returns the augmented preview text.
 	 */
-	public static makeAugmentationRequest(url: string, locale: string, pageContent: string, requestCorrelationId: string): Promise<OneNoteApi.ResponsePackage<any>> {
-		return Clipper.getUserSessionIdWhenDefined().then((sessionId) => {
-			let augmentationApiUrl = Constants.Urls.augmentationApiUrl + "?renderMethod=extractAggressive&url=" + url + "&lang=" + locale;
+	public static makeAugmentationRequest(url: string, locale: string, pageContent: string, requestCorrelationId: string): Promise<ResponsePackage<any>> {
+		return new Promise<ResponsePackage<any>>((resolve, reject) => {
+			Clipper.getUserSessionIdWhenDefined().then((sessionId) => {
+				let augmentationApiUrl = Constants.Urls.augmentationApiUrl + "?renderMethod=extractAggressive&url=" + url + "&lang=" + locale;
 
-			let headers = {};
-			headers[Constants.HeaderValues.appIdKey] = Settings.getSetting("App_Id");
-			headers[Constants.HeaderValues.noAuthKey] = "true";
-			headers[Constants.HeaderValues.correlationId] = requestCorrelationId;
-			headers[Constants.HeaderValues.userSessionIdKey] = sessionId;
+				let headers = {};
+				headers[Constants.HeaderValues.appIdKey] = Settings.getSetting("App_Id");
+				headers[Constants.HeaderValues.noAuthKey] = "true";
+				headers[Constants.HeaderValues.correlationId] = requestCorrelationId;
+				headers[Constants.HeaderValues.userSessionIdKey] = sessionId;
 
-			return HttpWithRetries.post(augmentationApiUrl, pageContent, headers).then((request: XMLHttpRequest) => {
-				let parsedResponse: any;
-				try {
-					parsedResponse = JSON.parse(request.response);
-				} catch (e) {
-					Clipper.logger.logJsonParseUnexpected(request.response);
-					return Promise.reject(OneNoteApi.ErrorUtils.createRequestErrorObject(request, OneNoteApi.RequestErrorType.UNABLE_TO_PARSE_RESPONSE));
-				}
+				HttpWithRetries.post(augmentationApiUrl, pageContent, headers).then((response: Response) => {
+					response.text().then((responseText: string) => {
+						let parsedResponse: any;
+						try {
+							parsedResponse = JSON.parse(responseText);
+						} catch (e) {
+							Clipper.logger.logJsonParseUnexpected(responseText);
+							reject(OneNoteApi.RequestErrorType.UNABLE_TO_PARSE_RESPONSE);
+						}
 
-				let responsePackage = {
-					parsedResponse: parsedResponse,
-					request: request
-				};
-				return Promise.resolve(responsePackage);
+						let responsePackage = {
+							parsedResponse: parsedResponse
+						};
+						resolve(responsePackage);
+					});
+				});
 			});
 		});
 	}

--- a/src/scripts/contentCapture/augmentationHelper.ts
+++ b/src/scripts/contentCapture/augmentationHelper.ts
@@ -6,13 +6,10 @@ import {ObjectUtils} from "../objectUtils";
 import {Clipper} from "../clipperUI/frontEndGlobals";
 import {ClipperState} from "../clipperUI/clipperState";
 import {OneNoteApiUtils} from "../clipperUI/oneNoteApiUtils";
-import {Status} from "../clipperUI/status";
 
 import {DomUtils, EmbeddedVideoIFrameSrcs} from "../domParsers/domUtils";
 
 import {HttpWithRetries} from "../http/httpWithRetries";
-
-import {Localization} from "../localization/localization";
 
 import * as Log from "../logging/log";
 

--- a/src/scripts/contentCapture/augmentationHelper.ts
+++ b/src/scripts/contentCapture/augmentationHelper.ts
@@ -45,12 +45,12 @@ export class AugmentationHelper {
 			let correlationId = StringUtils.generateGuid();
 			augmentationEvent.setCustomProperty(Log.PropertyName.Custom.CorrelationId, correlationId);
 
-			AugmentationHelper.makeAugmentationRequest(url, locale, pageContent, correlationId).then((responsePackage: { parsedResponse: AugmentationResult[] }) => {
+			AugmentationHelper.makeAugmentationRequest(url, locale, pageContent, correlationId).then((responsePackage: { parsedResponse: AugmentationResult[], response: Response }) => {
 				let parsedResponse = responsePackage.parsedResponse;
 				let result: AugmentationResult = { ContentModel: AugmentationModel.None, ContentObjects: []	};
 
 				// TODO: Check if the following line is necessary
-				/* augmentationEvent.setCustomProperty(Log.PropertyName.Custom.CorrelationId, responsePackage.request.getResponseHeader(Constants.HeaderValues.correlationId)); */
+				augmentationEvent.setCustomProperty(Log.PropertyName.Custom.CorrelationId, responsePackage.response.headers.get(Constants.HeaderValues.correlationId));
 
 				if (parsedResponse && parsedResponse.length > 0 && parsedResponse[0].ContentInHtml) {
 					result = parsedResponse[0];
@@ -126,7 +126,8 @@ export class AugmentationHelper {
 						}
 
 						let responsePackage = {
-							parsedResponse: parsedResponse
+							parsedResponse: parsedResponse,
+							response: response
 						};
 						resolve(responsePackage);
 					});

--- a/src/scripts/contentCapture/augmentationHelper.ts
+++ b/src/scripts/contentCapture/augmentationHelper.ts
@@ -49,7 +49,6 @@ export class AugmentationHelper {
 				let parsedResponse = responsePackage.parsedResponse;
 				let result: AugmentationResult = { ContentModel: AugmentationModel.None, ContentObjects: []	};
 
-				// TODO: Check if the following line is necessary
 				augmentationEvent.setCustomProperty(Log.PropertyName.Custom.CorrelationId, responsePackage.response.headers.get(Constants.HeaderValues.correlationId));
 
 				if (parsedResponse && parsedResponse.length > 0 && parsedResponse[0].ContentInHtml) {

--- a/src/scripts/contentCapture/fullPageScreenshotHelper.ts
+++ b/src/scripts/contentCapture/fullPageScreenshotHelper.ts
@@ -12,6 +12,7 @@ import {Settings} from "../settings";
 import {StringUtils} from "../stringUtils";
 
 import {CaptureFailureInfo} from "./captureFailureInfo";
+import { ErrorUtils } from "../responsePackage";
 
 export interface FullPageScreenshotResult extends CaptureFailureInfo {
 	ImageEncoding?: string;
@@ -49,7 +50,9 @@ export class FullPageScreenshotHelper {
 								resolve(JSON.parse(responseText) as FullPageScreenshotResult);
 								fullPageScreenshotEvent.setCustomProperty(Log.PropertyName.Custom.FullPageScreenshotContentFound, true);
 							} catch (e) {
-								reject(OneNoteApi.RequestErrorType.UNABLE_TO_PARSE_RESPONSE);
+								ErrorUtils.createRequestErrorObject(response, OneNoteApi.RequestErrorType.UNABLE_TO_PARSE_RESPONSE).then((error) => {
+									reject(error);
+								});
 							}
 						});
 					} else {

--- a/src/scripts/contentCapture/fullPageScreenshotHelper.ts
+++ b/src/scripts/contentCapture/fullPageScreenshotHelper.ts
@@ -50,7 +50,7 @@ export class FullPageScreenshotHelper {
 								resolve(JSON.parse(responseText) as FullPageScreenshotResult);
 								fullPageScreenshotEvent.setCustomProperty(Log.PropertyName.Custom.FullPageScreenshotContentFound, true);
 							} catch (e) {
-								ErrorUtils.createRequestErrorObject(response, OneNoteApi.RequestErrorType.UNABLE_TO_PARSE_RESPONSE).then((error) => {
+								ErrorUtils.createRequestErrorObject(response, OneNoteApi.RequestErrorType.UNABLE_TO_PARSE_RESPONSE, FullPageScreenshotHelper.timeout).then((error) => {
 									reject(error);
 								});
 							}

--- a/src/scripts/contentCapture/fullPageScreenshotHelper.ts
+++ b/src/scripts/contentCapture/fullPageScreenshotHelper.ts
@@ -42,15 +42,16 @@ export class FullPageScreenshotHelper {
 					OneNoteApiUtils.logOneNoteApiRequestError(fullPageScreenshotEvent, error);
 				};
 
-				HttpWithRetries.post(Constants.Urls.fullPageScreenshotUrl, pageInfoContentData, headers, [200, 204], FullPageScreenshotHelper.timeout).then((request: XMLHttpRequest) => {
-					if (request.status === 200) {
-						try {
-							resolve(JSON.parse(request.response) as FullPageScreenshotResult);
-							fullPageScreenshotEvent.setCustomProperty(Log.PropertyName.Custom.FullPageScreenshotContentFound, true);
-						} catch (e) {
-							errorCallback(OneNoteApi.ErrorUtils.createRequestErrorObject(request, OneNoteApi.RequestErrorType.UNABLE_TO_PARSE_RESPONSE));
-							reject();
-						}
+				HttpWithRetries.post(Constants.Urls.fullPageScreenshotUrl, pageInfoContentData, headers, [200, 204], FullPageScreenshotHelper.timeout).then((response: Response) => {
+					if (response.status === 200) {
+						response.text().then((responseText: string) => {
+							try {
+								resolve(JSON.parse(responseText) as FullPageScreenshotResult);
+								fullPageScreenshotEvent.setCustomProperty(Log.PropertyName.Custom.FullPageScreenshotContentFound, true);
+							} catch (e) {
+								reject(OneNoteApi.RequestErrorType.UNABLE_TO_PARSE_RESPONSE);
+							}
+						});
 					} else {
 						fullPageScreenshotEvent.setCustomProperty(Log.PropertyName.Custom.FullPageScreenshotContentFound, false);
 						reject();

--- a/src/scripts/extensions/authenticationHelper.ts
+++ b/src/scripts/extensions/authenticationHelper.ts
@@ -3,13 +3,13 @@ import {SmartValue} from "../communicator/smartValue";
 import * as Log from "../logging/log";
 import {Logger} from "../logging/logger";
 
-import {CachedHttp, TimeStampedData} from "../http/cachedHttp";
+import {TimeStampedData} from "../http/cachedHttp";
 import {HttpWithRetries} from "../http/httpWithRetries";
 
 import {ClipperData} from "../storage/clipperData";
 import {ClipperStorageKeys} from "../storage/clipperStorageKeys";
 
-import {AuthType, UserInfo, UpdateReason} from "../userInfo";
+import {UserInfo, UpdateReason} from "../userInfo";
 import {Constants} from "../constants";
 import {ObjectUtils} from "../objectUtils";
 import {ResponsePackage} from "../responsePackage";

--- a/src/scripts/extensions/authenticationHelper.ts
+++ b/src/scripts/extensions/authenticationHelper.ts
@@ -4,7 +4,7 @@ import * as Log from "../logging/log";
 import {Logger} from "../logging/logger";
 
 import {CachedHttp, TimeStampedData} from "../http/cachedHttp";
-import {HttpWithRetries} from "../http/HttpWithRetries";
+import {HttpWithRetries} from "../http/httpWithRetries";
 
 import {ClipperData} from "../storage/clipperData";
 import {ClipperStorageKeys} from "../storage/clipperStorageKeys";
@@ -119,7 +119,7 @@ export class AuthenticationHelper {
 
 			HttpWithRetries.post(userInfoUrl, postData, headers).then((response: Response) => {
 				response.text().then((responseText: string) => {
-					resolve({ parsedResponse: responseText });
+					resolve({ parsedResponse: responseText, response: response });
 				});
 			}, (error: OneNoteApi.RequestError) => {
 				retrieveUserInformationEvent.setStatus(Log.Status.Failed);

--- a/src/scripts/extensions/authenticationHelper.ts
+++ b/src/scripts/extensions/authenticationHelper.ts
@@ -17,7 +17,7 @@ import {StringUtils} from "../stringUtils";
 import {UserInfoData} from "../userInfo";
 import { UrlUtils } from "../urlUtils";
 import { UserDataBoundaryHelper } from "./userDataBoundaryHelper";
-import { DataBoundary } from "./DataBoundary";
+import { DataBoundary } from "./dataBoundary";
 
 declare var browser;
 
@@ -117,10 +117,10 @@ export class AuthenticationHelper {
 				postData = cookie.replace(/\+/g, "%2B");
 			}
 
-			HttpWithRetries.post(userInfoUrl, postData, headers).then((request: XMLHttpRequest) => {
-				let response = request.response;
-
-				resolve({ parsedResponse: response, request: request });
+			HttpWithRetries.post(userInfoUrl, postData, headers).then((response: Response) => {
+				response.text().then((responseText: string) => {
+					resolve({ parsedResponse: responseText });
+				});
 			}, (error: OneNoteApi.RequestError) => {
 				retrieveUserInformationEvent.setStatus(Log.Status.Failed);
 				retrieveUserInformationEvent.setFailureInfo(error);

--- a/src/scripts/extensions/extensionBase.ts
+++ b/src/scripts/extensions/extensionBase.ts
@@ -1,8 +1,6 @@
 import {ClientInfo} from "../clientInfo";
-import {ClientType} from "../ClientType";
+import {ClientType} from "../clientType";
 import {Constants} from "../constants";
-import {Experiments} from "../experiments";
-import {ResponsePackage} from "../responsePackage";
 import {StringUtils} from "../stringUtils";
 import {UrlUtils} from "../urlUtils";
 

--- a/src/scripts/extensions/extensionWorkerBase.ts
+++ b/src/scripts/extensions/extensionWorkerBase.ts
@@ -1,6 +1,6 @@
 import {BrowserUtils} from "../browserUtils";
 import {ClientInfo} from "../clientInfo";
-import {ClientType} from "../clientType";
+import {ClientType} from "../ClientType";
 import {ClipperUrls} from "../clipperUrls";
 import {CookieUtils} from "../cookieUtils";
 import {Constants} from "../constants";

--- a/src/scripts/extensions/extensionWorkerBase.ts
+++ b/src/scripts/extensions/extensionWorkerBase.ts
@@ -1,6 +1,6 @@
 import {BrowserUtils} from "../browserUtils";
 import {ClientInfo} from "../clientInfo";
-import {ClientType} from "../ClientType";
+import {ClientType} from "../clientType";
 import {ClipperUrls} from "../clipperUrls";
 import {CookieUtils} from "../cookieUtils";
 import {Constants} from "../constants";
@@ -17,7 +17,6 @@ import {SmartValue} from "../communicator/smartValue";
 
 import {ClipperCachedHttp} from "../http/clipperCachedHttp";
 
-import {Localization} from "../localization/localization";
 import {LocalizationHelper} from "../localization/localizationHelper";
 
 import * as Log from "../logging/log";

--- a/src/scripts/extensions/userDataBoundaryHelper.ts
+++ b/src/scripts/extensions/userDataBoundaryHelper.ts
@@ -3,7 +3,7 @@ import { Constants } from "../constants";
 import { HttpWithRetries } from "../http/HttpWithRetries";
 import { UrlUtils } from "../urlUtils";
 import { UserInfoData, AuthType } from "../userInfo";
-import { DataBoundary } from "./DataBoundary";
+import { DataBoundary } from "./dataBoundary";
 
 export class UserDataBoundaryHelper {
 	/**
@@ -39,21 +39,23 @@ export class UserDataBoundaryHelper {
 			let domainValue = userInfo.emailAddress.substring(
 				userInfo.emailAddress.indexOf("@") + 1);
 			const urlDataBoundaryDomain: string = UrlUtils.addUrlQueryValue(Constants.Urls.userDataBoundaryDomain, Constants.Urls.QueryParams.domain, domainValue);
-			HttpWithRetries.get(urlDataBoundaryDomain).then((request: XMLHttpRequest) => {
+			HttpWithRetries.get(urlDataBoundaryDomain).then((response: Response) => {
 				let expectedCodes = [200];
-				if (expectedCodes.indexOf(request.status) > -1) {
-					let parsedResponse: any;
-					try {
-						parsedResponse = JSON.parse(request.responseText);
-					} catch (error) {
-						Clipper.logger.logJsonParseUnexpected(request.response);
-						reject(error);
-					}
-					if (parsedResponse && parsedResponse.telemetryRegion) {
-						resolve(parsedResponse.telemetryRegion);
-					} else {
-						resolve(DataBoundary[DataBoundary.UNKNOWN]);
-					}
+				if (expectedCodes.indexOf(response.status) > -1) {
+					response.text().then((responseText: string) => {
+						let parsedResponse: any;
+						try {
+							parsedResponse = JSON.parse(responseText);
+						} catch (error) {
+							Clipper.logger.logJsonParseUnexpected(responseText);
+							reject(error);
+						}
+						if (parsedResponse && parsedResponse.telemetryRegion) {
+							resolve(parsedResponse.telemetryRegion);
+						} else {
+							resolve(DataBoundary[DataBoundary.UNKNOWN]);
+						}
+					});
 				} else {
 					resolve(DataBoundary[DataBoundary.UNKNOWN]);
 				}

--- a/src/scripts/extensions/userDataBoundaryHelper.ts
+++ b/src/scripts/extensions/userDataBoundaryHelper.ts
@@ -1,6 +1,6 @@
 import { Clipper } from "../clipperUI/frontEndGlobals";
 import { Constants } from "../constants";
-import { HttpWithRetries } from "../http/HttpWithRetries";
+import { HttpWithRetries } from "../http/httpWithRetries";
 import { UrlUtils } from "../urlUtils";
 import { UserInfoData, AuthType } from "../userInfo";
 import { DataBoundary } from "./dataBoundary";

--- a/src/scripts/http/clipperCachedHttp.ts
+++ b/src/scripts/http/clipperCachedHttp.ts
@@ -59,7 +59,6 @@ export class ClipperCachedHttp extends CachedHttp {
 
 			return new Promise<ResponsePackage<string>>((resolve, reject) => {
 				getResponseAsync().then((responsePackage) => {
-					// TODO: Check if the following piece of code is necessary
 					if (responsePackage.response) {
 						ClipperCachedHttp.addCorrelationIdToLogEvent(fetchNonLocalDataEvent, responsePackage.response);
 					}

--- a/src/scripts/http/clipperCachedHttp.ts
+++ b/src/scripts/http/clipperCachedHttp.ts
@@ -60,9 +60,9 @@ export class ClipperCachedHttp extends CachedHttp {
 			return new Promise<ResponsePackage<string>>((resolve, reject) => {
 				getResponseAsync().then((responsePackage) => {
 					// TODO: Check if the following piece of code is necessary
-					/* if (responsePackage.request) {
-						ClipperCachedHttp.addCorrelationIdToLogEvent(fetchNonLocalDataEvent, responsePackage.request);
-					} */
+					if (responsePackage.response) {
+						ClipperCachedHttp.addCorrelationIdToLogEvent(fetchNonLocalDataEvent, responsePackage.response);
+					}
 					resolve(responsePackage);
 				}, (error) => {
 					fetchNonLocalDataEvent.setStatus(Log.Status.Failed);
@@ -75,8 +75,8 @@ export class ClipperCachedHttp extends CachedHttp {
 		};
 	}
 
-	private static addCorrelationIdToLogEvent(logEvent: Log.Event.PromiseEvent, request: XMLHttpRequest) {
-		let correlationId = request.getResponseHeader(Constants.HeaderValues.correlationId);
+	private static addCorrelationIdToLogEvent(logEvent: Log.Event.PromiseEvent, response: Response) {
+		let correlationId = response.headers.get(Constants.HeaderValues.correlationId);
 		if (correlationId) {
 			logEvent.setCustomProperty(Log.PropertyName.Custom.CorrelationId, correlationId);
 		}

--- a/src/scripts/http/clipperCachedHttp.ts
+++ b/src/scripts/http/clipperCachedHttp.ts
@@ -59,9 +59,10 @@ export class ClipperCachedHttp extends CachedHttp {
 
 			return new Promise<ResponsePackage<string>>((resolve, reject) => {
 				getResponseAsync().then((responsePackage) => {
-					if (responsePackage.request) {
+					// TODO: Check if the following piece of code is necessary
+					/* if (responsePackage.request) {
 						ClipperCachedHttp.addCorrelationIdToLogEvent(fetchNonLocalDataEvent, responsePackage.request);
-					}
+					} */
 					resolve(responsePackage);
 				}, (error) => {
 					fetchNonLocalDataEvent.setStatus(Log.Status.Failed);

--- a/src/scripts/http/http.ts
+++ b/src/scripts/http/http.ts
@@ -1,4 +1,5 @@
 import {ObjectUtils} from "../objectUtils";
+import { ErrorUtils } from "../responsePackage";
 
 /**
  * Helper class for performing http requests. For each of the http methods, resolve(request) is only
@@ -34,7 +35,9 @@ export class Http {
 				if (expectedCodes.indexOf(response.status) > -1) {
 					resolve(response);
 				} else {
-					reject(OneNoteApi.RequestErrorType.UNEXPECTED_RESPONSE_STATUS);
+					ErrorUtils.createRequestErrorObject(response, OneNoteApi.RequestErrorType.UNEXPECTED_RESPONSE_STATUS, timeout).then((error) => {
+						reject(error);
+					});
 				}
 			}).catch(() => {
 				reject(OneNoteApi.RequestErrorType.NETWORK_ERROR);

--- a/src/scripts/http/httpWithRetries.ts
+++ b/src/scripts/http/httpWithRetries.ts
@@ -7,7 +7,7 @@ import {PromiseUtils, RetryOptions} from "../promiseUtils";
  * Helper class which extends the Http class in order to allow automatic retries.
  */
 export class HttpWithRetries extends Http {
-	public static get(url: string, headers?: any, timeout = Http.defaultTimeout, expectedCodes = [200], retryOptions?: RetryOptions): Promise<XMLHttpRequest> {
+	public static get(url: string, headers?: any, timeout = Http.defaultTimeout, expectedCodes = [200], retryOptions?: RetryOptions): Promise<Response> {
 		let func = () => {
 			return super.createAndSendRequest("GET", url, headers, expectedCodes, timeout);
 		};
@@ -15,7 +15,7 @@ export class HttpWithRetries extends Http {
 		return PromiseUtils.execWithRetry(func, retryOptions);
 	}
 
-	public static post(url: string, data: any, headers?: any, expectedCodes = [200], timeout = Http.defaultTimeout, retryOptions?: RetryOptions): Promise<XMLHttpRequest> {
+	public static post(url: string, data: any, headers?: any, expectedCodes = [200], timeout = Http.defaultTimeout, retryOptions?: RetryOptions): Promise<Response> {
 		if (ObjectUtils.isNullOrUndefined(data)) {
 			throw new Error("data must be a non-undefined object, but was: " + data);
 		}

--- a/src/scripts/localization/localizationHelper.ts
+++ b/src/scripts/localization/localizationHelper.ts
@@ -8,10 +8,13 @@ export class LocalizationHelper {
 	public static makeLocStringsFetchRequest(locale: string): Promise<ResponsePackage<string>> {
 		let url = UrlUtils.addUrlQueryValue(Constants.Urls.localizedStringsUrlBase, "locale", locale);
 
-		return HttpWithRetries.get(url).then((request) => {
-			return Promise.resolve({
-				request: request,
-				parsedResponse: request.responseText
+		return HttpWithRetries.get(url).then((response: Response) => {
+			return new Promise<ResponsePackage<string>>(resolve => {
+				response.text().then((responseText: string) => {
+					resolve({
+						parsedResponse: responseText
+					});
+				});
 			});
 		});
 	}

--- a/src/scripts/localization/localizationHelper.ts
+++ b/src/scripts/localization/localizationHelper.ts
@@ -2,7 +2,7 @@ import {Constants} from "../constants";
 import {ResponsePackage} from "../responsePackage";
 import {UrlUtils} from "../urlUtils";
 
-import {HttpWithRetries} from "../http/HttpWithRetries";
+import {HttpWithRetries} from "../http/httpWithRetries";
 
 export class LocalizationHelper {
 	public static makeLocStringsFetchRequest(locale: string): Promise<ResponsePackage<string>> {
@@ -12,7 +12,8 @@ export class LocalizationHelper {
 			return new Promise<ResponsePackage<string>>(resolve => {
 				response.text().then((responseText: string) => {
 					resolve({
-						parsedResponse: responseText
+						parsedResponse: responseText,
+						response: response
 					});
 				});
 			});

--- a/src/scripts/logging/submodules/errorUtils.ts
+++ b/src/scripts/logging/submodules/errorUtils.ts
@@ -1,5 +1,5 @@
 import {ClientInfo} from "../../clientInfo";
-import {ClientType} from "../../clientType";
+import {ClientType} from "../../ClientType";
 import {Constants} from "../../constants";
 import {ObjectUtils} from "../../objectUtils";
 import {Settings} from "../../settings";

--- a/src/scripts/logging/submodules/errorUtils.ts
+++ b/src/scripts/logging/submodules/errorUtils.ts
@@ -1,14 +1,13 @@
 import {ClientInfo} from "../../clientInfo";
-import {ClientType} from "../../ClientType";
+import {ClientType} from "../../clientType";
 import {Constants} from "../../constants";
 import {ObjectUtils} from "../../objectUtils";
-import {Settings} from "../../settings";
 
 import {SmartValue} from "../../communicator/smartValue";
 
 import {Localization} from "../../localization/localization";
 
-import {Failure, LogDataPackage, LogMethods, NoOp, PropertyName, reportData, unknownValue} from "../log";
+import {Failure, NoOp, unknownValue} from "../log";
 
 export module ErrorUtils {
 	enum ErrorPropertyName {

--- a/src/scripts/responsePackage.ts
+++ b/src/scripts/responsePackage.ts
@@ -1,4 +1,4 @@
 export interface ResponsePackage<T> {
 	parsedResponse: T;
-	request: XMLHttpRequest;
+	/* request: XMLHttpRequest; */
 }

--- a/src/scripts/responsePackage.ts
+++ b/src/scripts/responsePackage.ts
@@ -1,4 +1,4 @@
 export interface ResponsePackage<T> {
 	parsedResponse: T;
-	/* request: XMLHttpRequest; */
+	response: Response;
 }

--- a/src/scripts/responsePackage.ts
+++ b/src/scripts/responsePackage.ts
@@ -2,3 +2,45 @@ export interface ResponsePackage<T> {
 	parsedResponse: T;
 	response: Response;
 }
+
+export class ErrorUtils {
+	public static createRequestErrorObject(response: Response, errorType: OneNoteApi.RequestErrorType, timeout = 30000): Promise<OneNoteApi.RequestError> {
+		return new Promise<OneNoteApi.RequestError>((resolve, reject) => {
+			if (response === undefined) {
+				reject();
+			}
+
+			response.text().then((responseText: string) => {
+				resolve(createRequestErrorObjectInternal(response.status, responseText, response.headers, timeout, errorType));
+			});
+		});
+	}
+}
+
+function createRequestErrorObjectInternal(status: number, responseText: string, responseHeaders: Headers, timeout: number, errorType: OneNoteApi.RequestErrorType): OneNoteApi.RequestError {
+	let errorMessage = formatRequestErrorTypeAsString(errorType);
+	if (errorType === OneNoteApi.RequestErrorType.NETWORK_ERROR) {
+		// readyState doesn't exist on Response, so we can't use it here
+	}
+	if (errorType === OneNoteApi.RequestErrorType.REQUEST_TIMED_OUT) {
+		status = 408;
+	}
+	let requestErrorObject: OneNoteApi.RequestError = {
+		error: errorMessage,
+		statusCode: status,
+		responseHeaders: JSON.parse(responseHeaders.toString()),
+		response: responseText
+	};
+	// add the timeout property iff
+	// 1) timeout is greater than 0ms
+	// 2) status code is not in the 2XX range
+	if (timeout > 0 && !(status >= 200 && status < 300)) {
+		requestErrorObject.timeout = timeout;
+	}
+	return requestErrorObject;
+}
+
+function formatRequestErrorTypeAsString(errorType: OneNoteApi.RequestErrorType): string {
+	let errorTypeString = OneNoteApi.RequestErrorType[errorType];
+	return errorTypeString.charAt(0).toUpperCase() + errorTypeString.replace(/_/g, " ").toLowerCase().slice(1);
+}

--- a/src/tests/contentCapture/augmentationHelper_tests.ts
+++ b/src/tests/contentCapture/augmentationHelper_tests.ts
@@ -54,6 +54,7 @@ export class AugmentationHelperTests extends TestModule {
 
 			AugmentationHelper.makeAugmentationRequest(pageInfo.canonicalUrl, pageInfo.contentLocale, pageInfo.contentData, "abc123").then((responsePackage) => {
 				deepEqual(responsePackage.parsedResponse, responseJson, "The parsedResponse field should be the response in json form");
+				ok(responsePackage.response, "The response field should be defined");
 			}).catch((error) => {
 				ok(false, "reject should not be called");
 			}).then(() => {

--- a/src/tests/contentCapture/augmentationHelper_tests.ts
+++ b/src/tests/contentCapture/augmentationHelper_tests.ts
@@ -54,7 +54,6 @@ export class AugmentationHelperTests extends TestModule {
 
 			AugmentationHelper.makeAugmentationRequest(pageInfo.canonicalUrl, pageInfo.contentLocale, pageInfo.contentData, "abc123").then((responsePackage) => {
 				deepEqual(responsePackage.parsedResponse, responseJson, "The parsedResponse field should be the response in json form");
-				ok(responsePackage.request, "The request field should be defined");
 			}).catch((error) => {
 				ok(false, "reject should not be called");
 			}).then(() => {

--- a/src/tests/http/cachedHttp_tests.ts
+++ b/src/tests/http/cachedHttp_tests.ts
@@ -74,7 +74,7 @@ export class CachedHttpTests extends TestModule {
 			let getRemoteValue = () => {
 				return Promise.resolve({
 					parsedResponse: JSON.stringify("notexpected"),
-					request: undefined // We don't care about the request in the test
+					response: undefined // We don't care about the request in the test
 				} as ResponsePackage<string>);
 			};
 
@@ -109,7 +109,7 @@ export class CachedHttpTests extends TestModule {
 			let getRemoteValue = () => {
 				return Promise.resolve({
 					parsedResponse: JSON.stringify(expected),
-					request: undefined // We don't care about the request in the test
+					response: undefined // We don't care about the request in the test
 				} as ResponsePackage<string>);
 			};
 
@@ -139,7 +139,7 @@ export class CachedHttpTests extends TestModule {
 			let getRemoteValue = () => {
 				return Promise.resolve({
 					parsedResponse: response,
-					request: undefined // We don't care about the request in the test
+					response: undefined // We don't care about the request in the test
 				} as ResponsePackage<string>);
 			};
 

--- a/src/tests/http/cachedHttp_tests.ts
+++ b/src/tests/http/cachedHttp_tests.ts
@@ -74,7 +74,7 @@ export class CachedHttpTests extends TestModule {
 			let getRemoteValue = () => {
 				return Promise.resolve({
 					parsedResponse: JSON.stringify("notexpected"),
-					response: undefined // We don't care about the request in the test
+					response: undefined // We don't care about the response in the test
 				} as ResponsePackage<string>);
 			};
 
@@ -109,7 +109,7 @@ export class CachedHttpTests extends TestModule {
 			let getRemoteValue = () => {
 				return Promise.resolve({
 					parsedResponse: JSON.stringify(expected),
-					response: undefined // We don't care about the request in the test
+					response: undefined // We don't care about the response in the test
 				} as ResponsePackage<string>);
 			};
 
@@ -139,7 +139,7 @@ export class CachedHttpTests extends TestModule {
 			let getRemoteValue = () => {
 				return Promise.resolve({
 					parsedResponse: response,
-					response: undefined // We don't care about the request in the test
+					response: undefined // We don't care about the response in the test
 				} as ResponsePackage<string>);
 			};
 

--- a/src/tests/storage/clipperData_tests.ts
+++ b/src/tests/storage/clipperData_tests.ts
@@ -26,7 +26,7 @@ export class ClipperDataTests extends TestModule {
 			let parsedResponse = {};
 			let expectedTimeStampedData = {
 				parsedResponse: JSON.stringify(parsedResponse),
-				request: undefined
+				response: undefined
 			};
 			let getRemoteValue = () => {
 				return Promise.resolve(expectedTimeStampedData);
@@ -50,7 +50,7 @@ export class ClipperDataTests extends TestModule {
 			let parsedResponse = {};
 			let expectedTimeStampedData = {
 				parsedResponse: JSON.stringify(parsedResponse),
-				request: undefined
+				response: undefined
 			};
 			let getRemoteValue = () => {
 				return Promise.resolve(expectedTimeStampedData);
@@ -74,7 +74,7 @@ export class ClipperDataTests extends TestModule {
 			let key = ClipperStorageKeys.cachedNotebooks;
 			let expectedTimeStampedData = JSON.stringify({
 				parsedResponse: "{ notebooks: {} }",
-				request: undefined
+				response: undefined
 			});
 
 			let clipperData = new ClipperData(this.mockStorage);
@@ -87,7 +87,7 @@ export class ClipperDataTests extends TestModule {
 			let key = ClipperStorageKeys.cachedNotebooks;
 			let expectedTimeStampedData = JSON.stringify({
 				parsedResponse: "{ notebooks: {} }",
-				request: undefined
+				response: undefined
 			});
 
 			this.mockStorage.setValue(ClipperStorageKeys.userInformation, "{ name: Leeeeeroy }");
@@ -102,7 +102,7 @@ export class ClipperDataTests extends TestModule {
 			let key = ClipperStorageKeys.currentSelectedSection;
 			let expectedTimeStampedData = JSON.stringify({
 				parsedResponse: "{ section: {} }",
-				request: undefined
+				response: undefined
 			});
 
 			let clipperData = new ClipperData(this.mockStorage);
@@ -115,7 +115,7 @@ export class ClipperDataTests extends TestModule {
 			let key = ClipperStorageKeys.currentSelectedSection;
 			let expectedTimeStampedData = JSON.stringify({
 				parsedResponse: "{ section: {} }",
-				request: undefined
+				response: undefined
 			});
 
 			this.mockStorage.setValue(ClipperStorageKeys.userInformation, "{ name: Leeeeeroy }");

--- a/src/tests/storage/mockStorage.ts
+++ b/src/tests/storage/mockStorage.ts
@@ -8,7 +8,7 @@ export class MockStorage implements Storage {
 	public static localData = { myKey: "local" };
 	public static fetchNonLocalData: () => Promise<ResponsePackage<string>> = () => {
 		return new Promise<ResponsePackage<string>>((resolve, reject) => {
-			resolve({ parsedResponse: JSON.stringify(MockStorage.nonLocalData) });
+			resolve({ parsedResponse: JSON.stringify(MockStorage.nonLocalData), response: undefined });
 		});
 	};
 

--- a/src/tests/storage/mockStorage.ts
+++ b/src/tests/storage/mockStorage.ts
@@ -8,7 +8,7 @@ export class MockStorage implements Storage {
 	public static localData = { myKey: "local" };
 	public static fetchNonLocalData: () => Promise<ResponsePackage<string>> = () => {
 		return new Promise<ResponsePackage<string>>((resolve, reject) => {
-			resolve({ parsedResponse: JSON.stringify(MockStorage.nonLocalData), request: undefined });
+			resolve({ parsedResponse: JSON.stringify(MockStorage.nonLocalData) });
 		});
 	};
 


### PR DESCRIPTION
As part of migrating OneNote Web Clipper from Manifest V2 to V3, we need to replace XMLHttpRequest() with global fetch() since XMLHttpRequest() can't be called from a service worker. This PR is to take care of the same.

Reference: https://developer.chrome.com/docs/extensions/develop/migrate/to-service-workers

NOTE: The typescript version has been updated from 2.1.6 to 2.3.4 in the package.json file to support the fetch() method.