### PR TITLE
Clipper Telemetry Fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3111,6 +3111,18 @@
                 "node": ">=0.9.9"
             }
         },
+        "node_modules/cordova-lib/node_modules/cordova-common/node_modules/elementtree": {
+            "version": "0.1.7",
+            "dev": true,
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "sax": "1.1.4"
+            },
+            "engines": {
+                "node": ">= 0.4.0"
+            }
+        },
         "node_modules/cordova-lib/node_modules/cordova-common/node_modules/q": {
             "version": "1.4.1",
             "dev": true,
@@ -3120,6 +3132,12 @@
                 "node": ">=0.6.0",
                 "teleport": ">=0.2.0"
             }
+        },
+        "node_modules/cordova-lib/node_modules/cordova-common/node_modules/sax": {
+            "version": "1.1.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC"
         },
         "node_modules/cordova-lib/node_modules/cordova-common/node_modules/semver": {
             "version": "5.1.0",
@@ -3147,6 +3165,15 @@
             "dev": true,
             "inBundle": true,
             "license": "MIT"
+        },
+        "node_modules/cordova-lib/node_modules/cordova-common/node_modules/unorm": {
+            "version": "1.6.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT or GPL-2.0",
+            "engines": {
+                "node": ">= 0.4.0"
+            }
         },
         "node_modules/cordova-lib/node_modules/cordova-registry-mapper": {
             "version": "1.1.15",
@@ -3179,7 +3206,6 @@
         "node_modules/cordova-lib/node_modules/elementtree": {
             "version": "0.1.6",
             "dev": true,
-            "inBundle": true,
             "dependencies": {
                 "sax": "0.3.5"
             },
@@ -3451,7 +3477,6 @@
         "node_modules/cordova-lib/node_modules/sax": {
             "version": "0.3.5",
             "dev": true,
-            "inBundle": true,
             "license": "MIT",
             "engines": {
                 "node": "*"
@@ -3494,7 +3519,6 @@
         "node_modules/cordova-lib/node_modules/unorm": {
             "version": "1.3.3",
             "dev": true,
-            "inBundle": true,
             "engines": {
                 "node": ">= 0.4.0"
             }
@@ -18687,8 +18711,21 @@
                         "unorm": "^1.3.3"
                     },
                     "dependencies": {
+                        "elementtree": {
+                            "version": "0.1.7",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "sax": "1.1.4"
+                            }
+                        },
                         "q": {
                             "version": "1.4.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "sax": {
+                            "version": "1.1.4",
                             "bundled": true,
                             "dev": true
                         },
@@ -18704,6 +18741,11 @@
                         },
                         "underscore": {
                             "version": "1.8.3",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "unorm": {
+                            "version": "1.6.0",
                             "bundled": true,
                             "dev": true
                         }
@@ -18731,7 +18773,6 @@
                 },
                 "elementtree": {
                     "version": "0.1.6",
-                    "bundled": true,
                     "dev": true,
                     "requires": {
                         "sax": "0.3.5"
@@ -18936,7 +18977,6 @@
                 },
                 "sax": {
                     "version": "0.3.5",
-                    "bundled": true,
                     "dev": true
                 },
                 "shelljs": {
@@ -18962,7 +19002,6 @@
                 },
                 "unorm": {
                     "version": "1.3.3",
-                    "bundled": true,
                     "dev": true
                 },
                 "util-deprecate": {

--- a/src/scripts/extensions/extensionBase.ts
+++ b/src/scripts/extensions/extensionBase.ts
@@ -51,7 +51,7 @@ export abstract class ExtensionBase<TWorker extends ExtensionWorkerBase<TTab, TT
 		ExtensionBase.extensionId = StringUtils.generateGuid();
 
 		this.clipperData = clipperData;
-		this.clipperData.setLogger(this.logger);
+		this.clipperData.setLogger(Promise.resolve(this.logger));
 		this.auth = new AuthenticationHelper(this.clipperData, this.logger);
 		this.tooltip = new TooltipHelper(this.clipperData);
 
@@ -281,7 +281,7 @@ export abstract class ExtensionBase<TWorker extends ExtensionWorkerBase<TTab, TT
 			Promise.all([lastSeenTooltipTimeBase, numTimesTooltipHasBeenSeenBase]).then((values) => {
 				tooltipImpressionEvent.setCustomProperty(Log.PropertyName.Custom.LastSeenTooltipTime, values[0]);
 				tooltipImpressionEvent.setCustomProperty(Log.PropertyName.Custom.NumTimesTooltipHasBeenSeen, values[1]);
-				worker.getLogger().logEvent(tooltipImpressionEvent);
+				worker.getLogger().then(sessionLogger => sessionLogger.logEvent(tooltipImpressionEvent));
 			});
 		});
 	}
@@ -300,7 +300,7 @@ export abstract class ExtensionBase<TWorker extends ExtensionWorkerBase<TTab, TT
 					if (wasInvoked) {
 						let whatsNewImpressionEvent = new Log.Event.BaseEvent(Log.Event.Label.WhatsNewImpression);
 						whatsNewImpressionEvent.setCustomProperty(Log.PropertyName.Custom.FeatureEnabled, wasInvoked);
-						worker.getLogger().logEvent(whatsNewImpressionEvent);
+						worker.getLogger().then(sessionLogger => sessionLogger.logEvent(whatsNewImpressionEvent));
 
 						// We don't want to do this if the tooltip was not invoked (e.g., on about:blank) so we can show it at the next opportunity
 						this.updateLastSeenVersionInStorageToCurrent();

--- a/src/scripts/extensions/webExtensionBase/webExtensionWorker.ts
+++ b/src/scripts/extensions/webExtensionBase/webExtensionWorker.ts
@@ -41,10 +41,9 @@ export class WebExtensionWorker extends ExtensionWorkerBase<W3CTab, number> {
 
 		let isPrivateWindow: Boolean = !!tab.incognito || !!tab.inPrivate;
 
-		this.consoleOutputEnabledFlagProcessed.then(() => {
-			this.logger.setContextProperty(Log.Context.Custom.InPrivateBrowsing, isPrivateWindow.toString());
-			this.invokeDebugLoggingIfEnabled();
-		});
+		this.logger.then(sessionLogger => sessionLogger.setContextProperty(Log.Context.Custom.InPrivateBrowsing, isPrivateWindow.toString()));
+
+		this.invokeDebugLoggingIfEnabled();
 	}
 
 	/**
@@ -59,8 +58,8 @@ export class WebExtensionWorker extends ExtensionWorkerBase<W3CTab, number> {
 	 * authentication. Otherwise, it resolves with true if the redirect endpoint was hit as a result of a successful
 	 * sign in attempt, and false if it was not hit (e.g., user manually closed the popup)
 	 */
-	protected doSignInAction(authType: AuthType): Promise<boolean> {
-		let usidQueryParamValue = this.getUserSessionIdQueryParamValue();
+	protected async doSignInAction(authType: AuthType): Promise<boolean> {
+		let usidQueryParamValue = await this.getUserSessionIdQueryParamValue();
 		let signInUrl = ClipperUrls.generateSignInUrl(this.clientInfo.get().clipperId, usidQueryParamValue, AuthType[authType]);
 
 		return this.launchWebExtensionPopupAndWaitForClose(signInUrl, Constants.Urls.Authentication.authRedirectUrl);
@@ -70,9 +69,10 @@ export class WebExtensionWorker extends ExtensionWorkerBase<W3CTab, number> {
 	 * Signs the user out
 	 */
 	protected doSignOutAction(authType: AuthType) {
-		let usidQueryParamValue = this.getUserSessionIdQueryParamValue();
-		let signOutUrl = ClipperUrls.generateSignOutUrl(this.clientInfo.get().clipperId, usidQueryParamValue, AuthType[authType]);
-		fetch(signOutUrl);
+		this.getUserSessionIdQueryParamValue().then(usidQueryParamValue => {
+			let signOutUrl = ClipperUrls.generateSignOutUrl(this.clientInfo.get().clipperId, usidQueryParamValue, AuthType[authType]);
+			fetch(signOutUrl);
+		});
 	}
 
 	/**
@@ -271,7 +271,7 @@ export class WebExtensionWorker extends ExtensionWorkerBase<W3CTab, number> {
 					});
 				} catch (e) {
 					// In the event that there was an exception thrown during the creation of the popup, fallback to using window.open with a monitor
-					this.logger.logFailure(Log.Failure.Label.WebExtensionWindowCreate, Log.Failure.Type.Unexpected, { error: e.message });
+					this.logger.then(sessionLogger => sessionLogger.logFailure(Log.Failure.Label.WebExtensionWindowCreate, Log.Failure.Type.Unexpected, { error: e.message }));
 
 					this.launchPopupAndWaitForClose(url).then((redirectOccurred) => {
 						// From chrome's background, we currently are unable to reliably determine if the redirect happened

--- a/src/scripts/extensions/workerPassthroughLogger.ts
+++ b/src/scripts/extensions/workerPassthroughLogger.ts
@@ -1,7 +1,6 @@
 import * as Log from "../logging/log";
 import {Logger} from "../logging/logger";
 import {ExtensionWorkerBase} from "./extensionWorkerBase";
-import {NoRequirements} from "../logging/context";
 
 export class WorkerPassthroughLogger extends Logger {
 	private workers: ExtensionWorkerBase<any, any>[];
@@ -13,55 +12,55 @@ export class WorkerPassthroughLogger extends Logger {
 
 	public logEvent(event: Log.Event.BaseEvent): void {
 		for (let worker of this.workers) {
-			worker.getLogger().logEvent(event);
+			worker.getLogger().then(sessionLogger => sessionLogger.logEvent(event));
 		}
 	}
 
 	public pushToStream(label: Log.Event.Label, value: any): void {
 		for (let worker of this.workers) {
-			worker.getLogger().pushToStream(label, value);
+			worker.getLogger().then(sessionLogger => sessionLogger.pushToStream(label, value));
 		}
 	}
 
 	public logFailure(label: Log.Failure.Label, failureType: Log.Failure.Type, failureInfo?: OneNoteApi.GenericError, id?: string): void {
 		for (let worker of this.workers) {
-			worker.getLogger().logFailure(label, failureType, failureInfo, id);
+			worker.getLogger().then(sessionLogger => sessionLogger.logFailure(label, failureType, failureInfo, id));
 		}
 	}
 
 	public logUserFunnel(label: Log.Funnel.Label): void {
 		for (let worker of this.workers) {
-			worker.getLogger().logUserFunnel(label);
+			worker.getLogger().then(sessionLogger => sessionLogger.logUserFunnel(label));
 		}
 	}
 
 	public logSessionStart(): void {
 		for (let worker of this.workers) {
-			worker.getLogger().logSessionStart();
+			worker.getLogger().then(sessionLogger => sessionLogger.logSessionStart());
 		}
 	}
 
 	public logSessionEnd(endTrigger: Log.Session.EndTrigger): void {
 		for (let worker of this.workers) {
-			worker.getLogger().logSessionEnd(endTrigger);
+			worker.getLogger().then(sessionLogger => sessionLogger.logSessionEnd(endTrigger));
 		}
 	}
 
 	public logTrace(label: Log.Trace.Label, level: Log.Trace.Level, message?: string): void {
 		for (let worker of this.workers) {
-			worker.getLogger().logTrace(label, level, message);
+			worker.getLogger().then(sessionLogger => sessionLogger.logTrace(label, level, message));
 		}
 	}
 
 	public logClickEvent(clickId: string): void {
 		for (let worker of this.workers) {
-			worker.getLogger().logClickEvent(clickId);
+			worker.getLogger().then(sessionLogger => sessionLogger.logClickEvent(clickId));
 		}
 	}
 
 	public setContextProperty(key: Log.Context.Custom, value: string): void {
 		for (let worker of this.workers) {
-			worker.getLogger().setContextProperty(key, value);
+			worker.getLogger().then(sessionLogger => sessionLogger.setContextProperty(key, value));
 		}
 	}
 }

--- a/src/scripts/http/clipperCachedHttp.ts
+++ b/src/scripts/http/clipperCachedHttp.ts
@@ -14,14 +14,14 @@ import {CachedHttp, GetResponseAsync, TimeStampedData} from "./cachedHttp";
 export class ClipperCachedHttp extends CachedHttp {
 	private static defaultExpiry = 12 * 60 * 60 * 1000; // 12 hours
 
-	private logger: Logger;
+	private logger: Promise<Logger>;
 
-	constructor(cache: Storage, logger?: Logger) {
+	constructor(cache: Storage, logger?: Promise<Logger>) {
 		super(cache);
 		this.logger = logger;
 	}
 
-	public setLogger(logger: Logger) {
+	public setLogger(logger: Promise<Logger>) {
 		this.logger = logger;
 	}
 
@@ -32,16 +32,16 @@ export class ClipperCachedHttp extends CachedHttp {
 	// Override
 	public getFreshValue(key: string, getRemoteValue: GetResponseAsync, updateInterval = ClipperCachedHttp.defaultExpiry): Promise<TimeStampedData> {
 		if (!key) {
-			this.logger.logFailure(Log.Failure.Label.InvalidArgument, Log.Failure.Type.Unexpected,
-				{ error: "getFreshValue key parameter should be passed a non-empty string" }, "" + key);
+			this.logger.then(logger => logger.logFailure(Log.Failure.Label.InvalidArgument, Log.Failure.Type.Unexpected,
+				{ error: "getFreshValue key parameter should be passed a non-empty string" }, "" + key));
 			return Promise.resolve(undefined);
 		} else if (!getRemoteValue) {
-			this.logger.logFailure(Log.Failure.Label.InvalidArgument, Log.Failure.Type.Unexpected,
-				{ error: "getFreshValue getRemoteValue parameter should be passed a non-undefined function" }, "" + getRemoteValue);
+			this.logger.then(logger => logger.logFailure(Log.Failure.Label.InvalidArgument, Log.Failure.Type.Unexpected,
+				{ error: "getFreshValue getRemoteValue parameter should be passed a non-undefined function" }, "" + getRemoteValue));
 			return Promise.resolve(undefined);
 		} else if (updateInterval < 0) {
-			this.logger.logFailure(Log.Failure.Label.InvalidArgument, Log.Failure.Type.Unexpected,
-				{ error: "getFreshValue updateInterval parameter should be passed a number >= 0" }, "" + updateInterval);
+			this.logger.then(logger => logger.logFailure(Log.Failure.Label.InvalidArgument, Log.Failure.Type.Unexpected,
+				{ error: "getFreshValue updateInterval parameter should be passed a number >= 0" }, "" + updateInterval));
 			updateInterval = 0;
 		}
 
@@ -68,7 +68,7 @@ export class ClipperCachedHttp extends CachedHttp {
 					fetchNonLocalDataEvent.setFailureInfo(error);
 					reject(error);
 				}).then(() => {
-					this.logger.logEvent(fetchNonLocalDataEvent);
+					this.logger.then(logger => logger.logEvent(fetchNonLocalDataEvent));
 				});
 			});
 		};

--- a/src/scripts/storage/clipperData.ts
+++ b/src/scripts/storage/clipperData.ts
@@ -18,14 +18,14 @@ export class ClipperData implements Storage {
 	private storageGateStrategy: StorageGateStrategy;
 	private cachedHttp: ClipperCachedHttp;
 
-	constructor(storage: Storage, logger?: Logger) {
+	constructor(storage: Storage, logger?: Promise<Logger>) {
 		this.storage = storage;
 		this.storageGateStrategy = new ClipperStorageGateStrategy(storage);
 		// We pass 'this' as the Storage object as it handles all the sanity-check gating in the setValue
 		this.cachedHttp = new ClipperCachedHttp(this, logger);
 	}
 
-	public setLogger(logger: Logger) {
+	public setLogger(logger: Promise<Logger>) {
 		this.cachedHttp.setLogger(logger);
 	}
 

--- a/src/tests/http/clipperCachedHttp_tests.ts
+++ b/src/tests/http/clipperCachedHttp_tests.ts
@@ -26,7 +26,7 @@ export class ClipperCachedHttpTests extends TestModule {
 
 	protected tests() {
 		test("When getFreshValue is called with an undefined key, a failure should be logged", () => {
-			let clipperCachedHttp = new ClipperCachedHttp(this.mockStorage, this.stubLogger);
+			let clipperCachedHttp = new ClipperCachedHttp(this.mockStorage, Promise.resolve(this.stubLogger));
 
 			clipperCachedHttp.getFreshValue(undefined, MockStorage.fetchNonLocalData);
 
@@ -37,7 +37,7 @@ export class ClipperCachedHttpTests extends TestModule {
 		});
 
 		test("When getFreshValue is called with an empty key, a failure should be logged", () => {
-			let clipperCachedHttp = new ClipperCachedHttp(this.mockStorage, this.stubLogger);
+			let clipperCachedHttp = new ClipperCachedHttp(this.mockStorage, Promise.resolve(this.stubLogger));
 
 			clipperCachedHttp.getFreshValue("", MockStorage.fetchNonLocalData);
 
@@ -48,7 +48,7 @@ export class ClipperCachedHttpTests extends TestModule {
 		});
 
 		test("When getFreshValue is called with an undefined fetchNonLocalData parameter, a failure should be logged", () => {
-			let clipperCachedHttp = new ClipperCachedHttp(this.mockStorage, this.stubLogger);
+			let clipperCachedHttp = new ClipperCachedHttp(this.mockStorage, Promise.resolve(this.stubLogger));
 
 			clipperCachedHttp.getFreshValue("k", undefined);
 
@@ -59,7 +59,7 @@ export class ClipperCachedHttpTests extends TestModule {
 		});
 
 		test("When getFreshValue is called with an updateInterval of less than 0, a failure should be logged", () => {
-			let clipperCachedHttp = new ClipperCachedHttp(this.mockStorage, this.stubLogger);
+			let clipperCachedHttp = new ClipperCachedHttp(this.mockStorage, Promise.resolve(this.stubLogger));
 
 			clipperCachedHttp.getFreshValue("k", MockStorage.fetchNonLocalData, -1);
 
@@ -72,7 +72,7 @@ export class ClipperCachedHttpTests extends TestModule {
 		test("When getFreshValue is called with valid parameters (assuming when nothing is in storage), logEvent should be called once", (assert: QUnitAssert) => {
 			let done = assert.async();
 
-			let clipperCachedHttp = new ClipperCachedHttp(this.mockStorage, this.stubLogger);
+			let clipperCachedHttp = new ClipperCachedHttp(this.mockStorage, Promise.resolve(this.stubLogger));
 
 			clipperCachedHttp.getFreshValue("k", MockStorage.fetchNonLocalData, 0).then((timeStampedData) => {
 				let logEventSpy = this.stubLogger.logEvent as sinon.SinonSpy;
@@ -96,7 +96,7 @@ export class ClipperCachedHttpTests extends TestModule {
 			} as TimeStampedData;
 			this.mockStorage.setValue(key, JSON.stringify(value));
 
-			let clipperCachedHttp = new ClipperCachedHttp(this.mockStorage, this.stubLogger);
+			let clipperCachedHttp = new ClipperCachedHttp(this.mockStorage, Promise.resolve(this.stubLogger));
 
 			clipperCachedHttp.getFreshValue(key, MockStorage.fetchNonLocalData, expiry).then((timeStampedData) => {
 				let logEventSpy = this.stubLogger.logEvent as sinon.SinonSpy;


### PR DESCRIPTION
**Issue**
No telemetry for any of the clipper versions from v3.10.0 onwards.

**Fix**
Convert `logger` from a `SessionLogger` to a `Promise<SessionLogger>` so that we are sure that the logger is available before we invoke the functions on it.