### PR TITLE
Prevent XSS via usid

### DIFF
--- a/src/scripts/extensions/extensionWorkerBase.ts
+++ b/src/scripts/extensions/extensionWorkerBase.ts
@@ -340,7 +340,29 @@ export abstract class ExtensionWorkerBase<TTab, TTabIdentifier> {
 
 	protected getUserSessionIdQueryParamValue(): string {
 		let usidQueryParamValue = this.logger.getUserSessionId();
-		return usidQueryParamValue ? usidQueryParamValue : this.clientInfo.get().clipperId;
+		console.log("usidQueryParamValue: " + usidQueryParamValue);
+
+		// Validate the usid parameter (UUID-like format)
+		const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+		const isValidUsid = uuidRegex.test(usidQueryParamValue);
+		if (!isValidUsid) {
+			throw new Error("Invalid usid parameter");
+		}
+
+		// Validate the clipperId parameter (ON-UUID format)
+		const clipperId = this.clientInfo.get().clipperId;
+		const clipperIdRegex = /^ON-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+		const isValidClipperId = clipperIdRegex.test(clipperId);
+		if (!isValidClipperId) {
+			throw new Error("Invalid clipperId parameter");
+		}
+
+		// Encode the usid parameter
+		usidQueryParamValue = encodeURIComponent(usidQueryParamValue);
+		console.log("usidQueryParamValue: " + usidQueryParamValue);
+		console.log("clipperId: " + clipperId);
+
+		return usidQueryParamValue ? usidQueryParamValue : encodeURIComponent(clipperId);
 	}
 
 	protected async invokeDebugLoggingIfEnabled(): Promise<boolean> {

--- a/src/scripts/extensions/extensionWorkerBase.ts
+++ b/src/scripts/extensions/extensionWorkerBase.ts
@@ -340,7 +340,6 @@ export abstract class ExtensionWorkerBase<TTab, TTabIdentifier> {
 
 	protected getUserSessionIdQueryParamValue(): string {
 		let usidQueryParamValue = this.logger.getUserSessionId();
-		console.log("usidQueryParamValue: " + usidQueryParamValue);
 
 		// Validate the usid parameter (UUID-like format)
 		const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -359,8 +358,6 @@ export abstract class ExtensionWorkerBase<TTab, TTabIdentifier> {
 
 		// Encode the usid parameter
 		usidQueryParamValue = encodeURIComponent(usidQueryParamValue);
-		console.log("usidQueryParamValue: " + usidQueryParamValue);
-		console.log("clipperId: " + clipperId);
 
 		return usidQueryParamValue ? usidQueryParamValue : encodeURIComponent(clipperId);
 	}


### PR DESCRIPTION
**Issue**
Reporter states that there is a Reflected XSS via the "usid" parameter. When the page is rendered, the ClipperSignOutUrl and ClipperFeedbackUrl variables are not being handled safely and therefore are escaped. This allows an attacker to jump straight to the hash location, which can be set as a javascript handler like "javascript:alert()". This leads to XSS.

**Fix**
Use a regular expression to ensure that the "usid" parameter conforms to expected patterns.

**Testing**
Hardcoded `usidQueryParamValue` in `getUserSessionIdQueryParamValue`.

`let usidQueryParamValue = "ee%22+location.replace(location.hash.substr(1))+%22&SilentAuthAttempted=1&fromAR=4#javascript:alert()";`

Verified that sign out does not go through and instead the following error is thrown in the console:

![image](https://github.com/user-attachments/assets/648e2e47-e146-49e7-a2c0-ac39846053f6)
