### PR TITLE
A11y Bug 5122289: Update extension button accessible name for screen readers

### DIFF
--- a/src/scripts/extensions/chrome/manifest.json
+++ b/src/scripts/extensions/chrome/manifest.json
@@ -61,7 +61,7 @@
       "256": "icons/icon-256.png"
     },
     "action": {
-      "default_title": "Clip to OneNote",
+      "default_title": "OneNote Clipper",
       "default_icon": {
         "19": "icons/icon-19.png",
         "38": "icons/icon-38.png"

--- a/src/scripts/extensions/chrome/manifest.json
+++ b/src/scripts/extensions/chrome/manifest.json
@@ -61,7 +61,7 @@
       "256": "icons/icon-256.png"
     },
     "action": {
-      "default_title": "OneNote Clipper",
+      "default_title": "OneNote Web Clipper",
       "default_icon": {
         "19": "icons/icon-19.png",
         "38": "icons/icon-38.png"

--- a/src/scripts/extensions/edge/manifest.json
+++ b/src/scripts/extensions/edge/manifest.json
@@ -60,7 +60,7 @@
     },
 
     "action": {
-        "default_title": "OneNote Clipper",
+        "default_title": "OneNote Web Clipper",
         "default_icon": {
             "19": "icons/icon-19.png",
             "38": "icons/icon-38.png"

--- a/src/scripts/extensions/edge/manifest.json
+++ b/src/scripts/extensions/edge/manifest.json
@@ -60,7 +60,7 @@
     },
 
     "action": {
-        "default_title": "Clip to OneNote",
+        "default_title": "OneNote Clipper",
         "default_icon": {
             "19": "icons/icon-19.png",
             "38": "icons/icon-38.png"

--- a/src/scripts/extensions/firefox/manifest.json
+++ b/src/scripts/extensions/firefox/manifest.json
@@ -40,7 +40,7 @@
     "content_security_policy": "script-src 'self'; object-src 'self'",
 
     "browser_action": {
-        "default_title": "Clip to OneNote",
+        "default_title": "OneNote Clipper",
         "default_icon": {
             "19": "icons/icon-19.png",
             "38": "icons/icon-38.png"

--- a/src/scripts/extensions/firefox/manifest.json
+++ b/src/scripts/extensions/firefox/manifest.json
@@ -40,7 +40,7 @@
     "content_security_policy": "script-src 'self'; object-src 'self'",
 
     "browser_action": {
-        "default_title": "OneNote Clipper",
+        "default_title": "OneNote Web Clipper",
         "default_icon": {
             "19": "icons/icon-19.png",
             "38": "icons/icon-38.png"


### PR DESCRIPTION
Change the default_title from "Clip to OneNote" to "OneNote Clipper" across all browser extension manifests (Chrome, Edge, Firefox) to provide a clearer accessible name for screen reader users.
Demo after fix
For edge:
https://github.com/user-attachments/assets/4c6490cf-0ee9-4e9a-aac9-7ebfed1d10bf
https://github.com/user-attachments/assets/f35cf61c-4ca6-4eed-90b5-2b2fd614a513
For chrome:

https://github.com/user-attachments/assets/47ee4241-feed-4d6c-86d4-83ace8897f77





Fixes #629