### PR TITLE
Fix for Clipper not Loading

### DIFF
--- a/src/scripts/extensions/webExtensionBase/webExtension.ts
+++ b/src/scripts/extensions/webExtensionBase/webExtension.ts
@@ -101,8 +101,15 @@ export class WebExtension extends ExtensionBase<WebExtensionWorker, W3CTab, numb
 	}
 
 	private invokeClipperInTab(tab: W3CTab, invokeInfo: InvokeInfo, options: InvokeOptions) {
-		let worker = this.getOrCreateWorkerForTab(tab, this.getIdFromTab);
-		worker.closeAllFramesAndInvokeClipper(invokeInfo, options);
+		/**
+		 * Create a worker only after the clipperId is processed, since the clientInfo is available
+		 * only after the clipperId is processed. This is to ensure that the worker is created with the
+		 * correct clientInfo.
+		 */
+		this.clipperIdProcessed.then(() => {
+			let worker = this.getOrCreateWorkerForTab(tab, this.getIdFromTab);
+			worker.closeAllFramesAndInvokeClipper(invokeInfo, options);
+		});
 	}
 
 	private onInstalled() {


### PR DESCRIPTION
**Issue**
Unable to open OneNote Web Clipper after a few minutes of inactivity.

[Bug 9593888](https://office.visualstudio.com/OneNote/_workitems/edit/9593888): [OneNote][Online][Integration]: Unable to open the web clipper after getting the error.

**Cause**
Once the service worker becomes inactive after a few minutes of inactivity, the next time when clipper is invoked in tab, it is intermittently called too soon and a `WebExtensionWorker` gets created even before the `clientInfo` is available again.

**Fix**
Ensure to create a `WebExtensionWorker` only after the `clipperId` has been processed since the `clientInfo` is available only after that.