### PR TITLE
Modify Ratings Prompt Logic

### DIFF
--- a/src/scripts/clipperUI/ratingsHelper.ts
+++ b/src/scripts/clipperUI/ratingsHelper.ts
@@ -219,10 +219,18 @@ export class RatingsHelper {
 			return;
 		}
 
-		let numSuccessfulClipsRatingsEnablementAsStr: string = Clipper.getCachedValue(ClipperStorageKeys.numSuccessfulClipsRatingsEnablement);
+		/**
+		 * This is commented out since we would need numSuccessfulClipsRatingsEnablement
+		 * to be updated even if it has already been set. This is because the user could
+		 * have not already interacted with the prompt. If the user has already interacted
+		 * with the prompt, doNotPromptRatings will be set to true which in turn will
+		 * ensure that the prompt is not shown again.
+		 */
+
+		/* let numSuccessfulClipsRatingsEnablementAsStr: string = Clipper.getCachedValue(ClipperStorageKeys.numSuccessfulClipsRatingsEnablement);
 		if (parseInt(numSuccessfulClipsRatingsEnablementAsStr, 10) >= 0) {
 			return;
-		}
+		} */
 
 		let numSuccessfulClips: number = parseInt(Clipper.getCachedValue(ClipperStorageKeys.numSuccessfulClips), 10);
 		// subtracting 1 below to account for the fact that this set is occuring after one already successful clip

--- a/src/scripts/clipperUI/ratingsHelper.ts
+++ b/src/scripts/clipperUI/ratingsHelper.ts
@@ -99,7 +99,7 @@ export class RatingsHelper {
 	/**
 	 * Set ClipperStorageKeys.isRatingsPromptLogicExecutedInEdge value to "true"
 	 */
-	public static setisRatingsPromptLogicExecutedInEdge(): void {
+	public static setIsRatingsPromptLogicExecutedInEdge(): void {
 		Clipper.storeValue(ClipperStorageKeys.isRatingsPromptLogicExecutedInEdge, "true");
 
 		Clipper.logger.logEvent(new Log.Event.BaseEvent(Log.Event.Label.SetIsRatingsPromptLogicExecutedInEdge));
@@ -246,7 +246,7 @@ export class RatingsHelper {
 				return;
 			}
 		} else if (clientType === ClientType.EdgeExtension) {
-			RatingsHelper.setisRatingsPromptLogicExecutedInEdge();
+			RatingsHelper.setIsRatingsPromptLogicExecutedInEdge();
 		}
 
 		let numSuccessfulClips: number = parseInt(Clipper.getCachedValue(ClipperStorageKeys.numSuccessfulClips), 10);

--- a/src/scripts/clipperUI/ratingsHelper.ts
+++ b/src/scripts/clipperUI/ratingsHelper.ts
@@ -77,6 +77,7 @@ export class RatingsHelper {
 	public static preCacheNeededValues(): void {
 		let ratingsPromptStorageKeys = [
 			ClipperStorageKeys.doNotPromptRatings,
+			ClipperStorageKeys.isRatingsPromptLogicExecutedInEdge,
 			ClipperStorageKeys.lastBadRatingDate,
 			ClipperStorageKeys.lastBadRatingVersion,
 			ClipperStorageKeys.lastSeenVersion,
@@ -93,6 +94,15 @@ export class RatingsHelper {
 		Clipper.storeValue(ClipperStorageKeys.doNotPromptRatings, "true");
 
 		Clipper.logger.logEvent(new Log.Event.BaseEvent(Log.Event.Label.SetDoNotPromptRatings));
+	}
+
+	/**
+	 * Set ClipperStorageKeys.isRatingsPromptLogicExecutedInEdge value to "true"
+	 */
+	public static setisRatingsPromptLogicExecutedInEdge(): void {
+		Clipper.storeValue(ClipperStorageKeys.isRatingsPromptLogicExecutedInEdge, "true");
+
+		Clipper.logger.logEvent(new Log.Event.BaseEvent(Log.Event.Label.SetIsRatingsPromptLogicExecutedInEdge));
 	}
 
 	/**
@@ -204,7 +214,8 @@ export class RatingsHelper {
 	 *
 	 * The set is "needed" if ALL of the below applies:
 	 *   * The user has not already interacted with the prompt (ClipperStorageKeys.doNotPromptRatings is not set)
-	 *   * ClipperStorageKeys.numSuccessfulClipsRatingsEnablement has not already been set
+	 *   * The ratings prompt logic has not already executed in Edge or
+	 *       ClipperStorageKeys.numSuccessfulClipsRatingsEnablement has not already been set
 	 *
 	 * Public for testing
 	 *
@@ -213,24 +224,30 @@ export class RatingsHelper {
 	 * re-raise the prompt for users who have already interacted with it (although it is possible users who didn't interact
 	 * with the original prompt see it up to twice as many times as originally planned).
 	 */
-	public static setNumSuccessfulClipsRatingsEnablement(): void {
+	public static setNumSuccessfulClipsRatingsEnablement(clientType: ClientType): void {
 		let doNotPromptRatingsAsStr: string = Clipper.getCachedValue(ClipperStorageKeys.doNotPromptRatings);
 		if (RatingsHelper.doNotPromptRatingsIsSet(doNotPromptRatingsAsStr)) {
 			return;
 		}
 
 		/**
-		 * This is commented out since we would need numSuccessfulClipsRatingsEnablement
-		 * to be updated even if it has already been set. This is because the user could
-		 * have not already interacted with the prompt. If the user has already interacted
-		 * with the prompt, doNotPromptRatings will be set to true which in turn will
-		 * ensure that the prompt is not shown again.
+		 * If the ratings prompt logic hasn't been executed in Edge, then we would
+		 * need numSuccessfulClipsRatingsEnablement to be updated even if it has
+		 * already been set. This is because the user hasn't already interacted
+		 * with the prompt, and we need to ensure that the difference between the
+		 * number of successful clips and the anchor clip value is less than or
+		 * equal to the maximum number of successful clips for ratings enablement,
+		 * as per the logic in clipSuccessDelayIsOver(...).
 		 */
-
-		/* let numSuccessfulClipsRatingsEnablementAsStr: string = Clipper.getCachedValue(ClipperStorageKeys.numSuccessfulClipsRatingsEnablement);
-		if (parseInt(numSuccessfulClipsRatingsEnablementAsStr, 10) >= 0) {
-			return;
-		} */
+		let isRatingsPromptLogicExecutedInEdgeAsStr: string = Clipper.getCachedValue(ClipperStorageKeys.isRatingsPromptLogicExecutedInEdge);
+		if (clientType !== ClientType.EdgeExtension || RatingsHelper.isRatingsPromptLogicExecutedInEdge(isRatingsPromptLogicExecutedInEdgeAsStr)) {
+			let numSuccessfulClipsRatingsEnablementAsStr: string = Clipper.getCachedValue(ClipperStorageKeys.numSuccessfulClipsRatingsEnablement);
+			if (parseInt(numSuccessfulClipsRatingsEnablementAsStr, 10) >= 0) {
+				return;
+			}
+		} else if (clientType === ClientType.EdgeExtension) {
+			RatingsHelper.setisRatingsPromptLogicExecutedInEdge();
+		}
 
 		let numSuccessfulClips: number = parseInt(Clipper.getCachedValue(ClipperStorageKeys.numSuccessfulClips), 10);
 		// subtracting 1 below to account for the fact that this set is occuring after one already successful clip
@@ -259,7 +276,7 @@ export class RatingsHelper {
 			return false;
 		}
 
-		RatingsHelper.setNumSuccessfulClipsRatingsEnablement();
+		RatingsHelper.setNumSuccessfulClipsRatingsEnablement(clipperState.clientInfo.clipperType);
 
 		let doNotPromptRatingsStr: string = Clipper.getCachedValue(ClipperStorageKeys.doNotPromptRatings);
 		let lastBadRatingDateAsStr: string = Clipper.getCachedValue(ClipperStorageKeys.lastBadRatingDate);
@@ -320,5 +337,9 @@ export class RatingsHelper {
 
 	private static doNotPromptRatingsIsSet(doNotPromptRatingsStr: string): boolean {
 		return !ObjectUtils.isNullOrUndefined(doNotPromptRatingsStr) && doNotPromptRatingsStr.toLowerCase() === "true";
+	}
+
+	private static isRatingsPromptLogicExecutedInEdge(isRatingsPromptLogicExecutedInEdgeAsStr: string): boolean {
+		return !ObjectUtils.isNullOrUndefined(isRatingsPromptLogicExecutedInEdgeAsStr) && isRatingsPromptLogicExecutedInEdgeAsStr.toLowerCase() === "true";
 	}
 }

--- a/src/scripts/logging/submodules/event.ts
+++ b/src/scripts/logging/submodules/event.ts
@@ -58,6 +58,7 @@ export module Event {
 		SendBatchRequest,
 		SetContextProperty,
 		SetDoNotPromptRatings,
+		SetIsRatingsPromptLogicExecutedInEdge,
 		ShouldShowRatingsPrompt,
 		TooltipImpression,
 		UpdatePage,

--- a/src/scripts/storage/clipperStorageKeys.ts
+++ b/src/scripts/storage/clipperStorageKeys.ts
@@ -20,4 +20,5 @@ export module ClipperStorageKeys {
 	export var numTimesTooltipHasBeenSeenBase = "numTimesTooltipHasBeenSeen";
 	export var userInformation = "userInformation";
 	export var isUserLoggedIn = "isUserLoggedIn";
+	export var isRatingsPromptLogicExecutedInEdge = "isRatingsPromptLogicExecutedInEdge";
 }

--- a/src/tests/clipperUI/ratingsHelper_tests.tsx
+++ b/src/tests/clipperUI/ratingsHelper_tests.tsx
@@ -37,13 +37,14 @@ export class RatingsHelperTests extends TestModule {
 
 	protected tests() {
 		test("setNumSuccessfulClipsRatingsEnablement does not set the value when ClipperStorageKeys.doNotPromptRatings is set", (assert: QUnitAssert) => {
+			let clientType: ClientType = ClientType.EdgeExtension;
 			let done = assert.async();
 
 			let numClips = 12;
 			Clipper.storeValue(ClipperStorageKeys.numSuccessfulClips, numClips.toString());
 			Clipper.storeValue(ClipperStorageKeys.doNotPromptRatings, "true");
 
-			RatingsHelper.setNumSuccessfulClipsRatingsEnablement();
+			RatingsHelper.setNumSuccessfulClipsRatingsEnablement(clientType);
 
 			Clipper.getStoredValue(ClipperStorageKeys.numSuccessfulClipsRatingsEnablement, (numClipsAnchorAsStr: string) => {
 				ok(ObjectUtils.isNullOrUndefined(numClipsAnchorAsStr));
@@ -52,15 +53,19 @@ export class RatingsHelperTests extends TestModule {
 		});
 
 		test("setNumSuccessfulClipsRatingsEnablement does not overwrite the value when it already exists", (assert: QUnitAssert) => {
+			let clientType: ClientType = ClientType.EdgeExtension;
 			let done = assert.async();
 
 			let numClips = 12;
 			Clipper.storeValue(ClipperStorageKeys.numSuccessfulClips, numClips.toString());
 
+			let isRatingsPromptExecutedInEdge = true;
+			Clipper.storeValue(ClipperStorageKeys.isRatingsPromptLogicExecutedInEdge, isRatingsPromptExecutedInEdge.toString());
+
 			let expectedStorageValue = 999;
 			Clipper.storeValue(ClipperStorageKeys.numSuccessfulClipsRatingsEnablement, expectedStorageValue.toString());
 
-			RatingsHelper.setNumSuccessfulClipsRatingsEnablement();
+			RatingsHelper.setNumSuccessfulClipsRatingsEnablement(clientType);
 
 			Clipper.getStoredValue(ClipperStorageKeys.numSuccessfulClipsRatingsEnablement, (numClipsAnchorAsStr: string) => {
 				strictEqual(parseInt(numClipsAnchorAsStr, 10), expectedStorageValue);
@@ -69,12 +74,13 @@ export class RatingsHelperTests extends TestModule {
 		});
 
 		test("setNumSuccessfulClipsRatingsEnablement sets the value to (ClipperStorageKeys.numSuccessfulClips - 1) when applicable", (assert: QUnitAssert) => {
+			let clientType: ClientType = ClientType.EdgeExtension;
 			let done = assert.async();
 
 			let numClips = 12;
 			Clipper.storeValue(ClipperStorageKeys.numSuccessfulClips, numClips.toString());
 
-			RatingsHelper.setNumSuccessfulClipsRatingsEnablement();
+			RatingsHelper.setNumSuccessfulClipsRatingsEnablement(clientType);
 
 			Clipper.getStoredValue(ClipperStorageKeys.numSuccessfulClipsRatingsEnablement, (numClipsAnchorAsStr: string) => {
 				strictEqual(parseInt(numClipsAnchorAsStr, 10), numClips - 1);


### PR DESCRIPTION
**Issue**
This PR is to ensure that the ratings prompt starts showing up for users of Web Clipper in Edge.

**Fix**
If the ratings prompt logic hasn't been executed in Edge, then we would need `numSuccessfulClipsRatingsEnablement` to be updated even if it has already been set. This is because the user hasn't already interacted with the prompt, and we need to ensure that the difference between the number of successful clips and the anchor clip value is less than or equal to the maximum number of successful clips for ratings enablement, as per the logic in `clipSuccessDelayIsOver(...)`.

![image](https://github.com/user-attachments/assets/1cba1c59-f7b2-459d-8303-7c68eea1cb0a)

**Testing**
Verified that `numSuccessfulClipsRatingsEnablement` gets updated if `isRatingsPromptLogicExecutedInEdge` is set to false.

<img src="https://github.com/user-attachments/assets/dda785c4-560e-47f4-b5f9-84aeae6df3fd" width="500" height="100"><br/>

**After taking another successful clip:**

<img src="https://github.com/user-attachments/assets/0e3b5f8c-fbe1-43c0-a107-7079c4ae31a7" width="500" height="100"><br/>

**After taking a few more successful clips:**

<img src="https://github.com/user-attachments/assets/d54c608b-3a92-413f-b0f7-d7a99f25e5c4" width="500" height="100"><br/>

Since 11 - 7 = 5 >= 4 which is the minimum number of successful clips for ratings enablement, the ratings prompt is shown to the user.

<img src="https://github.com/user-attachments/assets/12f3514d-0876-48a2-925a-5554a76dfb4d" width="200" height="200">
