### PR TITLE
onenote.com subsites deprecation - Web Clipper Subsites

### DIFF
--- a/src/scripts/constants.ts
+++ b/src/scripts/constants.ts
@@ -377,10 +377,10 @@ export module Constants {
 		export var augmentationApiUrl = serviceDomain + "/onaugmentation/clipperextract/v1.0/";
 		export var changelogUrl = serviceDomain + "/whatsnext/webclipper";
 		export var clipperFeedbackUrl = serviceDomain + "/feedback";
-		export var clipperInstallPageUrl = serviceDomain + "/clipper/installed";
 		export var fullPageScreenshotUrl = serviceDomain + "/onaugmentation/clipperDomEnhancer/v1.0/";
 		export var localizedStringsUrlBase = serviceDomain + "/strings?ids=WebClipper.";
 
+		export var clipperInstallPageUrl = "https://support.microsoft.com/en-us/office/getting-started-with-the-onenote-web-clipper-5696609d-c5ae-4591-b3af-1f897cb6eda6";
 		export var msaDomain = "https://login.live.com";
 		export var orgIdDomain = "https://login.microsoftonline.com";
 		export var userDataBoundaryDomain = "https://odc.officeapps.live.com/odc/v2.1/federationprovider";

--- a/src/scripts/extensions/extensionBase.ts
+++ b/src/scripts/extensions/extensionBase.ts
@@ -153,11 +153,6 @@ export abstract class ExtensionBase<TWorker extends ExtensionWorkerBase<TTab, TT
 	protected getClipperInstalledPageUrl(clipperId: string, clipperType: ClientType, isInlineInstall: boolean): string {
 		let installUrl: string = Constants.Urls.clipperInstallPageUrl;
 
-		installUrl = UrlUtils.addUrlQueryValue(installUrl, Constants.Urls.QueryParams.clientType, ClientType[clipperType]);
-		installUrl = UrlUtils.addUrlQueryValue(installUrl, Constants.Urls.QueryParams.clipperId, clipperId);
-		installUrl = UrlUtils.addUrlQueryValue(installUrl, Constants.Urls.QueryParams.clipperVersion,  ExtensionBase.getExtensionVersion());
-		installUrl = UrlUtils.addUrlQueryValue(installUrl, Constants.Urls.QueryParams.inlineInstall, isInlineInstall.toString());
-
 		this.logger.logTrace(Log.Trace.Label.RequestForClipperInstalledPageUrl, Log.Trace.Level.Information, installUrl);
 
 		return installUrl;
@@ -286,9 +281,9 @@ export abstract class ExtensionBase<TWorker extends ExtensionWorkerBase<TTab, TT
 		});
 	}
 
-	private shouldShowWhatsNewTooltip(tab: TTab, lastSeenVersion: Version, extensionVersion: Version): boolean {
-		// We explicitly check for control group as well so we prevent updating lastSeenVersion on everyone before the experiment starts
-		return this.checkIfTabIsOnWhitelistedUrl(tab) && ExtensionBase.shouldCheckForMajorUpdates(lastSeenVersion, extensionVersion);
+	private shouldShowWhatsNewTooltip(_tab: TTab, _lastSeenVersion: Version, _extensionVersion: Version): boolean {
+		// Disable the "What's New" tooltip for OneNote Web Clipper for now
+		return false;
 	}
 
 	private showWhatsNewTooltip(tab: TTab, lastSeenVersion: Version, extensionVersion: Version): void {


### PR DESCRIPTION
**Issue**
The following Web Clipper subsites are being deprecated:

1. https://www.onenote.com/whatsnext/webclipper
2. https://www.onenote.com/clipper/installed

**Fix**

https://www.onenote.com/whatsnext/webclipper - At this subsite, I only see change logs from very old versions from 2016, i.e. 3.1.0, 3.2.0 and 3.3.0. This indicates that the "What's New" tooltip might not even be shown to users currently. Hence, we have decided to disable the tooltip for now.

https://www.onenote.com/clipper/installed - Redirect to https://support.microsoft.com/en-us/office/getting-started-with-the-onenote-web-clipper-5696609d-c5ae-4591-b3af-1f897cb6eda6 on a successful clipper installation.

**Testing**
Verified that we are now successfully redirected to https://support.microsoft.com/en-us/office/getting-started-with-the-onenote-web-clipper-5696609d-c5ae-4591-b3af-1f897cb6eda6 on a successful clipper installation.