### PR TITLE
Panel Animation Fix

### DIFF
--- a/src/scripts/clipperUI/animations/animationHelper.ts
+++ b/src/scripts/clipperUI/animations/animationHelper.ts
@@ -2,9 +2,7 @@ declare var Velocity: jquery.velocity.VelocityStatic;
 
 export class AnimationHelper {
 	public static stopAnimationsThen(el: HTMLElement, callback: () => void) {
-		Velocity.animate(el, "stop", {
-			queue: true,
-		});
+		Velocity.animate(el, "stop", true as any);
 		setTimeout(callback, 1);
 	}
 }


### PR DESCRIPTION
**Issue**
When we select the region option, or if we clip an image or selections to OneNote in web clipper, all the options are suddenly closing and after a few seconds, it is opening again.

[Bug 9593889](https://office.visualstudio.com/OneNote/_workitems/edit/9593889): [OneNote][Online][Integration]: when we select the region option, selecting Image and clip selections to OneNote in web clipper all the options are suddenly closing and after few seconds again its opening.

**Cause**
The following code change was made in order to resolve a typescript error complaining about the type of the 3rd argument which needs to be of type `jquery.velocity.Options`. This code change is resulting in the issue mentioned above.

![image](https://github.com/user-attachments/assets/869e848d-d09d-4545-bdf6-37ca126a492e)

Please note that the expected type for the 3rd argument was `jquery.velocity.Options` even before the recent typescript version upgrade. However, the older version of typescript was not complaining about this.

**Fix**
We will still need to pass `true` as the 3rd argument so that the panel animations work as expected. Type cast `true` to `any` in order to resolve the typescript error.