### PR TITLE
API Changes to comply with Manifest V3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "jwt-decode": "^2.2.0"
             },
             "devDependencies": {
-                "@types/chrome": "0.0.130",
+                "@types/chrome": "0.0.132",
                 "@types/es6-promise": "0.0.32",
                 "@types/har-format": "1.2.7",
                 "@types/jquery": "2.0.40",
@@ -88,9 +88,9 @@
             }
         },
         "node_modules/@types/chrome": {
-            "version": "0.0.130",
-            "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.130.tgz",
-            "integrity": "sha512-pAHbcPeOmjNCF5EoUCAZk3+5lll1yyIDP+CZRNf1Dk8LaANkNBNZ5szHqeYYVjMyEGP6yIFeaO+Y7qNpz1hVOw==",
+            "version": "0.0.132",
+            "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.132.tgz",
+            "integrity": "sha512-+yTDaSmY+hCEoB0dIG4OeiVOPpvlDcjLcExtZqJEWv7NCSVnX9AfSUWyzlgK0Kd6yXKpDOjK/pZkeX4ElTzNKA==",
             "dev": true,
             "dependencies": {
                 "@types/filesystem": "*",
@@ -3065,6 +3065,18 @@
                 "node": ">=0.9.9"
             }
         },
+        "node_modules/cordova-lib/node_modules/cordova-common/node_modules/elementtree": {
+            "version": "0.1.7",
+            "dev": true,
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "sax": "1.1.4"
+            },
+            "engines": {
+                "node": ">= 0.4.0"
+            }
+        },
         "node_modules/cordova-lib/node_modules/cordova-common/node_modules/q": {
             "version": "1.4.1",
             "dev": true,
@@ -3074,6 +3086,12 @@
                 "node": ">=0.6.0",
                 "teleport": ">=0.2.0"
             }
+        },
+        "node_modules/cordova-lib/node_modules/cordova-common/node_modules/sax": {
+            "version": "1.1.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC"
         },
         "node_modules/cordova-lib/node_modules/cordova-common/node_modules/semver": {
             "version": "5.1.0",
@@ -3101,6 +3119,15 @@
             "dev": true,
             "inBundle": true,
             "license": "MIT"
+        },
+        "node_modules/cordova-lib/node_modules/cordova-common/node_modules/unorm": {
+            "version": "1.6.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT or GPL-2.0",
+            "engines": {
+                "node": ">= 0.4.0"
+            }
         },
         "node_modules/cordova-lib/node_modules/cordova-registry-mapper": {
             "version": "1.1.15",
@@ -3133,7 +3160,6 @@
         "node_modules/cordova-lib/node_modules/elementtree": {
             "version": "0.1.6",
             "dev": true,
-            "inBundle": true,
             "dependencies": {
                 "sax": "0.3.5"
             },
@@ -3405,7 +3431,6 @@
         "node_modules/cordova-lib/node_modules/sax": {
             "version": "0.3.5",
             "dev": true,
-            "inBundle": true,
             "license": "MIT",
             "engines": {
                 "node": "*"
@@ -3448,7 +3473,6 @@
         "node_modules/cordova-lib/node_modules/unorm": {
             "version": "1.3.3",
             "dev": true,
-            "inBundle": true,
             "engines": {
                 "node": ">= 0.4.0"
             }
@@ -15782,9 +15806,9 @@
             }
         },
         "@types/chrome": {
-            "version": "0.0.130",
-            "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.130.tgz",
-            "integrity": "sha512-pAHbcPeOmjNCF5EoUCAZk3+5lll1yyIDP+CZRNf1Dk8LaANkNBNZ5szHqeYYVjMyEGP6yIFeaO+Y7qNpz1hVOw==",
+            "version": "0.0.132",
+            "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.132.tgz",
+            "integrity": "sha512-+yTDaSmY+hCEoB0dIG4OeiVOPpvlDcjLcExtZqJEWv7NCSVnX9AfSUWyzlgK0Kd6yXKpDOjK/pZkeX4ElTzNKA==",
             "dev": true,
             "requires": {
                 "@types/filesystem": "*",
@@ -18397,8 +18421,21 @@
                         "unorm": "^1.3.3"
                     },
                     "dependencies": {
+                        "elementtree": {
+                            "version": "0.1.7",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "sax": "1.1.4"
+                            }
+                        },
                         "q": {
                             "version": "1.4.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "sax": {
+                            "version": "1.1.4",
                             "bundled": true,
                             "dev": true
                         },
@@ -18414,6 +18451,11 @@
                         },
                         "underscore": {
                             "version": "1.8.3",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "unorm": {
+                            "version": "1.6.0",
                             "bundled": true,
                             "dev": true
                         }
@@ -18441,7 +18483,6 @@
                 },
                 "elementtree": {
                     "version": "0.1.6",
-                    "bundled": true,
                     "dev": true,
                     "requires": {
                         "sax": "0.3.5"
@@ -18646,7 +18687,6 @@
                 },
                 "sax": {
                     "version": "0.3.5",
-                    "bundled": true,
                     "dev": true
                 },
                 "shelljs": {
@@ -18672,7 +18712,6 @@
                 },
                 "unorm": {
                     "version": "1.3.3",
-                    "bundled": true,
                     "dev": true
                 },
                 "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "url": "git+https://github.com/OneNoteDev/WebClipper.git"
     },
     "devDependencies": {
-        "@types/chrome": "0.0.130",
+        "@types/chrome": "0.0.132",
         "@types/har-format": "1.2.7",
         "@types/es6-promise": "0.0.32",
         "@types/jquery": "2.0.40",

--- a/src/scripts/extensions/webExtensionBase/webExtension.ts
+++ b/src/scripts/extensions/webExtensionBase/webExtension.ts
@@ -114,7 +114,7 @@ export class WebExtension extends ExtensionBase<WebExtensionWorker, W3CTab, numb
 	}
 
 	private registerBrowserButton() {
-		WebExtension.browser.browserAction.onClicked.addListener((tab: W3CTab) => {
+		WebExtension.browser.action.onClicked.addListener((tab: W3CTab) => {
 			this.invokeClipperInTab(tab, { invokeSource: InvokeSource.ExtensionButton }, { invokeMode: InvokeMode.Default });
 		});
 	}

--- a/src/scripts/extensions/webExtensionBase/webExtensionWorker.ts
+++ b/src/scripts/extensions/webExtensionBase/webExtensionWorker.ts
@@ -80,8 +80,9 @@ export class WebExtensionWorker extends ExtensionWorkerBase<W3CTab, number> {
 	 */
 	protected invokeClipperBrowserSpecific(): Promise<boolean> {
 		return new Promise<boolean>((resolve) => {
-			WebExtension.browser.tabs.executeScript(this.tab.id, {
-				code: ""
+			WebExtension.browser.scripting.executeScript({
+				target: { tabId: this.tab.id },
+				function: () => {}
 			}, () => {
 				if (WebExtension.browser.runtime.lastError) {
 					Log.ErrorUtils.sendFailureLogRequest({
@@ -104,7 +105,10 @@ export class WebExtensionWorker extends ExtensionWorkerBase<W3CTab, number> {
 						WebExtension.browser.management.uninstallSelf();
 						resolve(true);
 					} else {
-						WebExtension.browser.tabs.executeScript(this.tab.id, { file: this.injectUrls.webClipperInjectUrl });
+						WebExtension.browser.scripting.executeScript({
+							target: { tabId: this.tab.id },
+							files: [this.injectUrls.webClipperInjectUrl]
+						});
 
 						if (!this.noOpTrackerInvoked) {
 							this.setUpNoOpTrackers(this.tab.url);
@@ -123,7 +127,10 @@ export class WebExtensionWorker extends ExtensionWorkerBase<W3CTab, number> {
 	 */
 	protected invokeDebugLoggingBrowserSpecific(): Promise<boolean> {
 		return new Promise<boolean>((resolve) => {
-			WebExtension.browser.tabs.executeScript(this.tab.id, { file: this.injectUrls.debugLoggingInjectUrl }, () => {
+			WebExtension.browser.scripting.executeScript({
+				target: { tabId: this.tab.id },
+				files: [this.injectUrls.debugLoggingInjectUrl]
+			}, () => {
 				if (WebExtension.browser.runtime.lastError) {
 					// We are probably on a page like about:blank, which is pretty normal
 					resolve(false);
@@ -136,15 +143,19 @@ export class WebExtensionWorker extends ExtensionWorkerBase<W3CTab, number> {
 
 	protected invokePageNavBrowserSpecific(): Promise<boolean> {
 		return new Promise<boolean>((resolve) => {
-			WebExtension.browser.tabs.executeScript(this.tab.id, {
-				code: ""
+			WebExtension.browser.scripting.executeScript({
+				target: { tabId: this.tab.id },
+				function: () => {}
 			}, () => {
 				// It's safest to not use lastError in the resolve due to special behavior in the Chrome API
 				if (WebExtension.browser.runtime.lastError) {
 					// We are probably on a page like about:blank, which is pretty normal
 					resolve(false);
 				} else {
-					WebExtension.browser.tabs.executeScript(this.tab.id, { file: this.injectUrls.pageNavInjectUrl });
+					WebExtension.browser.scripting.executeScript({
+						target: { tabId: this.tab.id },
+						files: [this.injectUrls.pageNavInjectUrl]
+					});
 					resolve(true);
 				}
 			});


### PR DESCRIPTION
This PR is to make certain API changes to comply with Manifest V3.

**NOTE**: OneNote Web Clipper won't work with these changes alone but will work once the remaining changes to migrate to Manifest V3 are completed.