### PR TITLE
Remove notification on unclippable page and version update to 3.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 3.10.2 (December 2024)
+Improvement : Removed the notification permission
+
 ## 3.10.1 (December 2024)
 * Bug : Fixed showing tooltip consistently on video and pdf clips. 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "webclipper",
-    "version": "3.10.1",
+    "version": "3.10.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "webclipper",
-            "version": "3.10.1",
+            "version": "3.10.2",
             "license": "MIT",
             "dependencies": {
                 "jwt-decode": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.10.1",
+    "version": "3.10.2",
     "name": "webclipper",
     "private": true,
     "description": "The core of the OneNote Web Clipper found at https://www.onenote.com/clipper",

--- a/src/scripts/extensions/chrome/manifest.json
+++ b/src/scripts/extensions/chrome/manifest.json
@@ -42,7 +42,6 @@
       "webRequest",
       "storage",
       "webNavigation",
-      "notifications",
       "offscreen"
     ],
     "host_permissions": [

--- a/src/scripts/extensions/chrome/manifest.json
+++ b/src/scripts/extensions/chrome/manifest.json
@@ -3,7 +3,7 @@
     "name": "OneNote Web Clipper",
     "description": "__MSG_appDesc__",
     "default_locale": "en",
-    "version": "3.10.1",
+    "version": "3.10.2",
     "background": {
       "service_worker": "chromeExtension.js",
       "type": "module"

--- a/src/scripts/extensions/edge/manifest.json
+++ b/src/scripts/extensions/edge/manifest.json
@@ -4,7 +4,7 @@
     "name": "OneNote Web Clipper",
     "description": "__MSG_appDesc__",
     "default_locale": "en",
-    "version": "3.10.1",
+    "version": "3.10.2",
     "background": {
         "scripts": ["edgeExtension.js"],
         "persistent": true

--- a/src/scripts/extensions/edge/manifest.json
+++ b/src/scripts/extensions/edge/manifest.json
@@ -29,8 +29,7 @@
         "tabs",
         "webRequest",
         "storage",
-        "webNavigation",
-        "notifications"
+        "webNavigation"
     ],
 
     "content_security_policy": "script-src 'self'; object-src 'self'",

--- a/src/scripts/extensions/edge/package/AppXManifest.xml
+++ b/src/scripts/extensions/edge/package/AppXManifest.xml
@@ -7,7 +7,7 @@
 	<Identity 
 		Name="Microsoft.OneNoteWebClipper" 
 		Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" 
-		Version="3.10.1.0" />
+		Version="3.10.2.0" />
 
 	<Properties> 
 		<DisplayName>OneNote Web Clipper</DisplayName> 

--- a/src/scripts/extensions/extensionBase.ts
+++ b/src/scripts/extensions/extensionBase.ts
@@ -41,7 +41,7 @@ export abstract class ExtensionBase<TWorker extends ExtensionWorkerBase<TTab, TT
 	protected auth: AuthenticationHelper;
 	protected tooltip: TooltipHelper;
 	protected clientInfo: SmartValue<ClientInfo>;
-	protected static version = "3.10.1";
+	protected static version = "3.10.2";
 
 	constructor(clipperType: ClientType, clipperData: ClipperData) {
 		this.setUnhandledExceptionLogging();

--- a/src/scripts/extensions/firefox/manifest.json
+++ b/src/scripts/extensions/firefox/manifest.json
@@ -3,7 +3,7 @@
     "name": "OneNote Web Clipper",
     "description": "__MSG_appDesc__",
     "default_locale": "en",
-    "version": "3.10.1",
+    "version": "3.10.2",
     "background": {
         "scripts": ["firefoxExtension.js"]
     },

--- a/src/scripts/extensions/firefox/manifest.json
+++ b/src/scripts/extensions/firefox/manifest.json
@@ -27,8 +27,7 @@
         "tabs",
         "webRequest",
         "storage",
-        "webNavigation",
-        "notifications"
+        "webNavigation"
     ],
 
     "applications": {

--- a/src/scripts/extensions/injectHelper.ts
+++ b/src/scripts/extensions/injectHelper.ts
@@ -7,13 +7,13 @@ export class InjectHelper {
 	];
 
 	public static alertUserOfUnclippablePage() {
-		WebExtension.browser.notifications.create({
+		/*WebExtension.browser.notifications.create({
 			type: "basic",
 			iconUrl: "/icons/icon-48.png",
 			title: Localization.getLocalizedString("WebClipper.Notification.Title"),
 			message: Localization.getLocalizedString("WebClipper.Error.CannotClipPage"),
 			priority: 1
-			});
+			});*/
 	}
 
 	public static isKnownUninjectablePage(url: string): boolean {

--- a/src/scripts/extensions/injectHelper.ts
+++ b/src/scripts/extensions/injectHelper.ts
@@ -7,13 +7,7 @@ export class InjectHelper {
 	];
 
 	public static alertUserOfUnclippablePage() {
-		/*WebExtension.browser.notifications.create({
-			type: "basic",
-			iconUrl: "/icons/icon-48.png",
-			title: Localization.getLocalizedString("WebClipper.Notification.Title"),
-			message: Localization.getLocalizedString("WebClipper.Error.CannotClipPage"),
-			priority: 1
-			});*/
+		// No-op for now
 	}
 
 	public static isKnownUninjectablePage(url: string): boolean {

--- a/src/scripts/extensions/safari/Info.plist
+++ b/src/scripts/extensions/safari/Info.plist
@@ -13,9 +13,9 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.10.1</string>
+	<string>3.10.2</string>
 	<key>CFBundleVersion</key>
-	<string>3.10.1</string>
+	<string>3.10.2</string>
 	<key>Chrome</key>
 	<dict>
 		<key>Global Page</key>

--- a/src/scripts/logging/submodules/errorUtils.ts
+++ b/src/scripts/logging/submodules/errorUtils.ts
@@ -135,13 +135,7 @@ export module ErrorUtils {
 		}, true);
 
 		if (shouldShowAlert) {
-			/*WebExtension.browser.notifications.create({
-				type: "basic",
-				iconUrl: "/icons/icon-48.png",
-				title: Localization.getLocalizedString("WebClipper.Notification.Title"),
-				message: Localization.getLocalizedString("WebClipper.Error.NoOpError"),
-				priority: 1
-				});*/
+			// No-op for for now
 		}
 	}
 

--- a/src/scripts/logging/submodules/errorUtils.ts
+++ b/src/scripts/logging/submodules/errorUtils.ts
@@ -135,13 +135,13 @@ export module ErrorUtils {
 		}, true);
 
 		if (shouldShowAlert) {
-			WebExtension.browser.notifications.create({
+			/*WebExtension.browser.notifications.create({
 				type: "basic",
 				iconUrl: "/icons/icon-48.png",
 				title: Localization.getLocalizedString("WebClipper.Notification.Title"),
 				message: Localization.getLocalizedString("WebClipper.Error.NoOpError"),
 				priority: 1
-				});
+				});*/
 		}
 	}
 

--- a/src/strings.json
+++ b/src/strings.json
@@ -154,6 +154,5 @@
 	"WebClipper.FontFamily.Semibold": "Segoe UI Semibold,Segoe UI,Segoe,Segoe WP,Helvetica Neue,Roboto,Helvetica,Arial,Tahoma,Verdana,sans-serif",
 	"WebClipper.FontFamily.Semilight": "Segoe UI Semilight,Segoe UI Light,Segoe WP Light,Segoe UI,Segoe,Segoe WP,Helvetica Neue,Roboto,Helvetica,Arial,Tahoma,Verdana,sans-serif",
 	"WebClipper.FontSize.Preview.SerifDefault": "16px",
-	"WebClipper.FontSize.Preview.SansSerifDefault": "16px",
-	"WebClipper.Notification.Title": "Cannot Clip Page"
+	"WebClipper.FontSize.Preview.SansSerifDefault": "16px"
 }


### PR DESCRIPTION
Remove notifications from clipper

Current behavior is no op on unclippable page

Version update to 3.10.2