### PR TITLE
Updated version from 3.10.11 to 3.10.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 3.10.12 (January 2026)
+* Improvement : Added a11y improvements.
+
 ## 3.10.11 (October 2025)
 * Improvement : Chrome and Edge extension icons refreshed to match the updated icon set across all platforms.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "webclipper",
-    "version": "3.10.11",
+    "version": "3.10.12",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "webclipper",
-            "version": "3.10.11",
+            "version": "3.10.12",
             "license": "MIT",
             "dependencies": {
                 "jwt-decode": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
         "url": "git+https://github.com/OneNoteDev/WebClipper.git"
     },
     "devDependencies": {
-        "@playwright/test": "^1.57.0",
         "@types/chrome": "0.0.257",
         "@types/es6-promise": "0.0.32",
         "@types/filesystem": "0.0.36",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.10.11",
+    "version": "3.10.12",
     "name": "webclipper",
     "private": true,
     "description": "The core of the OneNote Web Clipper found at https://www.onenote.com/clipper",
@@ -21,6 +21,7 @@
         "url": "git+https://github.com/OneNoteDev/WebClipper.git"
     },
     "devDependencies": {
+        "@playwright/test": "^1.57.0",
         "@types/chrome": "0.0.257",
         "@types/es6-promise": "0.0.32",
         "@types/filesystem": "0.0.36",

--- a/src/scripts/extensions/chrome/manifest.json
+++ b/src/scripts/extensions/chrome/manifest.json
@@ -3,7 +3,7 @@
     "name": "OneNote Web Clipper",
     "description": "__MSG_appDesc__",
     "default_locale": "en",
-    "version": "3.10.11",
+    "version": "3.10.12",
     "background": {
       "service_worker": "chromeExtension.js",
       "type": "module"

--- a/src/scripts/extensions/edge/manifest.json
+++ b/src/scripts/extensions/edge/manifest.json
@@ -4,7 +4,7 @@
     "name": "OneNote Web Clipper",
     "description": "__MSG_appDesc__",
     "default_locale": "en",
-    "version": "3.10.11",
+    "version": "3.10.12",
     "background": {
         "service_worker": "edgeExtension.js",
         "type": "module"

--- a/src/scripts/extensions/edge/package/AppXManifest.xml
+++ b/src/scripts/extensions/edge/package/AppXManifest.xml
@@ -7,7 +7,7 @@
 	<Identity 
 		Name="Microsoft.OneNoteWebClipper" 
 		Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" 
-		Version="3.10.11.0" />
+		Version="3.10.12.0" />
 
 	<Properties> 
 		<DisplayName>OneNote Web Clipper</DisplayName> 

--- a/src/scripts/extensions/extensionBase.ts
+++ b/src/scripts/extensions/extensionBase.ts
@@ -41,7 +41,7 @@ export abstract class ExtensionBase<TWorker extends ExtensionWorkerBase<TTab, TT
 	protected auth: AuthenticationHelper;
 	protected tooltip: TooltipHelper;
 	protected clientInfo: SmartValue<ClientInfo>;
-	protected static version = "3.10.11";
+	protected static version = "3.10.12";
 
 	constructor(clipperType: ClientType, clipperData: ClipperData) {
 		this.setUnhandledExceptionLogging();


### PR DESCRIPTION
Updated version from 3.10.11 to 3.10.12

This version of OneNote Web Clipper fixes the following A11y bugs-
[Bug 7396207](https://dev.azure.com/office/OneNote/_workitems/edit/7396207)
[Bug 7396201](https://dev.azure.com/office/OneNote/_workitems/edit/7396201)
[Bug 8781406](https://dev.azure.com/office/OneNote/_workitems/edit/8781406)
[Bug 8784966](https://dev.azure.com/office/OneNote/_workitems/edit/8784966)
[Bug 8780741](https://dev.azure.com/office/OneNote/_workitems/edit/8780741)
[Bug 8780801](https://dev.azure.com/office/OneNote/_workitems/edit/8780801)
[Bug 8781387](https://dev.azure.com/office/OneNote/_workitems/edit/8781387)