### PR TITLE
Show Refresh Clipper message when Service Worker becomes inactive

### DIFF
--- a/src/scripts/extensions/clipperInject.ts
+++ b/src/scripts/extensions/clipperInject.ts
@@ -219,6 +219,14 @@ export class ClipperInject extends FrameInjectBase<ClipperInjectOptions> {
 			return Promise.resolve();
 		});
 
+		// Register the following function to the extension communicator in
+		// order to allow the function to be remotely called from the same
+		this.extCommunicator.registerFunction(Constants.FunctionKeys.showRefreshClipperMessage, (errorMessage: string) => {
+			this.uiCommunicator.callRemoteFunction(Constants.FunctionKeys.showRefreshClipperMessage, {
+				param: errorMessage
+			});
+		});
+
 		this.extCommunicator.setErrorHandler((e: Error) => {
 			this.uiCommunicator.callRemoteFunction(Constants.FunctionKeys.showRefreshClipperMessage, {
 				param: "Communicator " + Constants.CommunicationChannels.injectedAndExtension + " caught an error: " + e.message

--- a/src/scripts/extensions/extensionWorkerBase.ts
+++ b/src/scripts/extensions/extensionWorkerBase.ts
@@ -120,6 +120,15 @@ export abstract class ExtensionWorkerBase<TTab, TTabIdentifier> {
 			if (!!this.keepAlive) {
 				clearInterval(this.keepAlive);
 				this.keepAlive = undefined;
+				/**
+				 * If we reach this point, it means that the keep alive interval was not cleared within 10 minutes
+				 * which is an indication that the clipper ux is not being used. We will now allow the service worker
+				 * to become inactive and notifiy the user to refresh the page.
+				 */
+				this.injectCommunicator.callRemoteFunction(Constants.FunctionKeys.showRefreshClipperMessage, {
+					param: "Communicator " + Constants.CommunicationChannels.injectedAndExtension + " caught an error: " +
+						"Clipper UX was not used for 10 minutes."
+				});
 			}
 		}, 10 * 60 * 1000);
 	}


### PR DESCRIPTION
**Issue**
If a user keeps the clipper ux open, we keep the service worker active for atmost 10 minutes after which we allow the service worker to become inactive. This is based on the assumption that most users won't keep the clipper ux open for more than 10 minutes without interacting with it.

However, in case a user does keep the clipper ux open for more than 10 minutes and then tries to perform a Clip, the clipper ux will keep spinning indefinitely since the service worker is inactive.

**Fix**
Show a refresh clipper message when the service worker becomes inactive after 10 minutes of inactivity.

![image](https://github.com/user-attachments/assets/cd862dd3-5c42-44d0-b3fd-12dd18b97ad5)

**Testing**
Reduced the keep alive interval to 1 minute for testing purposes, and ensured that the refresh clipper message is shown automatically if the clipper ux is kept open for more than a minute.

Also, opened the clipper ux on 2 different webpages at 2 different times and ensured that the refresh clipper message is shown on both webpages after a minute of opening the clipper ux on the corresponding webpage.