### PR TITLE
Updated version from 3.10.8 to 3.10.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 3.10.9 (March 2025)
+* Improvement : Removed the storage permission.
+
 ## 3.10.8 (March 2025)
 * Improvement : Deprecated onenote.com subsites.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "webclipper",
-    "version": "3.10.8",
+    "version": "3.10.9",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "webclipper",
-            "version": "3.10.8",
+            "version": "3.10.9",
             "license": "MIT",
             "dependencies": {
                 "jwt-decode": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.10.8",
+    "version": "3.10.9",
     "name": "webclipper",
     "private": true,
     "description": "The core of the OneNote Web Clipper found at https://www.onenote.com/clipper",

--- a/src/scripts/extensions/chrome/manifest.json
+++ b/src/scripts/extensions/chrome/manifest.json
@@ -3,7 +3,7 @@
     "name": "OneNote Web Clipper",
     "description": "__MSG_appDesc__",
     "default_locale": "en",
-    "version": "3.10.8",
+    "version": "3.10.9",
     "background": {
       "service_worker": "chromeExtension.js",
       "type": "module"

--- a/src/scripts/extensions/edge/manifest.json
+++ b/src/scripts/extensions/edge/manifest.json
@@ -4,7 +4,7 @@
     "name": "OneNote Web Clipper",
     "description": "__MSG_appDesc__",
     "default_locale": "en",
-    "version": "3.10.8",
+    "version": "3.10.9",
     "background": {
         "service_worker": "edgeExtension.js",
         "type": "module"

--- a/src/scripts/extensions/edge/package/AppXManifest.xml
+++ b/src/scripts/extensions/edge/package/AppXManifest.xml
@@ -7,7 +7,7 @@
 	<Identity 
 		Name="Microsoft.OneNoteWebClipper" 
 		Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" 
-		Version="3.10.8.0" />
+		Version="3.10.9.0" />
 
 	<Properties> 
 		<DisplayName>OneNote Web Clipper</DisplayName> 

--- a/src/scripts/extensions/extensionBase.ts
+++ b/src/scripts/extensions/extensionBase.ts
@@ -41,7 +41,7 @@ export abstract class ExtensionBase<TWorker extends ExtensionWorkerBase<TTab, TT
 	protected auth: AuthenticationHelper;
 	protected tooltip: TooltipHelper;
 	protected clientInfo: SmartValue<ClientInfo>;
-	protected static version = "3.10.8";
+	protected static version = "3.10.9";
 
 	constructor(clipperType: ClientType, clipperData: ClipperData) {
 		this.setUnhandledExceptionLogging();

--- a/src/scripts/extensions/firefox/manifest.json
+++ b/src/scripts/extensions/firefox/manifest.json
@@ -3,7 +3,7 @@
     "name": "OneNote Web Clipper",
     "description": "__MSG_appDesc__",
     "default_locale": "en",
-    "version": "3.10.8",
+    "version": "3.10.9",
     "background": {
         "scripts": ["firefoxExtension.js"]
     },

--- a/src/scripts/extensions/safari/Info.plist
+++ b/src/scripts/extensions/safari/Info.plist
@@ -13,9 +13,9 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.10.8</string>
+	<string>3.10.9</string>
 	<key>CFBundleVersion</key>
-	<string>3.10.8</string>
+	<string>3.10.9</string>
 	<key>Chrome</key>
 	<dict>
 		<key>Global Page</key>


### PR DESCRIPTION
Updated version from 3.10.8 to 3.10.9

This version of OneNote Web Clipper removes the storage permission since it isn't required.