### PR TITLE
Remove storage permission

### DIFF
--- a/src/scripts/extensions/chrome/manifest.json
+++ b/src/scripts/extensions/chrome/manifest.json
@@ -40,7 +40,6 @@
       "contextMenus",
       "tabs",
       "webRequest",
-      "storage",
       "webNavigation",
       "offscreen"
     ],

--- a/src/scripts/extensions/edge/manifest.json
+++ b/src/scripts/extensions/edge/manifest.json
@@ -35,7 +35,6 @@
         "cookies",
         "tabs",
         "webRequest",
-        "storage",
         "webNavigation",
         "offscreen"
     ],


### PR DESCRIPTION
**Issue**
Chrome has reported a violation on latest version of OneNote Web Clipper.

![image](https://github.com/user-attachments/assets/8e306935-191b-481e-8067-72b2d36485e6)

**Cause**
As per https://developer.chrome.com/docs/extensions/reference/api/storage, the storage permission is required to make use of the chrome.storage API.

However, there aren't any occurrences of `chrome.storage` or `WebExtension.browser.storage` in the codebase.

**Fix**
Remove the storage permission.

**Testing**
Verified that clipper continues working as expected without any storage related errors in the console.