### PR TITLE
Fix for dark mode issues

### DIFF
--- a/src/scripts/extensions/styledFrameFactory.ts
+++ b/src/scripts/extensions/styledFrameFactory.ts
@@ -43,6 +43,7 @@ export class StyledFrameFactory {
 		iframe.style.position = "fixed";
 		iframe.style.transition = "initial";
 		iframe.style.zIndex = "2147483647";
+		(iframe.style as any).colorScheme = "light";
 	}
 
 	private static getGloballyStyledFrame(): HTMLIFrameElement {


### PR DESCRIPTION
If we hide / delete the entire html element within the oneNoteWebClipper iframe, we can see a big white box which is what is hiding the contents of the actual webpage. The iframe has an inherited css property color-scheme as shown below:
![image](https://github.com/user-attachments/assets/ac888e24-4867-4585-b7d7-41af30210a27)
However, clipper isn't being comfortably rendered in dark mode. On changing the value of the above property from dark to light, clipper works fine even when the search engine is in dark mode.

As per [color-scheme - CSS: Cascading Style Sheets | MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme), "The color-scheme CSS property allows an element to indicate which color schemes it can comfortably be rendered in".

Before: 
<img width="1205" alt="image" src="https://github.com/user-attachments/assets/4b687975-0b8e-41da-90aa-f10133108758" />
After:
<img width="1175" alt="image" src="https://github.com/user-attachments/assets/552a2fdf-3cde-4b95-9c63-4b242e9fdadd" />


Before:
![image](https://github.com/user-attachments/assets/8bc1b077-06f0-4871-9e18-a0aa0fc25ac1)
After:
The white background does not appear in dark mode
