### PR TITLE
Idle Clip Fix

### DIFF
--- a/src/scripts/clipperUI/clipper.tsx
+++ b/src/scripts/clipperUI/clipper.tsx
@@ -449,7 +449,7 @@ class ClipperClass extends ComponentBase<ClipperState, {}> {
 			}), this.state.setState);
 		});
 
-		Clipper.getExtensionCommunicator().callRemoteFunction(Constants.FunctionKeys.keepAlive);
+		// Clipper.getExtensionCommunicator().callRemoteFunction(Constants.FunctionKeys.keepAlive);
 
 		Clipper.getExtensionCommunicator().subscribeAcrossCommunicator(clientInfo, Constants.SmartValueKeys.clientInfo, (updatedClientInfo: ClientInfo) => {
 			if (updatedClientInfo) {
@@ -678,8 +678,12 @@ class ClipperClass extends ComponentBase<ClipperState, {}> {
 		}});
 	}
 
-	private startClip(): void {
+	private clearKeepAlive(): void {
 		Clipper.getExtensionCommunicator().callRemoteFunction(Constants.FunctionKeys.clearKeepAlive);
+	}
+
+	private startClip(): void {
+		this.clearKeepAlive();
 		this.state.setState({ oneNoteApiResult: { status: Status.InProgress } });
 
 		this.storeLastClippedInformation();
@@ -784,7 +788,9 @@ class ClipperClass extends ComponentBase<ClipperState, {}> {
 						onSignInInvoked={this.handleSignIn.bind(this) }
 						onSignOutInvoked={this.handleSignOut.bind(this) }
 						updateFrameHeight={this.updateFrameHeight.bind(this) }
-						onStartClip={this.handleStartClip.bind(this) } />
+						onStartClip={this.handleStartClip.bind(this)}
+						clearKeepAlive={this.clearKeepAlive.bind(this)}
+					/>
 				</div>
 			</div>
 		);

--- a/src/scripts/clipperUI/clipper.tsx
+++ b/src/scripts/clipperUI/clipper.tsx
@@ -449,8 +449,6 @@ class ClipperClass extends ComponentBase<ClipperState, {}> {
 			}), this.state.setState);
 		});
 
-		// Clipper.getExtensionCommunicator().callRemoteFunction(Constants.FunctionKeys.keepAlive);
-
 		Clipper.getExtensionCommunicator().subscribeAcrossCommunicator(clientInfo, Constants.SmartValueKeys.clientInfo, (updatedClientInfo: ClientInfo) => {
 			if (updatedClientInfo) {
 				this.state.setState({

--- a/src/scripts/clipperUI/clipper.tsx
+++ b/src/scripts/clipperUI/clipper.tsx
@@ -449,6 +449,8 @@ class ClipperClass extends ComponentBase<ClipperState, {}> {
 			}), this.state.setState);
 		});
 
+		Clipper.getExtensionCommunicator().callRemoteFunction(Constants.FunctionKeys.keepAlive);
+
 		Clipper.getExtensionCommunicator().subscribeAcrossCommunicator(clientInfo, Constants.SmartValueKeys.clientInfo, (updatedClientInfo: ClientInfo) => {
 			if (updatedClientInfo) {
 				this.state.setState({
@@ -677,6 +679,7 @@ class ClipperClass extends ComponentBase<ClipperState, {}> {
 	}
 
 	private startClip(): void {
+		Clipper.getExtensionCommunicator().callRemoteFunction(Constants.FunctionKeys.clearKeepAlive);
 		this.state.setState({ oneNoteApiResult: { status: Status.InProgress } });
 
 		this.storeLastClippedInformation();

--- a/src/scripts/clipperUI/mainController.tsx
+++ b/src/scripts/clipperUI/mainController.tsx
@@ -58,6 +58,7 @@ export interface MainControllerProps extends ClipperStateProp {
 	onSignOutInvoked: (authType: string) => void;
 	updateFrameHeight: (newContainerHeight: number) => void;
 	onStartClip: () => void;
+	clearKeepAlive: () => void;
 }
 
 export class MainControllerClass extends ComponentBase<MainControllerState, MainControllerProps> {
@@ -191,6 +192,8 @@ export class MainControllerClass extends ComponentBase<MainControllerState, Main
 		closeEvent.setCustomProperty(Log.PropertyName.Custom.CurrentPanel, PanelType[this.state.currentPanel]);
 		closeEvent.setCustomProperty(Log.PropertyName.Custom.CloseReason, CloseReason[closeReason]);
 		Clipper.logger.logEvent(closeEvent);
+
+		this.props.clearKeepAlive();
 
 		// Clear region selections on clipper exit rather than invoke to avoid conflicting logic with scenarios like context menu image selection
 		this.props.clipperState.setState({

--- a/src/scripts/constants.ts
+++ b/src/scripts/constants.ts
@@ -327,6 +327,8 @@ export module Constants {
 		export var unloadHandler = "UNLOAD_HANDLER";
 		export var updateFrameHeight = "UPDATE_FRAME_HEIGHT";
 		export var updatePageInfoIfUrlChanged = "UPDATE_PAGE_INFO_IF_URL_CHANGED";
+		export var keepAlive = "KEEP_ALIVE";
+		export var clearKeepAlive = "CLEAR_KEEP_ALIVE";
 	}
 
 	export module KeyCodes {

--- a/src/scripts/extensions/extensionWorkerBase.ts
+++ b/src/scripts/extensions/extensionWorkerBase.ts
@@ -461,11 +461,24 @@ export abstract class ExtensionWorkerBase<TTab, TTabIdentifier> {
 		this.uiCommunicator.broadcastAcrossCommunicator(this.sessionId, Constants.SmartValueKeys.sessionId);
 
 		this.uiCommunicator.registerFunction(Constants.FunctionKeys.keepAlive, () => {
+			if (!!this.keepAlive) {
+				clearInterval(this.keepAlive);
+			}
 			this.keepAlive = setInterval(chrome.runtime.getPlatformInfo, 25 * 1000);
+			// Ensure to clear the interval after 10 minutes if it hasn't been cleared already
+			setTimeout(() => {
+				if (!!this.keepAlive) {
+					clearInterval(this.keepAlive);
+					this.keepAlive = undefined;
+				}
+			}, 10 * 60 * 1000);
 		});
 
 		this.uiCommunicator.registerFunction(Constants.FunctionKeys.clearKeepAlive, () => {
-			clearInterval(this.keepAlive);
+			if (!!this.keepAlive) {
+				clearInterval(this.keepAlive);
+				this.keepAlive = undefined;
+			}
 		});
 
 		this.uiCommunicator.registerFunction(Constants.FunctionKeys.clipperStrings, () => {

--- a/src/scripts/extensions/extensionWorkerBase.ts
+++ b/src/scripts/extensions/extensionWorkerBase.ts
@@ -185,6 +185,18 @@ export abstract class ExtensionWorkerBase<TTab, TTabIdentifier> {
 	 * Skeleton method that notifies the UI to invoke the Clipper. Also performs logging.
 	 */
 	public invokeClipper(invokeInfo: InvokeInfo, options: InvokeOptions) {
+		if (!!this.keepAlive) {
+			clearInterval(this.keepAlive);
+		}
+		this.keepAlive = setInterval(chrome.runtime.getPlatformInfo, 25 * 1000);
+		// Ensure to clear the interval after 10 minutes if it hasn't been cleared already
+		setTimeout(() => {
+			if (!!this.keepAlive) {
+				clearInterval(this.keepAlive);
+				this.keepAlive = undefined;
+			}
+		}, 10 * 60 * 1000);
+
 		// For safety, we enforce that the object we send is never undefined.
 		let invokeOptionsToSend: InvokeOptions = {
 			invokeDataForMode: options ? options.invokeDataForMode : undefined,

--- a/src/scripts/extensions/extensionWorkerBase.ts
+++ b/src/scripts/extensions/extensionWorkerBase.ts
@@ -40,6 +40,7 @@ export abstract class ExtensionWorkerBase<TTab, TTabIdentifier> {
 	private onUnloading: () => void;
 	private loggerId: string;
 	private clipperFunnelAlreadyLogged = false;
+	private keepAlive: number;
 
 	protected consoleOutputEnabledFlagProcessed: Promise<void>;
 	protected tab: TTab;
@@ -458,6 +459,14 @@ export abstract class ExtensionWorkerBase<TTab, TTabIdentifier> {
 		this.uiCommunicator.broadcastAcrossCommunicator(this.auth.user, Constants.SmartValueKeys.user);
 		this.uiCommunicator.broadcastAcrossCommunicator(this.clientInfo, Constants.SmartValueKeys.clientInfo);
 		this.uiCommunicator.broadcastAcrossCommunicator(this.sessionId, Constants.SmartValueKeys.sessionId);
+
+		this.uiCommunicator.registerFunction(Constants.FunctionKeys.keepAlive, () => {
+			this.keepAlive = setInterval(chrome.runtime.getPlatformInfo, 25 * 1000);
+		});
+
+		this.uiCommunicator.registerFunction(Constants.FunctionKeys.clearKeepAlive, () => {
+			clearInterval(this.keepAlive);
+		});
 
 		this.uiCommunicator.registerFunction(Constants.FunctionKeys.clipperStrings, () => {
 			return new Promise<string>((resolve) => {

--- a/src/scripts/extensions/extensionWorkerBase.ts
+++ b/src/scripts/extensions/extensionWorkerBase.ts
@@ -110,6 +110,20 @@ export abstract class ExtensionWorkerBase<TTab, TTabIdentifier> {
 		}
 	}
 
+	private setKeepAlive() {
+		if (!!this.keepAlive) {
+			clearInterval(this.keepAlive);
+		}
+		this.keepAlive = setInterval(chrome.runtime.getPlatformInfo, 25 * 1000);
+		// Ensure to clear the interval after 10 minutes if it hasn't been cleared already
+		setTimeout(() => {
+			if (!!this.keepAlive) {
+				clearInterval(this.keepAlive);
+				this.keepAlive = undefined;
+			}
+		}, 10 * 60 * 1000);
+	}
+
 	/**
 	 * Get the unique id associated with this worker's tab. The type is any type that allows us to distinguish
 	 * between tabs, and is dependent on the browser itself.
@@ -185,17 +199,7 @@ export abstract class ExtensionWorkerBase<TTab, TTabIdentifier> {
 	 * Skeleton method that notifies the UI to invoke the Clipper. Also performs logging.
 	 */
 	public invokeClipper(invokeInfo: InvokeInfo, options: InvokeOptions) {
-		if (!!this.keepAlive) {
-			clearInterval(this.keepAlive);
-		}
-		this.keepAlive = setInterval(chrome.runtime.getPlatformInfo, 25 * 1000);
-		// Ensure to clear the interval after 10 minutes if it hasn't been cleared already
-		setTimeout(() => {
-			if (!!this.keepAlive) {
-				clearInterval(this.keepAlive);
-				this.keepAlive = undefined;
-			}
-		}, 10 * 60 * 1000);
+		this.setKeepAlive();
 
 		// For safety, we enforce that the object we send is never undefined.
 		let invokeOptionsToSend: InvokeOptions = {
@@ -473,17 +477,11 @@ export abstract class ExtensionWorkerBase<TTab, TTabIdentifier> {
 		this.uiCommunicator.broadcastAcrossCommunicator(this.sessionId, Constants.SmartValueKeys.sessionId);
 
 		this.uiCommunicator.registerFunction(Constants.FunctionKeys.keepAlive, () => {
-			if (!!this.keepAlive) {
-				clearInterval(this.keepAlive);
-			}
-			this.keepAlive = setInterval(chrome.runtime.getPlatformInfo, 25 * 1000);
-			// Ensure to clear the interval after 10 minutes if it hasn't been cleared already
-			setTimeout(() => {
-				if (!!this.keepAlive) {
-					clearInterval(this.keepAlive);
-					this.keepAlive = undefined;
-				}
-			}, 10 * 60 * 1000);
+			/**
+			 * This function is currently not being called from anywhere, but it is being registered
+			 * so that it may be used in the future if needed.
+			 */
+			this.setKeepAlive();
 		});
 
 		this.uiCommunicator.registerFunction(Constants.FunctionKeys.clearKeepAlive, () => {

--- a/src/tests/mockProps.ts
+++ b/src/tests/mockProps.ts
@@ -232,7 +232,9 @@ export module MockProps {
 			updateFrameHeight: (newContainerHeight: number) => {
 			},
 			onStartClip: () => {
-			}
+			},
+			clearKeepAlive: () => {
+			},
 		};
 	}
 


### PR DESCRIPTION
**Issue**
If the Clipper UI is opened and left inactive for a certain period, clipping does not work and the UI keeps spinning indefinitely.

**Cause**
Several variables lose their values once the service worker becomes inactive.

**Fix**
Periodically call a trivial extension API to keep the service worker active till the user performs a "Clip" or closes the Clipper UI. 

Reference: https://developer.chrome.com/docs/extensions/develop/migrate/to-service-workers#keep-sw-alive

Please note that we have added a timeout of 10 minutes to clear the keep-alive call so as to ensure that the service worker does not remain active indefinitely. In case a user keeps the Clipper UI open for more than 10 minutes without performing any action, the user will still be required to reload the Clipper UI for a successful clip.

**Testing**

- Open Clipper on Page 1 -> Close Clipper on Page 1: Service worker becomes inactive soon after
- Open Clipper on Page 1 -> Open Clipper on Page 2 -> Close / Clip on Page 1 -> Service worker stays active -> Close / Clip on Page 2 -> Service worker becomes inactive soon after
- Open Clipper on Page 1 -> Close Clipper on Page 1 -> Wait for service worker to become inactive -> Re-open Clipper on Page 1 -> Wait for sometime -> Service worker stays active -> Clip on Page 1 -> Service worker becomes inactive soon after
- Open Clipper on Page 1 -> Close browser -> Re-open browser: Service worker becomes inactive soon after
- Open Clipper on Page 1 -> Do nothing for 10 mins: Service worker becomes inactive soon after (This is because of a timeout of 10 mins that we have introduced to avoid the service worker from staying active indefinitely), in such a case the Clipper UI will have to be reloaded on Page 1 for a successful clip