### PR TITLE
Fix casing of import statements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "webclipper",
-            "version": "3.9.5",
+            "version": "3.9.6",
             "license": "MIT",
             "dependencies": {
                 "jwt-decode": "^2.2.0"

--- a/src/scripts/contentCapture/fullPageScreenshotHelper.ts
+++ b/src/scripts/contentCapture/fullPageScreenshotHelper.ts
@@ -1,13 +1,11 @@
 import {Clipper} from "../clipperUI/frontEndGlobals";
 import {OneNoteApiUtils} from "../clipperUI/oneNoteApiUtils";
-import {Status} from "../clipperUI/status";
 
 import {HttpWithRetries} from "../http/httpWithRetries";
 
 import * as Log from "../logging/log";
 
 import {Constants} from "../constants";
-import {PageInfo} from "../pageInfo";
 import {Settings} from "../settings";
 import {StringUtils} from "../stringUtils";
 

--- a/src/scripts/domParsers/domUtils.ts
+++ b/src/scripts/domParsers/domUtils.ts
@@ -12,7 +12,7 @@ import {Constants} from "../constants";
 import {ObjectUtils} from "../objectUtils";
 import {SupportedVideoDomains, VideoUtils} from "./videoUtils";
 
-import {VideoExtractorFactory} from "./VideoExtractorFactory";
+import {VideoExtractorFactory} from "./videoExtractorFactory";
 
 export interface EmbeddedVideoIFrameSrcs {
 	srcAttribute: string;

--- a/src/scripts/domParsers/videoExtractorFactory.ts
+++ b/src/scripts/domParsers/videoExtractorFactory.ts
@@ -1,8 +1,8 @@
 import {KhanAcademyVideoExtractor} from "./khanAcademyVideoExtractor";
-import {VideoExtractor} from "./VideoExtractor";
+import {VideoExtractor} from "./videoExtractor";
 import {SupportedVideoDomains, VideoUtils} from "./videoUtils";
 import {VimeoVideoExtractor} from "./vimeoVideoExtractor";
-import {YoutubeVideoExtractor} from "./YoutubeVideoExtractor";
+import {YoutubeVideoExtractor} from "./youtubeVideoExtractor";
 
 /**
  * Factory class to return a domain specific video extractor given a Domain

--- a/src/scripts/extensions/bookmarklet/bookmarkletInject.ts
+++ b/src/scripts/extensions/bookmarklet/bookmarkletInject.ts
@@ -7,7 +7,6 @@ import {ClipperInject, ClipperInjectOptions} from "../../extensions/clipperInjec
 import {DebugLoggingInject} from "../../extensions/debugLoggingInject";
 import {UnsupportedBrowserInject} from "../../extensions/unsupportedBrowserInject";
 import {BrowserUtils} from "../../browserUtils";
-import {Constants} from "../../Constants";
 
 import {InjectHelper} from "../injectHelper";
 

--- a/src/scripts/extensions/extensionWorkerBase.ts
+++ b/src/scripts/extensions/extensionWorkerBase.ts
@@ -2,7 +2,6 @@ import {BrowserUtils} from "../browserUtils";
 import {ClientInfo} from "../clientInfo";
 import {ClientType} from "../clientType";
 import {ClipperUrls} from "../clipperUrls";
-import {CookieUtils} from "../cookieUtils";
 import {Constants} from "../constants";
 import {Polyfills} from "../polyfills";
 import {AuthType, UserInfo, UpdateReason} from "../userInfo";

--- a/src/scripts/extensions/safari/safariExtension.ts
+++ b/src/scripts/extensions/safari/safariExtension.ts
@@ -1,5 +1,4 @@
 import {ClientType} from "../../clientType";
-import {Constants} from "../../constants";
 import {UrlUtils} from "../../urlUtils";
 
 import {TooltipType} from "../../clipperUI/tooltipType";
@@ -9,9 +8,7 @@ import {VideoUtils} from "../../domParsers/videoUtils";
 import {Localization} from "../../localization/localization";
 
 import {ClipperData} from "../../storage/clipperData";
-import {LocalStorage} from "../../storage/LocalStorage";
-
-import {Version} from "../../versioning/version";
+import {LocalStorage} from "../../storage/localStorage";
 
 import {ExtensionBase} from "../extensionBase";
 import {InvokeInfo} from "../invokeInfo";

--- a/src/scripts/extensions/webExtensionBase/webExtensionWorker.ts
+++ b/src/scripts/extensions/webExtensionBase/webExtensionWorker.ts
@@ -6,28 +6,23 @@ import {ClipperUrls} from "../../clipperUrls";
 import {Constants} from "../../constants";
 import {UrlUtils} from "../../urlUtils";
 
-import {Communicator} from "../../communicator/communicator";
 import {SmartValue} from "../../communicator/smartValue";
-
-import {Localization} from "../../localization/localization";
 
 import * as Log from "../../logging/log";
 
 import {ClipperData} from "../../storage/clipperData";
-import {LocalStorage} from "../../storage/LocalStorage";
+import {LocalStorage} from "../../storage/localStorage";
 
 import {ChangeLog} from "../../versioning/changeLog";
 
 import {AuthenticationHelper} from "../authenticationHelper";
 import {ExtensionWorkerBase} from "../extensionWorkerBase";
 import {InjectHelper} from "../injectHelper";
-import {InvokeSource} from "../invokeSource";
 
 import {InjectUrls} from "./injectUrls";
 import {WebExtension} from "./webExtension";
 import {WebExtensionBackgroundMessageHandler} from "./webExtensionMessageHandler";
 
-type Tab = chrome.tabs.Tab;
 type TabRemoveInfo = chrome.tabs.TabRemoveInfo;
 type WebResponseCacheDetails = chrome.webRequest.WebResponseCacheDetails;
 type Window = chrome.windows.Window;

--- a/src/scripts/logging/consoleLoggerPure.ts
+++ b/src/scripts/logging/consoleLoggerPure.ts
@@ -1,7 +1,7 @@
 import * as Log from "./log";
 import {ConsoleOutput} from "./consoleOutput";
 import {ConsoleLoggerShell} from "./consoleLoggerShell";
-import {Logger} from "./Logger";
+import {Logger} from "./logger";
 import {LogHelpers} from "./logHelpers";
 
 export class ConsoleLoggerPure extends Logger {

--- a/src/scripts/saveToOneNote/oneNoteApiWithLogging.ts
+++ b/src/scripts/saveToOneNote/oneNoteApiWithLogging.ts
@@ -1,7 +1,7 @@
 import {Constants} from "../constants";
 
 import {Clipper} from "../clipperUI/frontEndGlobals";
-import {OneNoteApiUtils} from "../clipperUI/OneNoteApiUtils";
+import {OneNoteApiUtils} from "../clipperUI/oneNoteApiUtils";
 
 import * as Log from "../logging/log";
 

--- a/src/scripts/storage/clipperData.ts
+++ b/src/scripts/storage/clipperData.ts
@@ -5,7 +5,7 @@ import {Logger} from "../logging/logger";
 
 import {ClipperStorageGateStrategy} from "./clipperStorageGateStrategy";
 import {Storage} from "./storage";
-import {StorageGateStrategy} from "./StorageGateStrategy";
+import {StorageGateStrategy} from "./storageGateStrategy";
 
 /**
  * The data-access-like object that handles the fetching and caching of data

--- a/src/tests/clipperUI/components/pdfClipOptions_tests.tsx
+++ b/src/tests/clipperUI/components/pdfClipOptions_tests.tsx
@@ -10,7 +10,7 @@ import {MithrilUtils} from "../../mithrilUtils";
 import {MockProps} from "../../mockProps";
 import {TestModule} from "../../testModule";
 
-import {MockPdfDocument, MockPdfValues} from "../../contentCapture/MockPdfDocument";
+import {MockPdfDocument, MockPdfValues} from "../../contentCapture/mockPdfDocument";
 
 declare function require(name: string);
 

--- a/src/tests/clipperUI/components/previewViewer/pdfPageViewport_tests.tsx
+++ b/src/tests/clipperUI/components/previewViewer/pdfPageViewport_tests.tsx
@@ -1,6 +1,6 @@
 import {Constants} from "../../../../scripts/constants";
 
-import {PdfPageViewport} from "../../../../scripts/clipperUI/components/previewViewer/pdfPageViewport";
+import {PdfPageViewport} from "../../../../scripts/clipperUI/components/previewViewer/PdfPageViewport";
 
 import {MithrilUtils} from "../../../mithrilUtils";
 import {TestModule} from "../../../testModule";

--- a/src/tests/versioning/changeLogHelper_tests.ts
+++ b/src/tests/versioning/changeLogHelper_tests.ts
@@ -1,5 +1,5 @@
 import {ChangeLog} from "../../scripts/versioning/changeLog";
-import {ChangeLogHelper} from "../../scripts/versioning/changeLogHelper";
+import {ChangeLogHelper} from "../../scripts/versioning/changelogHelper";
 import {Version} from "../../scripts/versioning/version";
 import {TestModule} from "../testModule";
 


### PR DESCRIPTION
This PR is to fix the casing of import statements in order to avoid the following error which might otherwise come up at a later stage during the Manifest V2 to V3 migration effort.

`error TS1261: Already included file name ... differs from file name ... only in casing`