### PR TITLE
A11y Bug 8780715 : add keyboard focus to success panel and region selecting panel

### DIFF
--- a/src/scripts/clipperUI/panels/regionSelectingPanel.tsx
+++ b/src/scripts/clipperUI/panels/regionSelectingPanel.tsx
@@ -4,10 +4,6 @@ import {ClipperStateProp} from "../clipperState";
 import {ComponentBase} from "../componentBase";
 
 class RegionSelectingPanelClass extends ComponentBase<{}, ClipperStateProp> {
-	initiallySetFocus(element: HTMLElement) {
-		element.focus();
-	}
-
 	handleCancelButton() {
 		this.props.clipperState.setState({
 			focusOnRender: Constants.Ids.regionButton
@@ -32,7 +28,6 @@ class RegionSelectingPanelClass extends ComponentBase<{}, ClipperStateProp> {
 					</div>
 					<div className="wideButtonContainer">
 						<a id={ Constants.Ids.regionClipCancelButton } role="button"
-							{...this.onElementFirstDraw(this.initiallySetFocus)}
 							{...this.enableInvoke({callback: this.handleCancelButton, tabIndex: 0})} >
 							<span className="wideButtonFont wideActionButton buttonTextInHighContrast" style={Localization.getFontFamilyAsStyle(Localization.FontFamily.Semibold)}>
 								{Localization.getLocalizedString("WebClipper.Action.BackToHome")}

--- a/src/scripts/clipperUI/panels/regionSelectingPanel.tsx
+++ b/src/scripts/clipperUI/panels/regionSelectingPanel.tsx
@@ -4,6 +4,10 @@ import {ClipperStateProp} from "../clipperState";
 import {ComponentBase} from "../componentBase";
 
 class RegionSelectingPanelClass extends ComponentBase<{}, ClipperStateProp> {
+	initiallySetFocus(element: HTMLElement) {
+		element.focus();
+	}
+
 	handleCancelButton() {
 		this.props.clipperState.setState({
 			focusOnRender: Constants.Ids.regionButton
@@ -28,6 +32,7 @@ class RegionSelectingPanelClass extends ComponentBase<{}, ClipperStateProp> {
 					</div>
 					<div className="wideButtonContainer">
 						<a id={ Constants.Ids.regionClipCancelButton } role="button"
+							{...this.onElementFirstDraw(this.initiallySetFocus)}
 							{...this.enableInvoke({callback: this.handleCancelButton, tabIndex: 0})} >
 							<span className="wideButtonFont wideActionButton buttonTextInHighContrast" style={Localization.getFontFamilyAsStyle(Localization.FontFamily.Semibold)}>
 								{Localization.getLocalizedString("WebClipper.Action.BackToHome")}

--- a/src/scripts/clipperUI/panels/successPanel.tsx
+++ b/src/scripts/clipperUI/panels/successPanel.tsx
@@ -14,6 +14,10 @@ import {Clipper} from "../frontEndGlobals";
 import {SpriteAnimation} from "../components/spriteAnimation";
 
 class SuccessPanelClass extends ComponentBase<{ }, ClipperStateProp> {
+	initiallySetFocus(element: HTMLElement) {
+		element.focus();
+	}
+
 	public onLaunchOneNoteButton() {
 		Clipper.logger.logUserFunnel(Log.Funnel.Label.ViewInWac);
 		let data = this.props.clipperState.oneNoteApiResult.data as OneNoteApi.Page;
@@ -38,6 +42,7 @@ class SuccessPanelClass extends ComponentBase<{ }, ClipperStateProp> {
 				</div>
 				<div className="wideButtonContainer">
 					<a id={Constants.Ids.launchOneNoteButton} className="wideButtonFont wideActionButton buttonTextInHighContrast" role="button"
+						{...this.onElementFirstDraw(this.initiallySetFocus)}
 						{...this.enableInvoke({callback: this.onLaunchOneNoteButton, tabIndex: 70})}
 						style={Localization.getFontFamilyAsStyle(Localization.FontFamily.Regular)}>
 						{Localization.getLocalizedString("WebClipper.Action.ViewInOneNote")}


### PR DESCRIPTION
Add automatic focus management to ensure keyboard focus is visible when the success panel and region selecting panel are first rendered. This addresses accessibility issue MAS 2.4.7 (Focus Visible).

- Add initiallySetFocus method to SuccessPanelClass
- Add onElementFirstDraw to focus "View in OneNote" button on success
- Add initiallySetFocus method to RegionSelectingPanelClass
- Add onElementFirstDraw to focus "Back to Home" button in region panel

Fixes #628
Before
https://github.com/user-attachments/assets/b81c843a-51d0-481a-8744-bea6b85f6497

After
https://github.com/user-attachments/assets/cface3d5-f132-486b-a4f9-27e6a066639e



