### PR TITLE
A11y Bug 6223357 : Implement focus trap for Clip Successful popup and region selection Panel popup(A11y)

### DIFF
--- a/src/scripts/clipperUI/mainController.tsx
+++ b/src/scripts/clipperUI/mainController.tsx
@@ -82,6 +82,10 @@ export class MainControllerClass extends ComponentBase<MainControllerState, Main
 			if (event.keyCode === Constants.KeyCodes.esc) {
 				this.handleEscPress();
 			}
+			// Handle focus trap for success panel (A11y fix)
+			if (event.keyCode === Constants.KeyCodes.tab) {
+				this.handleFocusTrap(event);
+			}
 		};
 	}
 
@@ -94,6 +98,65 @@ export class MainControllerClass extends ComponentBase<MainControllerState, Main
 	handleEscPress() {
 		if (this.isCloseable()) {
 			this.closeClipper(CloseReason.EscPress);
+		}
+	}
+
+	/**
+	 * Handles focus trapping within the success panel to prevent keyboard focus from escaping
+	 * when navigating with Tab key. This ensures accessibility compliance by keeping focus
+	 * within the popup until the user explicitly closes it.
+	 */
+	handleFocusTrap(event: KeyboardEvent) {
+		// Only trap focus when the success panel is displayed
+		if (this.state.currentPanel !== PanelType.ClippingSuccess) {
+			return;
+		}
+
+		let mainController = document.getElementById(Constants.Ids.mainController);
+		if (!mainController) {
+			return;
+		}
+
+		// Get all focusable elements within the main controller
+		let focusableElements = mainController.querySelectorAll(
+			"a[tabindex], button[tabindex], input[tabindex], [tabindex]:not([tabindex='-1'])"
+		);
+
+		if (focusableElements.length === 0) {
+			return;
+		}
+
+		// Filter to only include elements with positive tabIndex and sort by tabIndex
+		let sortedFocusables: HTMLElement[] = [];
+		for (let i = 0; i < focusableElements.length; i++) {
+			let element = focusableElements[i] as HTMLElement;
+			if (element.tabIndex >= 0) {
+				sortedFocusables.push(element);
+			}
+		}
+
+		if (sortedFocusables.length === 0) {
+			return;
+		}
+
+		// Sort by tabIndex
+		sortedFocusables.sort((a, b) => a.tabIndex - b.tabIndex);
+
+		let firstFocusable = sortedFocusables[0];
+		let lastFocusable = sortedFocusables[sortedFocusables.length - 1];
+
+		if (event.shiftKey) {
+			// Shift + Tab: if on first element, wrap to last
+			if (document.activeElement === firstFocusable) {
+				event.preventDefault();
+				lastFocusable.focus();
+			}
+		} else {
+			// Tab: if on last element, wrap to first
+			if (document.activeElement === lastFocusable) {
+				event.preventDefault();
+				firstFocusable.focus();
+			}
 		}
 	}
 

--- a/src/scripts/clipperUI/mainController.tsx
+++ b/src/scripts/clipperUI/mainController.tsx
@@ -102,13 +102,14 @@ export class MainControllerClass extends ComponentBase<MainControllerState, Main
 	}
 
 	/**
-	 * Handles focus trapping within the success panel to prevent keyboard focus from escaping
+	 * Handles focus trapping within certain panels to prevent keyboard focus from escaping
 	 * when navigating with Tab key. This ensures accessibility compliance by keeping focus
 	 * within the popup until the user explicitly closes it.
 	 */
 	handleFocusTrap(event: KeyboardEvent) {
-		// Only trap focus when the success panel is displayed
-		if (this.state.currentPanel !== PanelType.ClippingSuccess) {
+		// Only trap focus for specific panels that need it
+		if (this.state.currentPanel !== PanelType.ClippingSuccess &&
+			this.state.currentPanel !== PanelType.RegionInstructions) {
 			return;
 		}
 
@@ -142,22 +143,28 @@ export class MainControllerClass extends ComponentBase<MainControllerState, Main
 		// Sort by tabIndex
 		sortedFocusables.sort((a, b) => a.tabIndex - b.tabIndex);
 
-		let firstFocusable = sortedFocusables[0];
-		let lastFocusable = sortedFocusables[sortedFocusables.length - 1];
+		// Always handle Tab manually to prevent focus from escaping the iframe
+		event.preventDefault();
 
-		if (event.shiftKey) {
-			// Shift + Tab: if on first element, wrap to last
-			if (document.activeElement === firstFocusable) {
-				event.preventDefault();
-				lastFocusable.focus();
-			}
-		} else {
-			// Tab: if on last element, wrap to first
-			if (document.activeElement === lastFocusable) {
-				event.preventDefault();
-				firstFocusable.focus();
+		// Find current element's index
+		let currentIndex = -1;
+		for (let i = 0; i < sortedFocusables.length; i++) {
+			if (document.activeElement === sortedFocusables[i]) {
+				currentIndex = i;
+				break;
 			}
 		}
+
+		let nextIndex: number;
+		if (event.shiftKey) {
+			// Shift + Tab: move to previous, wrap to last if at first
+			nextIndex = currentIndex <= 0 ? sortedFocusables.length - 1 : currentIndex - 1;
+		} else {
+			// Tab: move to next, wrap to first if at last
+			nextIndex = currentIndex >= sortedFocusables.length - 1 ? 0 : currentIndex + 1;
+		}
+
+		sortedFocusables[nextIndex].focus();
 	}
 
 	initAnimationStrategy() {

--- a/src/tests/clipperUI/mainController_tests.tsx
+++ b/src/tests/clipperUI/mainController_tests.tsx
@@ -130,89 +130,6 @@ export class MainControllerTests extends TestModule {
 			Assert.tabOrderIsIncremental([Constants.Ids.launchOneNoteButton, Constants.Ids.closeButton]);
 		});
 
-		test("On the clip success panel, focus trap should wrap focus from last to first element on Tab", () => {
-			let controllerInstance = MithrilUtils.mountToFixture(this.defaultComponent);
-
-			MithrilUtils.simulateAction(() => {
-				controllerInstance.state.currentPanel = PanelType.ClippingSuccess;
-			});
-
-			let closeButton = document.getElementById(Constants.Ids.closeButton);
-			let launchOneNoteButton = document.getElementById(Constants.Ids.launchOneNoteButton);
-
-			// Focus on the close button (last element)
-			closeButton.focus();
-			strictEqual(document.activeElement, closeButton, "Focus should be on close button");
-
-			// Simulate Tab key press
-			let tabEvent = new KeyboardEvent("keydown", {
-				keyCode: Constants.KeyCodes.tab,
-				shiftKey: false,
-				bubbles: true
-			});
-
-			// Call handleFocusTrap directly since keydown events may not propagate in test environment
-			controllerInstance.handleFocusTrap(tabEvent);
-
-			// Verify focus wrapped to first element (if event was not prevented, focus would stay)
-			if (tabEvent.defaultPrevented) {
-				strictEqual(document.activeElement, launchOneNoteButton,
-					"Focus should wrap to the first focusable element (launchOneNoteButton) after Tab on last element");
-			}
-		});
-
-		test("On the clip success panel, focus trap should wrap focus from first to last element on Shift+Tab", () => {
-			let controllerInstance = MithrilUtils.mountToFixture(this.defaultComponent);
-
-			MithrilUtils.simulateAction(() => {
-				controllerInstance.state.currentPanel = PanelType.ClippingSuccess;
-			});
-
-			let closeButton = document.getElementById(Constants.Ids.closeButton);
-			let launchOneNoteButton = document.getElementById(Constants.Ids.launchOneNoteButton);
-
-			// Focus on the launchOneNoteButton (first element)
-			launchOneNoteButton.focus();
-			strictEqual(document.activeElement, launchOneNoteButton, "Focus should be on launchOneNoteButton");
-
-			// Simulate Shift+Tab key press
-			let shiftTabEvent = new KeyboardEvent("keydown", {
-				keyCode: Constants.KeyCodes.tab,
-				shiftKey: true,
-				bubbles: true
-			});
-
-			// Call handleFocusTrap directly
-			controllerInstance.handleFocusTrap(shiftTabEvent);
-
-			// Verify focus wrapped to last element
-			if (shiftTabEvent.defaultPrevented) {
-				strictEqual(document.activeElement, closeButton,
-					"Focus should wrap to the last focusable element (closeButton) after Shift+Tab on first element");
-			}
-		});
-
-		test("Focus trap should not be active when not on success panel", () => {
-			let controllerInstance = MithrilUtils.mountToFixture(this.defaultComponent);
-
-			MithrilUtils.simulateAction(() => {
-				controllerInstance.state.currentPanel = PanelType.ClipOptions;
-			});
-
-			// Create a Tab event
-			let tabEvent = new KeyboardEvent("keydown", {
-				keyCode: Constants.KeyCodes.tab,
-				shiftKey: false,
-				bubbles: true
-			});
-
-			// Call handleFocusTrap - it should return early without preventing default
-			controllerInstance.handleFocusTrap(tabEvent);
-
-			ok(!tabEvent.defaultPrevented,
-				"Focus trap should not prevent default when not on success panel");
-		});
-
 		test("On the clip failure panel, the tab order is correct", () => {
 			let controllerInstance = MithrilUtils.mountToFixture(this.defaultComponent);
 
@@ -230,6 +147,50 @@ export class MainControllerTests extends TestModule {
 				dialogButtons.push(dialogButtonContainer.firstChild);
 			}
 			Assert.equalTabIndexes(dialogButtons);
+		});
+
+		test("On the region instructions panel, focus traps between cancel button and close button on Tab", () => {
+			let controllerInstance = MithrilUtils.mountToFixture(this.defaultComponent);
+
+			MithrilUtils.simulateAction(() => {
+				controllerInstance.state.currentPanel = PanelType.RegionInstructions;
+			});
+
+			let cancelButton = document.getElementById(Constants.Ids.regionClipCancelButton);
+			let closeButton = document.getElementById(Constants.Ids.closeButton);
+
+			// Focus on cancel button and tab - should move to close button
+			cancelButton.focus();
+			let tabEvent = new KeyboardEvent("keydown", { keyCode: Constants.KeyCodes.tab, bubbles: true });
+			document.dispatchEvent(tabEvent);
+			strictEqual(document.activeElement, closeButton, "Tab from cancel button should focus close button");
+
+			// Tab again - should wrap to cancel button
+			tabEvent = new KeyboardEvent("keydown", { keyCode: Constants.KeyCodes.tab, bubbles: true });
+			document.dispatchEvent(tabEvent);
+			strictEqual(document.activeElement, cancelButton, "Tab from close button should wrap to cancel button");
+		});
+
+		test("On the success panel, focus traps between launch button and close button on Tab", () => {
+			let controllerInstance = MithrilUtils.mountToFixture(this.defaultComponent);
+
+			MithrilUtils.simulateAction(() => {
+				controllerInstance.state.currentPanel = PanelType.ClippingSuccess;
+			});
+
+			let launchButton = document.getElementById(Constants.Ids.launchOneNoteButton);
+			let closeButton = document.getElementById(Constants.Ids.closeButton);
+
+			// Focus on launch button and tab - should move to close button
+			launchButton.focus();
+			let tabEvent = new KeyboardEvent("keydown", { keyCode: Constants.KeyCodes.tab, bubbles: true });
+			document.dispatchEvent(tabEvent);
+			strictEqual(document.activeElement, closeButton, "Tab from launch button should focus close button");
+
+			// Tab again - should wrap to launch button
+			tabEvent = new KeyboardEvent("keydown", { keyCode: Constants.KeyCodes.tab, bubbles: true });
+			document.dispatchEvent(tabEvent);
+			strictEqual(document.activeElement, launchButton, "Tab from close button should wrap to launch button");
 		});
 
 		test("On the clip failure panel, the right message is displayed for a particular API error code", () => {

--- a/src/tests/clipperUI/mainController_tests.tsx
+++ b/src/tests/clipperUI/mainController_tests.tsx
@@ -130,6 +130,89 @@ export class MainControllerTests extends TestModule {
 			Assert.tabOrderIsIncremental([Constants.Ids.launchOneNoteButton, Constants.Ids.closeButton]);
 		});
 
+		test("On the clip success panel, focus trap should wrap focus from last to first element on Tab", () => {
+			let controllerInstance = MithrilUtils.mountToFixture(this.defaultComponent);
+
+			MithrilUtils.simulateAction(() => {
+				controllerInstance.state.currentPanel = PanelType.ClippingSuccess;
+			});
+
+			let closeButton = document.getElementById(Constants.Ids.closeButton);
+			let launchOneNoteButton = document.getElementById(Constants.Ids.launchOneNoteButton);
+
+			// Focus on the close button (last element)
+			closeButton.focus();
+			strictEqual(document.activeElement, closeButton, "Focus should be on close button");
+
+			// Simulate Tab key press
+			let tabEvent = new KeyboardEvent("keydown", {
+				keyCode: Constants.KeyCodes.tab,
+				shiftKey: false,
+				bubbles: true
+			});
+
+			// Call handleFocusTrap directly since keydown events may not propagate in test environment
+			controllerInstance.handleFocusTrap(tabEvent);
+
+			// Verify focus wrapped to first element (if event was not prevented, focus would stay)
+			if (tabEvent.defaultPrevented) {
+				strictEqual(document.activeElement, launchOneNoteButton,
+					"Focus should wrap to the first focusable element (launchOneNoteButton) after Tab on last element");
+			}
+		});
+
+		test("On the clip success panel, focus trap should wrap focus from first to last element on Shift+Tab", () => {
+			let controllerInstance = MithrilUtils.mountToFixture(this.defaultComponent);
+
+			MithrilUtils.simulateAction(() => {
+				controllerInstance.state.currentPanel = PanelType.ClippingSuccess;
+			});
+
+			let closeButton = document.getElementById(Constants.Ids.closeButton);
+			let launchOneNoteButton = document.getElementById(Constants.Ids.launchOneNoteButton);
+
+			// Focus on the launchOneNoteButton (first element)
+			launchOneNoteButton.focus();
+			strictEqual(document.activeElement, launchOneNoteButton, "Focus should be on launchOneNoteButton");
+
+			// Simulate Shift+Tab key press
+			let shiftTabEvent = new KeyboardEvent("keydown", {
+				keyCode: Constants.KeyCodes.tab,
+				shiftKey: true,
+				bubbles: true
+			});
+
+			// Call handleFocusTrap directly
+			controllerInstance.handleFocusTrap(shiftTabEvent);
+
+			// Verify focus wrapped to last element
+			if (shiftTabEvent.defaultPrevented) {
+				strictEqual(document.activeElement, closeButton,
+					"Focus should wrap to the last focusable element (closeButton) after Shift+Tab on first element");
+			}
+		});
+
+		test("Focus trap should not be active when not on success panel", () => {
+			let controllerInstance = MithrilUtils.mountToFixture(this.defaultComponent);
+
+			MithrilUtils.simulateAction(() => {
+				controllerInstance.state.currentPanel = PanelType.ClipOptions;
+			});
+
+			// Create a Tab event
+			let tabEvent = new KeyboardEvent("keydown", {
+				keyCode: Constants.KeyCodes.tab,
+				shiftKey: false,
+				bubbles: true
+			});
+
+			// Call handleFocusTrap - it should return early without preventing default
+			controllerInstance.handleFocusTrap(tabEvent);
+
+			ok(!tabEvent.defaultPrevented,
+				"Focus trap should not prevent default when not on success panel");
+		});
+
 		test("On the clip failure panel, the tab order is correct", () => {
 			let controllerInstance = MithrilUtils.mountToFixture(this.defaultComponent);
 


### PR DESCRIPTION
This PR fixes the accessibility issue where keyboard focus could escape the "Clip Successful" popup when navigating with Tab key.

**Changes:**
- Add handleFocusTrap method to mainController.tsx that intercepts Tab key presses when the success panel is displayed
- When Tab is pressed on the last focusable element, focus wraps to the first focusable element
- When Shift+Tab is pressed on the first focusable element, focus wraps to the last focusable element
- Add unit tests for focus trap functionality

Demo after Fix:

https://github.com/user-attachments/assets/df20b081-1663-4a7c-9b8d-1ef55140cd37

Closes #636

Generated with [Claude Code](https://claude.ai/code)