### PR TITLE
Idle Auth Fix

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -59,7 +59,7 @@ var PATHS = {
 
 var RTL_SUFFIX = "-rtl";
 
-var ARIA_LIB_VERSION = "2.9.0";
+var ARIA_LIB_VERSION = "2.8.2";
 
 // Used for debugging glob declarations
 function printGlobResults(glob) {

--- a/src/scripts/clipperUI/clipper.tsx
+++ b/src/scripts/clipperUI/clipper.tsx
@@ -630,7 +630,9 @@ class ClipperClass extends ComponentBase<ClipperState, {}> {
 	}
 
 	private handleSignOut(authType: string): void {
-		this.state.setState(this.getSignOutState());
+		Clipper.storeValue(ClipperStorageKeys.isUserLoggedIn, "false", () => {
+			this.state.setState(this.getSignOutState());
+		});
 		Clipper.getExtensionCommunicator().callRemoteFunction(Constants.FunctionKeys.signOutUser, { param: AuthType[authType] });
 
 		Clipper.logger.logUserFunnel(Log.Funnel.Label.SignOut);

--- a/src/scripts/clipperUI/clipperStateUtilities.ts
+++ b/src/scripts/clipperUI/clipperStateUtilities.ts
@@ -14,10 +14,10 @@ import { OffscreenMessageTypes } from "../communicator/offscreenMessageTypes";
 import { ClipperStorageKeys } from "../storage/clipperStorageKeys";
 
 export module ClipperStateUtilities {
-	export function isUserLoggedIn(state: ClipperState): boolean {
+	export function isUserLoggedIn(state: ClipperState, refreshUserInfo?: boolean): boolean {
 		if (state.userResult && state.userResult.status && state.userResult.data && !!state.userResult.data.user) {
 			return true;
-		} else {
+		} else if (!!refreshUserInfo) {
 			sendToOffscreenDocument(OffscreenMessageTypes.getFromLocalStorage, {
 				key: ClipperStorageKeys.isUserLoggedIn
 			}).then((isUserLoggedIn) => {

--- a/src/scripts/clipperUI/clipperStateUtilities.ts
+++ b/src/scripts/clipperUI/clipperStateUtilities.ts
@@ -1,13 +1,63 @@
-import {StringUtils} from "../stringUtils";
 import {ObjectUtils} from "../objectUtils";
 
+import * as Log from "../logging/log";
 import {ClipMode} from "./clipMode";
 import {ClipperState} from "./clipperState";
 import {Status} from "./status";
+import { Clipper } from "./frontEndGlobals";
+import { SmartValue } from "../communicator/smartValue";
+import { Constants } from "../constants";
+import { TimeStampedData, CachedHttp } from "../http/cachedHttp";
+import { UserInfo, UpdateReason } from "../userInfo";
 
 export module ClipperStateUtilities {
-	export function isUserLoggedIn(state: ClipperState): boolean {
-		return (state.userResult && state.userResult.status && state.userResult.data && !!state.userResult.data.user);
+	export function isUserLoggedIn(state: ClipperState, refreshUserInfo?: boolean): boolean {
+		if (state.userResult && state.userResult.status && state.userResult.data && !!state.userResult.data.user) {
+			return true;
+		} else if (!!refreshUserInfo) {
+			let userInfoUpdateCb = (updatedUser: UserInfo) => {
+				console.log(updatedUser);
+				if (updatedUser) {
+					let userInfoUpdatedEvent = new Log.Event.BaseEvent(Log.Event.Label.UserInfoUpdated);
+					userInfoUpdatedEvent.setCustomProperty(Log.PropertyName.Custom.UserUpdateReason, UpdateReason[updatedUser.updateReason]);
+					userInfoUpdatedEvent.setCustomProperty(Log.PropertyName.Custom.LastUpdated, new Date(updatedUser.lastUpdated).toUTCString());
+					Clipper.logger.logEvent(userInfoUpdatedEvent);
+				}
+
+				if (updatedUser && updatedUser.user) {
+					let timeStampedData: TimeStampedData = {
+						data: updatedUser.user,
+						lastUpdated: updatedUser.lastUpdated
+					};
+
+					// The user SV should never be set with expired user information
+					let tokenHasExpiredForLoggedInUser = CachedHttp.valueHasExpired(timeStampedData, (updatedUser.user.accessTokenExpiration * 1000) - 180000);
+					if (tokenHasExpiredForLoggedInUser) {
+						Clipper.logger.logFailure(Log.Failure.Label.UserSetWithInvalidExpiredData, Log.Failure.Type.Unexpected);
+					}
+
+					state.setState({ userResult: { status: Status.Succeeded, data: updatedUser } });
+					Clipper.logger.setContextProperty(Log.Context.Custom.AuthType, updatedUser.user.authType);
+					Clipper.logger.setContextProperty(Log.Context.Custom.UserInfoId, updatedUser.user.cid);
+				} else {
+					state.setState({ userResult: { status: Status.Failed, data: updatedUser } });
+				}
+			};
+
+			state.setState({ userResult: { status: Status.InProgress } });
+			Clipper.getExtensionCommunicator().callRemoteFunction(Constants.FunctionKeys.getInitialUser, {
+				callback: (freshInitialUser: UserInfo) => {
+					if (freshInitialUser && freshInitialUser.user) {
+						Clipper.logger.logUserFunnel(Log.Funnel.Label.AuthAlreadySignedIn);
+					} else if (!freshInitialUser) {
+						userInfoUpdateCb(freshInitialUser);
+					}
+					Clipper.getExtensionCommunicator().subscribeAcrossCommunicator(new SmartValue<UserInfo>(), Constants.SmartValueKeys.user, (updatedUser: UserInfo) => {
+						userInfoUpdateCb(updatedUser);
+					});
+				}
+			});
+		}
 	}
 
 	export function isMsaUser(state: ClipperState): boolean {

--- a/src/scripts/clipperUI/clipperStateUtilities.ts
+++ b/src/scripts/clipperUI/clipperStateUtilities.ts
@@ -9,51 +9,59 @@ import { SmartValue } from "../communicator/smartValue";
 import { Constants } from "../constants";
 import { TimeStampedData, CachedHttp } from "../http/cachedHttp";
 import { UserInfo, UpdateReason } from "../userInfo";
+import { sendToOffscreenDocument } from "../communicator/offscreenCommunicator";
+import { OffscreenMessageTypes } from "../communicator/offscreenMessageTypes";
+import { ClipperStorageKeys } from "../storage/clipperStorageKeys";
 
 export module ClipperStateUtilities {
-	export function isUserLoggedIn(state: ClipperState, refreshUserInfo?: boolean): boolean {
+	export function isUserLoggedIn(state: ClipperState): boolean {
 		if (state.userResult && state.userResult.status && state.userResult.data && !!state.userResult.data.user) {
 			return true;
-		} else if (!!refreshUserInfo) {
-			let userInfoUpdateCb = (updatedUser: UserInfo) => {
-				console.log(updatedUser);
-				if (updatedUser) {
-					let userInfoUpdatedEvent = new Log.Event.BaseEvent(Log.Event.Label.UserInfoUpdated);
-					userInfoUpdatedEvent.setCustomProperty(Log.PropertyName.Custom.UserUpdateReason, UpdateReason[updatedUser.updateReason]);
-					userInfoUpdatedEvent.setCustomProperty(Log.PropertyName.Custom.LastUpdated, new Date(updatedUser.lastUpdated).toUTCString());
-					Clipper.logger.logEvent(userInfoUpdatedEvent);
-				}
+		} else {
+			sendToOffscreenDocument(OffscreenMessageTypes.getFromLocalStorage, {
+				key: ClipperStorageKeys.isUserLoggedIn
+			}).then((isUserLoggedIn) => {
+				if (isUserLoggedIn === "true") {
+					let userInfoUpdateCb = (updatedUser: UserInfo) => {
+						if (updatedUser) {
+							let userInfoUpdatedEvent = new Log.Event.BaseEvent(Log.Event.Label.UserInfoUpdated);
+							userInfoUpdatedEvent.setCustomProperty(Log.PropertyName.Custom.UserUpdateReason, UpdateReason[updatedUser.updateReason]);
+							userInfoUpdatedEvent.setCustomProperty(Log.PropertyName.Custom.LastUpdated, new Date(updatedUser.lastUpdated).toUTCString());
+							Clipper.logger.logEvent(userInfoUpdatedEvent);
+						}
 
-				if (updatedUser && updatedUser.user) {
-					let timeStampedData: TimeStampedData = {
-						data: updatedUser.user,
-						lastUpdated: updatedUser.lastUpdated
+						if (updatedUser && updatedUser.user) {
+							let timeStampedData: TimeStampedData = {
+								data: updatedUser.user,
+								lastUpdated: updatedUser.lastUpdated
+							};
+
+							// The user SV should never be set with expired user information
+							let tokenHasExpiredForLoggedInUser = CachedHttp.valueHasExpired(timeStampedData, (updatedUser.user.accessTokenExpiration * 1000) - 180000);
+							if (tokenHasExpiredForLoggedInUser) {
+								Clipper.logger.logFailure(Log.Failure.Label.UserSetWithInvalidExpiredData, Log.Failure.Type.Unexpected);
+							}
+
+							state.setState({ userResult: { status: Status.Succeeded, data: updatedUser } });
+							Clipper.logger.setContextProperty(Log.Context.Custom.AuthType, updatedUser.user.authType);
+							Clipper.logger.setContextProperty(Log.Context.Custom.UserInfoId, updatedUser.user.cid);
+						} else {
+							state.setState({ userResult: { status: Status.Failed, data: updatedUser } });
+						}
 					};
 
-					// The user SV should never be set with expired user information
-					let tokenHasExpiredForLoggedInUser = CachedHttp.valueHasExpired(timeStampedData, (updatedUser.user.accessTokenExpiration * 1000) - 180000);
-					if (tokenHasExpiredForLoggedInUser) {
-						Clipper.logger.logFailure(Log.Failure.Label.UserSetWithInvalidExpiredData, Log.Failure.Type.Unexpected);
-					}
-
-					state.setState({ userResult: { status: Status.Succeeded, data: updatedUser } });
-					Clipper.logger.setContextProperty(Log.Context.Custom.AuthType, updatedUser.user.authType);
-					Clipper.logger.setContextProperty(Log.Context.Custom.UserInfoId, updatedUser.user.cid);
-				} else {
-					state.setState({ userResult: { status: Status.Failed, data: updatedUser } });
-				}
-			};
-
-			state.setState({ userResult: { status: Status.InProgress } });
-			Clipper.getExtensionCommunicator().callRemoteFunction(Constants.FunctionKeys.getInitialUser, {
-				callback: (freshInitialUser: UserInfo) => {
-					if (freshInitialUser && freshInitialUser.user) {
-						Clipper.logger.logUserFunnel(Log.Funnel.Label.AuthAlreadySignedIn);
-					} else if (!freshInitialUser) {
-						userInfoUpdateCb(freshInitialUser);
-					}
-					Clipper.getExtensionCommunicator().subscribeAcrossCommunicator(new SmartValue<UserInfo>(), Constants.SmartValueKeys.user, (updatedUser: UserInfo) => {
-						userInfoUpdateCb(updatedUser);
+					state.setState({ userResult: { status: Status.InProgress } });
+					Clipper.getExtensionCommunicator().callRemoteFunction(Constants.FunctionKeys.getInitialUser, {
+						callback: (freshInitialUser: UserInfo) => {
+							if (freshInitialUser && freshInitialUser.user) {
+								Clipper.logger.logUserFunnel(Log.Funnel.Label.AuthAlreadySignedIn);
+							} else if (!freshInitialUser) {
+								userInfoUpdateCb(freshInitialUser);
+							}
+							Clipper.getExtensionCommunicator().subscribeAcrossCommunicator(new SmartValue<UserInfo>(), Constants.SmartValueKeys.user, (updatedUser: UserInfo) => {
+								userInfoUpdateCb(updatedUser);
+							});
+						}
 					});
 				}
 			});

--- a/src/scripts/clipperUI/clipperStateUtilities.ts
+++ b/src/scripts/clipperUI/clipperStateUtilities.ts
@@ -18,6 +18,10 @@ export module ClipperStateUtilities {
 		if (state.userResult && state.userResult.status && state.userResult.data && !!state.userResult.data.user) {
 			return true;
 		} else if (!!refreshUserInfo) {
+			/**
+			 * Refresh the user info if the user is logged in and the user info is not available.
+			 * This could have possibly happened due to inactivity of the service worker.
+			 */
 			sendToOffscreenDocument(OffscreenMessageTypes.getFromLocalStorage, {
 				key: ClipperStorageKeys.isUserLoggedIn
 			}).then((isUserLoggedIn) => {
@@ -65,6 +69,12 @@ export module ClipperStateUtilities {
 					});
 				}
 			});
+			/**
+			 * There isn't a need to await the response from the offscreen document since the isUserLoggedIn
+			 * function will eventually return true once the user info is updated, and the signed in panel
+			 * will be shown to the user.
+			 */
+			return false;
 		}
 	}
 

--- a/src/scripts/clipperUI/frontEndGlobals.ts
+++ b/src/scripts/clipperUI/frontEndGlobals.ts
@@ -70,11 +70,11 @@ export class Clipper {
 		Clipper.storage.getValues(storageKeys, () => {}, true);
 	}
 
-	public static storeValue(key: string, value: string): void {
+	public static storeValue(key: string, value: string, callback?: (value: string) => void): void {
 		if (!Clipper.storage) {
 			throw new Error("The remote storage needs to be set up with the extension communicator first");
 		}
-		Clipper.storage.setValue(key, value, undefined);
+		Clipper.storage.setValue(key, value, callback);
 	}
 
 	private static setUpRemoteStorage(extensionCommunicator: Communicator) {

--- a/src/scripts/clipperUI/mainController.tsx
+++ b/src/scripts/clipperUI/mainController.tsx
@@ -160,7 +160,7 @@ export class MainControllerClass extends ComponentBase<MainControllerState, Main
 			return PanelType.Loading;
 		}
 
-		if (!ClipperStateUtilities.isUserLoggedIn(this.props.clipperState)) {
+		if (!ClipperStateUtilities.isUserLoggedIn(this.props.clipperState, true)) {
 			return PanelType.SignInNeeded;
 		}
 

--- a/src/scripts/clipperUI/mainController.tsx
+++ b/src/scripts/clipperUI/mainController.tsx
@@ -160,7 +160,7 @@ export class MainControllerClass extends ComponentBase<MainControllerState, Main
 			return PanelType.Loading;
 		}
 
-		if (!ClipperStateUtilities.isUserLoggedIn(this.props.clipperState, true)) {
+		if (!ClipperStateUtilities.isUserLoggedIn(this.props.clipperState)) {
 			return PanelType.SignInNeeded;
 		}
 

--- a/src/scripts/extensions/authenticationHelper.ts
+++ b/src/scripts/extensions/authenticationHelper.ts
@@ -43,7 +43,6 @@ export class AuthenticationHelper {
 				if (storedUserInformation) {
 					let currentInfo: any;
 					try {
-						this.clipperData.setValue(ClipperStorageKeys.isUserLoggedIn, "true");
 						currentInfo = JSON.parse(storedUserInformation);
 					} catch (e) {
 						this.logger.logJsonParseUnexpected(storedUserInformation);
@@ -80,6 +79,7 @@ export class AuthenticationHelper {
 						}
 						getInfoEvent.setCustomProperty(Log.PropertyName.Custom.DataBoundary, userDataBoundary);
 						response.data.dataBoundary = userDataBoundary;
+						this.clipperData.setValue(ClipperStorageKeys.isUserLoggedIn, "true");
 						this.user.set({ user: response.data, lastUpdated: response.lastUpdated, updateReason: updateReason, writeableCookies: writeableCookies });
 					} else {
 						this.user.set({ updateReason: updateReason, writeableCookies: writeableCookies });

--- a/src/scripts/extensions/authenticationHelper.ts
+++ b/src/scripts/extensions/authenticationHelper.ts
@@ -43,6 +43,7 @@ export class AuthenticationHelper {
 				if (storedUserInformation) {
 					let currentInfo: any;
 					try {
+						this.clipperData.setValue(ClipperStorageKeys.isUserLoggedIn, "true");
 						currentInfo = JSON.parse(storedUserInformation);
 					} catch (e) {
 						this.logger.logJsonParseUnexpected(storedUserInformation);

--- a/src/scripts/extensions/webExtensionBase/webExtensionWorker.ts
+++ b/src/scripts/extensions/webExtensionBase/webExtensionWorker.ts
@@ -73,7 +73,6 @@ export class WebExtensionWorker extends ExtensionWorkerBase<W3CTab, number> {
 	protected doSignOutAction(authType: AuthType) {
 		let usidQueryParamValue = this.getUserSessionIdQueryParamValue();
 		let signOutUrl = ClipperUrls.generateSignOutUrl(this.clientInfo.get().clipperId, usidQueryParamValue, AuthType[authType]);
-		this.clipperData.setValue(ClipperStorageKeys.isUserLoggedIn, "false");
 		fetch(signOutUrl);
 	}
 

--- a/src/scripts/extensions/webExtensionBase/webExtensionWorker.ts
+++ b/src/scripts/extensions/webExtensionBase/webExtensionWorker.ts
@@ -21,7 +21,6 @@ import {InjectHelper} from "../injectHelper";
 import {InjectUrls} from "./injectUrls";
 import {WebExtension} from "./webExtension";
 import {WebExtensionBackgroundMessageHandler} from "./webExtensionMessageHandler";
-import {ClipperStorageKeys} from "../../storage/clipperStorageKeys";
 
 type TabRemoveInfo = chrome.tabs.TabRemoveInfo;
 type WebResponseCacheDetails = chrome.webRequest.WebResponseCacheDetails;

--- a/src/scripts/extensions/webExtensionBase/webExtensionWorker.ts
+++ b/src/scripts/extensions/webExtensionBase/webExtensionWorker.ts
@@ -21,6 +21,7 @@ import {InjectHelper} from "../injectHelper";
 import {InjectUrls} from "./injectUrls";
 import {WebExtension} from "./webExtension";
 import {WebExtensionBackgroundMessageHandler} from "./webExtensionMessageHandler";
+import {ClipperStorageKeys} from "../../storage/clipperStorageKeys";
 
 type TabRemoveInfo = chrome.tabs.TabRemoveInfo;
 type WebResponseCacheDetails = chrome.webRequest.WebResponseCacheDetails;
@@ -72,6 +73,7 @@ export class WebExtensionWorker extends ExtensionWorkerBase<W3CTab, number> {
 	protected doSignOutAction(authType: AuthType) {
 		let usidQueryParamValue = this.getUserSessionIdQueryParamValue();
 		let signOutUrl = ClipperUrls.generateSignOutUrl(this.clientInfo.get().clipperId, usidQueryParamValue, AuthType[authType]);
+		this.clipperData.setValue(ClipperStorageKeys.isUserLoggedIn, "false");
 		fetch(signOutUrl);
 	}
 

--- a/src/scripts/storage/clipperData.ts
+++ b/src/scripts/storage/clipperData.ts
@@ -41,11 +41,17 @@ export class ClipperData implements Storage {
 		return this.storage.getValues(keys);
 	}
 
-	public setValue(key: string, value: string): void {
-		this.storageGateStrategy.shouldSet(key, value).then((result) => {
-			if (result) {
-				this.storage.setValue(key, value);
-			}
+	public async setValue(key: string, value: string): Promise<void> {
+		return new Promise<void>(resolve => {
+			this.storageGateStrategy.shouldSet(key, value).then((result) => {
+				if (result) {
+					this.storage.setValue(key, value).then(() => {
+						resolve();
+					});
+				} else {
+					resolve();
+				}
+			});
 		});
 	}
 

--- a/src/scripts/storage/clipperStorageKeys.ts
+++ b/src/scripts/storage/clipperStorageKeys.ts
@@ -19,4 +19,5 @@ export module ClipperStorageKeys {
 	export var numSuccessfulClipsRatingsEnablement = "numSuccessfulClipsRatingsEnablement";
 	export var numTimesTooltipHasBeenSeenBase = "numTimesTooltipHasBeenSeen";
 	export var userInformation = "userInformation";
+	export var isUserLoggedIn = "isUserLoggedIn";
 }

--- a/src/scripts/storage/localStorage.ts
+++ b/src/scripts/storage/localStorage.ts
@@ -36,15 +36,20 @@ export class LocalStorage implements Storage {
 		return values;
 	}
 
-	public setValue(key: string, value: string): void {
-		if (!value) {
-			this.removeKey(key);
-		} else {
-			sendToOffscreenDocument(OffscreenMessageTypes.setToLocalStorage, {
-				key: key,
-				value: value,
-			});
-		}
+	public async setValue(key: string, value: string): Promise<void> {
+		return new Promise<void>(resolve => {
+			if (!value) {
+				this.removeKey(key);
+				resolve();
+			} else {
+				sendToOffscreenDocument(OffscreenMessageTypes.setToLocalStorage, {
+					key: key,
+					value: value,
+				}).then(() => {
+					resolve();
+				});
+			}
+		});
 	}
 
 	public removeKey(key: string): boolean {

--- a/src/scripts/storage/storage.ts
+++ b/src/scripts/storage/storage.ts
@@ -1,6 +1,6 @@
 export interface Storage {
 	getValue(key: string): Promise<string>;
 	getValues(keys: string[]): Promise<{}>;
-	setValue(key: string, value: string): void;
+	setValue(key: string, value: string): Promise<void>;
 	removeKey(key: string): boolean;
 }

--- a/src/tests/storage/mockStorage.ts
+++ b/src/tests/storage/mockStorage.ts
@@ -32,7 +32,7 @@ export class MockStorage implements Storage {
 		return values;
 	}
 
-	public setValue(key: string, value: string): void {
+	public async setValue(key: string, value: string): Promise<void> {
 		this.storedValues[key] = value;
 	}
 


### PR DESCRIPTION
**Issue**
A signed in user is shown the sign in panel again after a certain period of inactivity.

**Cause**
The user information is no longer present in the state variable once the service worker becomes inactive.

**Fix**
Create a new variable in local storage to indicate if a user is logged in. If this variable is set to true, and the state variable does not already contain the user information, then fetch the user information and store it in the state variable.