### PR TITLE
Web Clipper Migration to Manifest v3 in Microsoft Edge

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -229,6 +229,13 @@ gulp.task("bundleAppendIsInstalledMarker", function () {
     return merge(tasks);
 });
 
+gulp.task("bundleOffscreen", function () {
+    var extensionRoot = PATHS.BUILDROOT + "scripts/extensions/";
+    var files = ["offscreen.js"];
+    var tasks = generateBrowserifyTasks(extensionRoot, files);
+    return merge(tasks);
+});
+
 gulp.task("bundleClipperUI", function () {
     var extensionRoot = PATHS.BUILDROOT + "scripts/clipperUI/";
     var files = ["clipper.js", "pageNav.js", "localeSpecificTasks.js", "unsupportedBrowser.js"];
@@ -263,7 +270,7 @@ gulp.task("bundleBookmarklet", function() {
 
 gulp.task("bundleChrome", function() {
     var extensionRoot = PATHS.BUILDROOT + "scripts/extensions/chrome/";
-    var files = ["chromeExtension.js", "chromeDebugLoggingInject.js", "chromeInject.js", "chromePageNavInject.js", "chromeOffscreen.js"];
+    var files = ["chromeExtension.js", "chromeDebugLoggingInject.js", "chromeInject.js", "chromePageNavInject.js"];
     var tasks = generateBrowserifyTasks(extensionRoot, files);
     return merge(tasks);
 });
@@ -299,6 +306,7 @@ gulp.task("bundleTests", function () {
 gulp.task("bundle", function(callback) {
     runSequence(
         "bundleAppendIsInstalledMarker",
+        "bundleOffscreen",
         "bundleClipperUI",
         "bundleLogManager",
         "bundleBookmarklet",
@@ -512,6 +520,10 @@ function exportChromeJS() {
         PATHS.BUNDLEROOT + "appendIsInstalledMarker.js"
     ]).pipe(concat("appendIsInstalledMarker.js")).pipe(gulp.dest(targetDir));
 
+    var offscreenTask = gulp.src([
+        PATHS.BUNDLEROOT + "offscreen.js"
+    ]).pipe(concat("offscreen.js")).pipe(gulp.dest(targetDir));
+
     var chromeExtensionTask = gulp.src([
         targetDir + "logManager.js",
         targetDir + "oneNoteApi.min.js",
@@ -536,14 +548,10 @@ function exportChromeJS() {
         PATHS.BUNDLEROOT + "chromePageNavInject.js"
     ]).pipe(concat("chromePageNavInject.js")).pipe(gulp.dest(targetDir));
 
-    var chromeOffscreenTask = gulp.src([
-        PATHS.BUNDLEROOT + "chromeOffscreen.js"
-    ]).pipe(gulp.dest(targetDir));
-
     if (commonTask) {
-        return merge(commonTask, appendIsInstalledMarkerTask, chromeExtensionTask, chromeDebugLoggingInjectTask, chromeInjectTask, chromePageNavInjectTask, chromeOffscreenTask);
+        return merge(commonTask, appendIsInstalledMarkerTask, offscreenTask, chromeExtensionTask, chromeDebugLoggingInjectTask, chromeInjectTask, chromePageNavInjectTask);
     }
-    return merge(chromeExtensionTask, appendIsInstalledMarkerTask, chromeDebugLoggingInjectTask, chromeInjectTask, chromePageNavInjectTask, chromeOffscreenTask);
+    return merge(chromeExtensionTask, appendIsInstalledMarkerTask, offscreenTask, chromeDebugLoggingInjectTask, chromeInjectTask, chromePageNavInjectTask);
 }
 
 function exportChromeCSS() {
@@ -561,11 +569,11 @@ function exportChromeSrcFiles() {
         PATHS.SRC.ROOT + "scripts/extensions/chrome/manifest.json"
     ]).pipe(gulp.dest(targetDir));
 
-    var chromeOffscreenTask = gulp.src([
-        PATHS.SRC.ROOT + "scripts/extensions/chrome/chromeOffscreen.html"
+    var offscreenTask = gulp.src([
+        PATHS.SRC.ROOT + "scripts/extensions/offscreen.html"
     ]).pipe(gulp.dest(targetDir));
 
-    return merge(srcCommonTask, commonWebExtensionFiles, chromeTask, chromeOffscreenTask);
+    return merge(srcCommonTask, commonWebExtensionFiles, chromeTask, offscreenTask);
 }
 
 function exportChromeLibFiles() {
@@ -581,6 +589,10 @@ function exportEdgeJS() {
     var appendIsInstalledMarkerTask = gulp.src([
         PATHS.BUNDLEROOT + "appendIsInstalledMarker.js"
     ]).pipe(concat("appendIsInstalledMarker.js")).pipe(gulp.dest(targetDir));
+
+    var offscreenTask = gulp.src([
+        PATHS.BUNDLEROOT + "offscreen.js"
+    ]).pipe(concat("offscreen.js")).pipe(gulp.dest(targetDir));
 
     var edgeExtensionTask = gulp.src([
         targetDir + "logManager.js",
@@ -607,9 +619,9 @@ function exportEdgeJS() {
     ]).pipe(concat("edgePageNavInject.js")).pipe(gulp.dest(targetDir));
 
     if (commonTask) {
-        return merge(commonTask, appendIsInstalledMarkerTask, edgeExtensionTask, edgeDebugLoggingInjectTask, edgeInjectTask, edgePageNavInjectTask);
+        return merge(commonTask, appendIsInstalledMarkerTask, offscreenTask, edgeExtensionTask, edgeDebugLoggingInjectTask, edgeInjectTask, edgePageNavInjectTask);
     }
-    return merge(edgeExtensionTask, appendIsInstalledMarkerTask, edgeDebugLoggingInjectTask, edgeInjectTask, edgePageNavInjectTask);
+    return merge(edgeExtensionTask, appendIsInstalledMarkerTask, offscreenTask, edgeDebugLoggingInjectTask, edgeInjectTask, edgePageNavInjectTask);
 }
 
 function exportEdgeCSS() {
@@ -628,7 +640,11 @@ function exportEdgeSrcFiles() {
         PATHS.SRC.ROOT + "scripts/extensions/edge/manifest.json"
     ]).pipe(gulp.dest(targetDir));
 
-    return merge(srcCommonTask, commonWebExtensionFiles, edgeTask);
+    var offscreenTask = gulp.src([
+        PATHS.SRC.ROOT + "scripts/extensions/offscreen.html"
+    ]).pipe(gulp.dest(targetDir));
+
+    return merge(srcCommonTask, commonWebExtensionFiles, edgeTask, offscreenTask);
 }
 
 function exportEdgePackageFiles() {
@@ -1049,7 +1065,7 @@ gulp.task("watchSrcFiles", function() {
             PATHS.SRC.ROOT + "unsupportedBrowser.html",
             PATHS.SRC.ROOT + "pageNav.html",
             PATHS.SRC.ROOT + "scripts/extensions/chrome/manifest.json",
-            PATHS.SRC.ROOT + "scripts/extensions/chrome/chromeOffscreen.html",
+            PATHS.SRC.ROOT + "scripts/extensions/offscreen.html",
             PATHS.SRC.ROOT + "scripts/extensions/edge/edgeExtension.html",
             PATHS.SRC.ROOT + "scripts/extensions/edge/manifest.json",
             PATHS.SRC.ROOT + "scripts/extensions/safari/Info.plist",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3111,6 +3111,18 @@
                 "node": ">=0.9.9"
             }
         },
+        "node_modules/cordova-lib/node_modules/cordova-common/node_modules/elementtree": {
+            "version": "0.1.7",
+            "dev": true,
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "sax": "1.1.4"
+            },
+            "engines": {
+                "node": ">= 0.4.0"
+            }
+        },
         "node_modules/cordova-lib/node_modules/cordova-common/node_modules/q": {
             "version": "1.4.1",
             "dev": true,
@@ -3120,6 +3132,12 @@
                 "node": ">=0.6.0",
                 "teleport": ">=0.2.0"
             }
+        },
+        "node_modules/cordova-lib/node_modules/cordova-common/node_modules/sax": {
+            "version": "1.1.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC"
         },
         "node_modules/cordova-lib/node_modules/cordova-common/node_modules/semver": {
             "version": "5.1.0",
@@ -3147,6 +3165,15 @@
             "dev": true,
             "inBundle": true,
             "license": "MIT"
+        },
+        "node_modules/cordova-lib/node_modules/cordova-common/node_modules/unorm": {
+            "version": "1.6.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT or GPL-2.0",
+            "engines": {
+                "node": ">= 0.4.0"
+            }
         },
         "node_modules/cordova-lib/node_modules/cordova-registry-mapper": {
             "version": "1.1.15",
@@ -3179,7 +3206,6 @@
         "node_modules/cordova-lib/node_modules/elementtree": {
             "version": "0.1.6",
             "dev": true,
-            "inBundle": true,
             "dependencies": {
                 "sax": "0.3.5"
             },
@@ -3451,7 +3477,6 @@
         "node_modules/cordova-lib/node_modules/sax": {
             "version": "0.3.5",
             "dev": true,
-            "inBundle": true,
             "license": "MIT",
             "engines": {
                 "node": "*"
@@ -3494,7 +3519,6 @@
         "node_modules/cordova-lib/node_modules/unorm": {
             "version": "1.3.3",
             "dev": true,
-            "inBundle": true,
             "engines": {
                 "node": ">= 0.4.0"
             }
@@ -18687,8 +18711,21 @@
                         "unorm": "^1.3.3"
                     },
                     "dependencies": {
+                        "elementtree": {
+                            "version": "0.1.7",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "sax": "1.1.4"
+                            }
+                        },
                         "q": {
                             "version": "1.4.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "sax": {
+                            "version": "1.1.4",
                             "bundled": true,
                             "dev": true
                         },
@@ -18704,6 +18741,11 @@
                         },
                         "underscore": {
                             "version": "1.8.3",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "unorm": {
+                            "version": "1.6.0",
                             "bundled": true,
                             "dev": true
                         }
@@ -18731,7 +18773,6 @@
                 },
                 "elementtree": {
                     "version": "0.1.6",
-                    "bundled": true,
                     "dev": true,
                     "requires": {
                         "sax": "0.3.5"
@@ -18936,7 +18977,6 @@
                 },
                 "sax": {
                     "version": "0.3.5",
-                    "bundled": true,
                     "dev": true
                 },
                 "shelljs": {
@@ -18962,7 +19002,6 @@
                 },
                 "unorm": {
                     "version": "1.3.3",
-                    "bundled": true,
                     "dev": true
                 },
                 "util-deprecate": {

--- a/src/scripts/clipperUI/clipper.tsx
+++ b/src/scripts/clipperUI/clipper.tsx
@@ -520,12 +520,11 @@ class ClipperClass extends ComponentBase<ClipperState, {}> {
 				 * The following initializations are necessary to make use of
 				 * an offscreen document from the clipper UI.
 				 */
-				if (updatedClientInfo.clipperType === ClientType.ChromeExtension) {
+				if (updatedClientInfo.clipperType === ClientType.ChromeExtension || updatedClientInfo.clipperType === ClientType.EdgeExtension) {
 					WebExtension.browser = chrome;
-					WebExtension.offscreenUrl = chrome.runtime.getURL("chromeOffscreen.html");
-				} else if (updatedClientInfo.clipperType === ClientType.EdgeExtension) {
-					WebExtension.browser = chrome;
-					WebExtension.offscreenUrl = chrome.runtime.getURL("chromeOffscreen.html");
+					WebExtension.offscreenUrl = chrome.runtime.getURL("offscreen.html");
+				} else {
+					// Do nothing since clipper has been deprecated for other browsers
 				}
 			}
 		});

--- a/src/scripts/clipperUI/clipper.tsx
+++ b/src/scripts/clipperUI/clipper.tsx
@@ -524,7 +524,8 @@ class ClipperClass extends ComponentBase<ClipperState, {}> {
 					WebExtension.browser = chrome;
 					WebExtension.offscreenUrl = chrome.runtime.getURL("chromeOffscreen.html");
 				} else if (updatedClientInfo.clipperType === ClientType.EdgeExtension) {
-					// TODO: Edge specific initialization
+					WebExtension.browser = chrome;
+					WebExtension.offscreenUrl = chrome.runtime.getURL("chromeOffscreen.html");
 				}
 			}
 		});

--- a/src/scripts/communicator/offscreenCommunicator.ts
+++ b/src/scripts/communicator/offscreenCommunicator.ts
@@ -27,6 +27,7 @@ async function handleResponse(message): Promise<string> {
 }
 
 export async function sendToOffscreenDocument(type: string, data: any): Promise<string> {
+	return "";
 	const existingContexts = await WebExtension.browser.runtime.getContexts({
 		contextTypes: [WebExtension.browser.runtime.ContextType.OFFSCREEN_DOCUMENT],
 		documentUrls: [WebExtension.offscreenUrl]

--- a/src/scripts/communicator/offscreenCommunicator.ts
+++ b/src/scripts/communicator/offscreenCommunicator.ts
@@ -27,7 +27,6 @@ async function handleResponse(message): Promise<string> {
 }
 
 export async function sendToOffscreenDocument(type: string, data: any): Promise<string> {
-	return "";
 	const existingContexts = await WebExtension.browser.runtime.getContexts({
 		contextTypes: [WebExtension.browser.runtime.ContextType.OFFSCREEN_DOCUMENT],
 		documentUrls: [WebExtension.offscreenUrl]

--- a/src/scripts/extensions/chrome/chromeExtension.ts
+++ b/src/scripts/extensions/chrome/chromeExtension.ts
@@ -2,7 +2,7 @@ import { ClientType } from "../../clientType";
 import { WebExtension } from "../webExtensionBase/webExtension";
 
 WebExtension.browser = chrome;
-WebExtension.offscreenUrl = chrome.runtime.getURL("chromeOffscreen.html");
+WebExtension.offscreenUrl = chrome.runtime.getURL("offscreen.html");
 
 let clipperBackground = new WebExtension(ClientType.ChromeExtension, {
 	debugLoggingInjectUrl: "chromeDebugLoggingInject.js",

--- a/src/scripts/extensions/chrome/chromeOffscreen.html
+++ b/src/scripts/extensions/chrome/chromeOffscreen.html
@@ -1,2 +1,0 @@
-<!DOCTYPE html>
-<script src="chromeOffscreen.js"></script>

--- a/src/scripts/extensions/edge/edgeExtension.ts
+++ b/src/scripts/extensions/edge/edgeExtension.ts
@@ -4,8 +4,12 @@ import {WebExtension} from "../webExtensionBase/webExtension";
 
 declare var browser;
 
+/**
+ * There is no need to check the window object for the browser property
+ * since the window object is no longer available with Manifest V3
+ */
 WebExtension.browser = chrome;
-WebExtension.offscreenUrl = chrome.runtime.getURL("chromeOffscreen.html");
+WebExtension.offscreenUrl = chrome.runtime.getURL("offscreen.html");
 
 let clipperBackground = new WebExtension(ClientType.EdgeExtension, {
 	debugLoggingInjectUrl: "edgeDebugLoggingInject.js",

--- a/src/scripts/extensions/edge/edgeExtension.ts
+++ b/src/scripts/extensions/edge/edgeExtension.ts
@@ -4,7 +4,8 @@ import {WebExtension} from "../webExtensionBase/webExtension";
 
 declare var browser;
 
-WebExtension.browser = ("browser" in window) ? browser : chrome;
+WebExtension.browser = chrome;
+WebExtension.offscreenUrl = chrome.runtime.getURL("chromeOffscreen.html");
 
 let clipperBackground = new WebExtension(ClientType.EdgeExtension, {
 	debugLoggingInjectUrl: "edgeDebugLoggingInject.js",

--- a/src/scripts/extensions/edge/edgeInject.ts
+++ b/src/scripts/extensions/edge/edgeInject.ts
@@ -3,8 +3,12 @@ import {WebExtension} from "../webExtensionBase/webExtension";
 import {WebExtensionContentMessageHandler} from "../webExtensionBase/webExtensionMessageHandler";
 
 declare var browser;
-WebExtension.browser = ("browser" in window) ? browser : chrome;
 
+/**
+ * There is no need to check the window object for the browser property
+ * since the window object is no longer available with Manifest V3
+ */
+WebExtension.browser = chrome;
 const frameUrl = WebExtension.browser.runtime.getURL("clipper.html");
 
 invoke({

--- a/src/scripts/extensions/edge/manifest.json
+++ b/src/scripts/extensions/edge/manifest.json
@@ -1,13 +1,13 @@
 {
-    "manifest_version": 2,
+    "manifest_version": 3,
     "author": "Microsoft Corporation",
     "name": "OneNote Web Clipper",
     "description": "__MSG_appDesc__",
     "default_locale": "en",
     "version": "3.10.3",
     "background": {
-        "scripts": ["edgeExtension.js"],
-        "persistent": true
+        "service_worker": "edgeExtension.js",
+        "type": "module"
     },
 
     "content_scripts": [{
@@ -18,28 +18,34 @@
     }],
 
     "web_accessible_resources": [
-        "clipper.html"
+        {
+            "resources": [
+                "clipper.html"
+            ],
+            "matches": [
+                "<all_urls>"
+            ]
+        }
     ],
 
     "permissions": [
-        "<all_urls>",
         "activeTab",
+        "scripting",
         "contextMenus",
         "cookies",
         "tabs",
         "webRequest",
         "storage",
-        "webNavigation"
+        "webNavigation",
+        "offscreen"
     ],
 
-    "content_security_policy": "script-src 'self'; object-src 'self'",
+    "host_permissions": [
+        "<all_urls>"
+    ],
 
-    "browser_action": {
-        "default_title": "Clip to OneNote",
-        "default_icon": {
-            "19": "icons/icon-19.png",
-            "38": "icons/icon-38.png"
-        }
+    "content_security_policy": {
+        "extension_pages": "script-src 'self'; object-src 'self'"
     },
 
     "icons": {
@@ -52,5 +58,13 @@
         "96": "icons/icon-96.png",
         "128": "icons/icon-128.png",
         "256": "icons/icon-256.png"
+    },
+
+    "action": {
+        "default_title": "Clip to OneNote",
+        "default_icon": {
+            "19": "icons/icon-19.png",
+            "38": "icons/icon-38.png"
+        }
     }
 }

--- a/src/scripts/extensions/offscreen.html
+++ b/src/scripts/extensions/offscreen.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<script src="offscreen.js"></script>

--- a/src/scripts/extensions/offscreen.ts
+++ b/src/scripts/extensions/offscreen.ts
@@ -1,4 +1,4 @@
-import {OffscreenMessageTypes} from "../../communicator/offscreenMessageTypes";
+import {OffscreenMessageTypes} from "../communicator/offscreenMessageTypes";
 
 // Registering this listener when the script is first executed ensures that the
 // offscreen document will be able to receive messages when the promise returned


### PR DESCRIPTION
This PR is to migrate Web Clipper to Manifest v3 in Microsoft Edge.

**Testing**
Verified that Clipper works, both in Chrome as well as Edge.

Also, given that the name of the offscreen document has now been changed, verified that Clipper continues to work as expected after a Reload in Chrome, and the name of one of the views changes from `chromeOffscreen.html` to `offscreen.html`.