### PR TITLE
Frame Url Injection Changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3065,6 +3065,18 @@
                 "node": ">=0.9.9"
             }
         },
+        "node_modules/cordova-lib/node_modules/cordova-common/node_modules/elementtree": {
+            "version": "0.1.7",
+            "dev": true,
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "sax": "1.1.4"
+            },
+            "engines": {
+                "node": ">= 0.4.0"
+            }
+        },
         "node_modules/cordova-lib/node_modules/cordova-common/node_modules/q": {
             "version": "1.4.1",
             "dev": true,
@@ -3074,6 +3086,12 @@
                 "node": ">=0.6.0",
                 "teleport": ">=0.2.0"
             }
+        },
+        "node_modules/cordova-lib/node_modules/cordova-common/node_modules/sax": {
+            "version": "1.1.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC"
         },
         "node_modules/cordova-lib/node_modules/cordova-common/node_modules/semver": {
             "version": "5.1.0",
@@ -3101,6 +3119,15 @@
             "dev": true,
             "inBundle": true,
             "license": "MIT"
+        },
+        "node_modules/cordova-lib/node_modules/cordova-common/node_modules/unorm": {
+            "version": "1.6.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT or GPL-2.0",
+            "engines": {
+                "node": ">= 0.4.0"
+            }
         },
         "node_modules/cordova-lib/node_modules/cordova-registry-mapper": {
             "version": "1.1.15",
@@ -3133,7 +3160,6 @@
         "node_modules/cordova-lib/node_modules/elementtree": {
             "version": "0.1.6",
             "dev": true,
-            "inBundle": true,
             "dependencies": {
                 "sax": "0.3.5"
             },
@@ -3405,7 +3431,6 @@
         "node_modules/cordova-lib/node_modules/sax": {
             "version": "0.3.5",
             "dev": true,
-            "inBundle": true,
             "license": "MIT",
             "engines": {
                 "node": "*"
@@ -3448,7 +3473,6 @@
         "node_modules/cordova-lib/node_modules/unorm": {
             "version": "1.3.3",
             "dev": true,
-            "inBundle": true,
             "engines": {
                 "node": ">= 0.4.0"
             }
@@ -18397,8 +18421,21 @@
                         "unorm": "^1.3.3"
                     },
                     "dependencies": {
+                        "elementtree": {
+                            "version": "0.1.7",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "sax": "1.1.4"
+                            }
+                        },
                         "q": {
                             "version": "1.4.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "sax": {
+                            "version": "1.1.4",
                             "bundled": true,
                             "dev": true
                         },
@@ -18414,6 +18451,11 @@
                         },
                         "underscore": {
                             "version": "1.8.3",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "unorm": {
+                            "version": "1.6.0",
                             "bundled": true,
                             "dev": true
                         }
@@ -18441,7 +18483,6 @@
                 },
                 "elementtree": {
                     "version": "0.1.6",
-                    "bundled": true,
                     "dev": true,
                     "requires": {
                         "sax": "0.3.5"
@@ -18646,7 +18687,6 @@
                 },
                 "sax": {
                     "version": "0.3.5",
-                    "bundled": true,
                     "dev": true
                 },
                 "shelljs": {
@@ -18672,7 +18712,6 @@
                 },
                 "unorm": {
                     "version": "1.3.3",
-                    "bundled": true,
                     "dev": true
                 },
                 "util-deprecate": {

--- a/src/scripts/contentCapture/pdfScreenshotHelper.ts
+++ b/src/scripts/contentCapture/pdfScreenshotHelper.ts
@@ -37,17 +37,16 @@ export class PdfScreenshotHelper {
 					getBinaryEvent.setFailureInfo(error);
 					Clipper.logger.logEvent(getBinaryEvent);
 					reject();
-				})
+				});
 			};
 
-
 			fetch(url)
-			.then(response => {
-				if (!response.ok) {
-					errorCallback(ErrorUtils.createRequestErrorObject(response, OneNoteApi.RequestErrorType.UNEXPECTED_RESPONSE_STATUS));
-				}
-				return response.arrayBuffer();
-			})
+				.then(response => {
+					if (!response.ok) {
+						errorCallback(ErrorUtils.createRequestErrorObject(response, OneNoteApi.RequestErrorType.UNEXPECTED_RESPONSE_STATUS));
+					}
+					return response.arrayBuffer();
+				})
 				.then(arrayBuffer => {
 					getBinaryEvent.setCustomProperty(Log.PropertyName.Custom.ByteLength, arrayBuffer.byteLength);
 					Clipper.logger.logEvent(getBinaryEvent);
@@ -56,13 +55,13 @@ export class PdfScreenshotHelper {
 						.then(pdfScreenshotResult => {
 							pdfScreenshotResult.byteLength = arrayBuffer.byteLength;
 							resolve(pdfScreenshotResult);
-						})
+						});
 				})
 			.catch(() => {
 				reject(OneNoteApi.RequestErrorType.NETWORK_ERROR);
 			});
 			setTimeout(() => {
-				reject(OneNoteApi.RequestErrorType.REQUEST_TIMED_OUT)
+				reject(OneNoteApi.RequestErrorType.REQUEST_TIMED_OUT);
 			}, 60000);
 		});
 	}

--- a/src/scripts/extensions/bookmarklet/bookmarkletInject.ts
+++ b/src/scripts/extensions/bookmarklet/bookmarkletInject.ts
@@ -1,4 +1,3 @@
-declare var frameUrl: string;
 declare var bookmarkletRoot: string;
 
 import {IFrameMessageHandler} from "../../communicator/iframeMessageHandler";

--- a/src/scripts/extensions/chrome/chromeInject.ts
+++ b/src/scripts/extensions/chrome/chromeInject.ts
@@ -2,8 +2,9 @@ import {invoke} from "../webExtensionBase/webExtensionInject";
 import {WebExtension} from "../webExtensionBase/webExtension";
 import {WebExtensionContentMessageHandler} from "../webExtensionBase/webExtensionMessageHandler";
 
-declare var frameUrl: string;
 WebExtension.browser = chrome;
+
+const frameUrl = WebExtension.browser.runtime.getURL("clipper.html");
 
 invoke({
 	frameUrl: frameUrl,

--- a/src/scripts/extensions/chrome/chromePageNavInject.ts
+++ b/src/scripts/extensions/chrome/chromePageNavInject.ts
@@ -2,8 +2,9 @@ import {invoke} from "../webExtensionBase/webExtensionPageNavInject";
 import {WebExtension} from "../webExtensionBase/webExtension";
 import {WebExtensionContentMessageHandler} from "../webExtensionBase/webExtensionMessageHandler";
 
-declare var frameUrl: string;
 WebExtension.browser = chrome;
+
+const frameUrl = WebExtension.browser.runtime.getURL("pageNav.html");
 
 invoke({
 	frameUrl: frameUrl,

--- a/src/scripts/extensions/edge/edgeInject.ts
+++ b/src/scripts/extensions/edge/edgeInject.ts
@@ -3,8 +3,9 @@ import {WebExtension} from "../webExtensionBase/webExtension";
 import {WebExtensionContentMessageHandler} from "../webExtensionBase/webExtensionMessageHandler";
 
 declare var browser;
-declare var frameUrl: string;
 WebExtension.browser = ("browser" in window) ? browser : chrome;
+
+const frameUrl = WebExtension.browser.runtime.getURL("clipper.html");
 
 invoke({
 	frameUrl: frameUrl,

--- a/src/scripts/extensions/edge/edgePageNavInject.ts
+++ b/src/scripts/extensions/edge/edgePageNavInject.ts
@@ -3,8 +3,9 @@ import {WebExtension} from "../webExtensionBase/webExtension";
 import {WebExtensionContentMessageHandler} from "../webExtensionBase/webExtensionMessageHandler";
 
 declare var browser;
-declare var frameUrl: string;
 WebExtension.browser = ("browser" in window) ? browser : chrome;
+
+const frameUrl = WebExtension.browser.runtime.getURL("pageNav.html");
 
 invoke({
 	frameUrl: frameUrl,

--- a/src/scripts/extensions/firefox/firefoxInject.ts
+++ b/src/scripts/extensions/firefox/firefoxInject.ts
@@ -2,8 +2,9 @@ import {invoke} from "../webExtensionBase/webExtensionInject";
 import {WebExtension} from "../webExtensionBase/webExtension";
 import {WebExtensionContentMessageHandler} from "../webExtensionBase/webExtensionMessageHandler";
 
-declare var frameUrl: string;
 WebExtension.browser = chrome;
+
+const frameUrl = WebExtension.browser.runtime.getURL("clipper.html");
 
 invoke({
 	frameUrl: frameUrl,

--- a/src/scripts/extensions/firefox/firefoxPageNavInject.ts
+++ b/src/scripts/extensions/firefox/firefoxPageNavInject.ts
@@ -2,8 +2,9 @@ import {invoke} from "../webExtensionBase/webExtensionPageNavInject";
 import {WebExtension} from "../webExtensionBase/webExtension";
 import {WebExtensionContentMessageHandler} from "../webExtensionBase/webExtensionMessageHandler";
 
-declare var frameUrl: string;
 WebExtension.browser = chrome;
+
+const frameUrl = WebExtension.browser.runtime.getURL("pageNav.html");
 
 invoke({
 	frameUrl: frameUrl,

--- a/src/scripts/extensions/injectHelper.ts
+++ b/src/scripts/extensions/injectHelper.ts
@@ -8,8 +8,8 @@ export class InjectHelper {
 
 	public static alertUserOfUnclippablePage() {
 		WebExtension.browser.notifications.create({
-			type: 'basic',
-			iconUrl: '/icons/icon-48.png',
+			type: "basic",
+			iconUrl: "/icons/icon-48.png",
 			title: Localization.getLocalizedString("WebClipper.Notification.Title"),
 			message: Localization.getLocalizedString("WebClipper.Error.CannotClipPage"),
 			priority: 1

--- a/src/scripts/extensions/webExtensionBase/webExtensionWorker.ts
+++ b/src/scripts/extensions/webExtensionBase/webExtensionWorker.ts
@@ -81,7 +81,7 @@ export class WebExtensionWorker extends ExtensionWorkerBase<W3CTab, number> {
 	protected invokeClipperBrowserSpecific(): Promise<boolean> {
 		return new Promise<boolean>((resolve) => {
 			WebExtension.browser.tabs.executeScript(this.tab.id, {
-				code: 'var frameUrl = "' + WebExtension.browser.extension.getURL("clipper.html") + '";'
+				code: ""
 			}, () => {
 				if (WebExtension.browser.runtime.lastError) {
 					Log.ErrorUtils.sendFailureLogRequest({
@@ -137,7 +137,7 @@ export class WebExtensionWorker extends ExtensionWorkerBase<W3CTab, number> {
 	protected invokePageNavBrowserSpecific(): Promise<boolean> {
 		return new Promise<boolean>((resolve) => {
 			WebExtension.browser.tabs.executeScript(this.tab.id, {
-				code: 'var frameUrl = "' + WebExtension.browser.extension.getURL("pageNav.html") + '";'
+				code: ""
 			}, () => {
 				// It's safest to not use lastError in the resolve due to special behavior in the Chrome API
 				if (WebExtension.browser.runtime.lastError) {

--- a/src/scripts/logging/submodules/errorUtils.ts
+++ b/src/scripts/logging/submodules/errorUtils.ts
@@ -136,8 +136,8 @@ export module ErrorUtils {
 
 		if (shouldShowAlert) {
 			WebExtension.browser.notifications.create({
-				type: 'basic',
-				iconUrl: '/icons/icon-48.png',
+				type: "basic",
+				iconUrl: "/icons/icon-48.png",
 				title: Localization.getLocalizedString("WebClipper.Notification.Title"),
 				message: Localization.getLocalizedString("WebClipper.Error.NoOpError"),
 				priority: 1


### PR DESCRIPTION
As part of this PR, the frame url injection logic has been modified so as to avoid injecting the frame url from `webExtensionWorker.ts` which will eventually be required as part of the effort of migrating OneNote Web Clipper from Manifest V2 to V3.