### PR TITLE
Remove webclipper/data usage

### DIFF
--- a/src/scripts/logging/logManager.d.ts
+++ b/src/scripts/logging/logManager.d.ts
@@ -1,8 +1,6 @@
 declare module LogManager {
 	export function createExtLogger(sessionId: any, uiCommunicator?: any): any;
 
-	export function sendMiscLogRequest(data: MiscLogEventData, keysToCamelCase: boolean);
-
 	export interface MiscLogEventData {
 		label: string;
 		category: string;

--- a/src/scripts/logging/logManager.ts
+++ b/src/scripts/logging/logManager.ts
@@ -36,13 +36,6 @@ function createDebugLogger(uiCommunicator: Communicator, sessionId: SmartValue<s
 	});
 }
 
-/**
- * Sends an event to console with relevant data as query parameters
- */
-export function sendMiscLogRequest(data: LogManager.MiscLogEventData, keysToCamelCase: boolean): void {
-	console.warn(JSON.stringify({ label: data.label, category: data.category, properties: data.properties }));
-}
-
 export function reInitLoggerForDataBoundaryChange(userDataBoundary: string): void {
 	let message: string = "DataBoundary different than default logging boundary :" + userDataBoundary;
 	console.log(message);

--- a/src/scripts/logging/submodules/errorUtils.ts
+++ b/src/scripts/logging/submodules/errorUtils.ts
@@ -65,7 +65,7 @@ export module ErrorUtils {
 	}
 
 	/**
-	 * Sends a request to the misc logging endpoint with relevant failure data as query parameters
+	 * Logs a failure with relevant failure data
 	 */
 	export function sendFailureLogRequest(data: FailureLogEventData): void {
 		let failureInfoString = ErrorUtils.toString(data.properties.failureInfo);


### PR DESCRIPTION
**Issue**
webclipper/data used in the function `sendMiscLogRequest` in WebClipper_Internal for telemetry purposes. We however want to deprecate this subsite.

**Fix**
`sendMiscLogRequest` is called only at 2 places.

1. sendNoOpTrackerRequest

We had disabled the clipper button on unclippable pages as part of https://github.com/OneNoteDev/WebClipper/pull/568. Hence, we shouldn't expect this function to be called anymore. Telemetry confirms the same.

![image](https://github.com/user-attachments/assets/ea3ddf75-71a1-42d3-b5fa-03c0d00e993b)

Hence, I have commented out the call to `sendMiscLogRequest` in this function.

2. sendFailureLogRequest

I have replaced the call to `sendMiscLogRequest` with a call to `Clipper.logger.logFailure` in this function.

The `sendMiscLogRequest` function itself is being removed from WebClipper_Internal as part of https://github.com/OneNoteDev/WebClipper_Internal/pull/68.

**Testing**
Post merge, we will need to verify that the labels for which `sendFailureLogRequest` is called (mainly `UnhandledExceptionThrown`) continues getting logged.