### PR TITLE
A11y Bug 8780675: Voice Access is showing numbers for the non interactive controls.

### DIFF
--- a/src/scripts/clipperUI/components/sectionPicker.tsx
+++ b/src/scripts/clipperUI/components/sectionPicker.tsx
@@ -296,10 +296,10 @@ export class SectionPickerClass extends ComponentBase<SectionPickerState, Sectio
 
 		return (
 			<div id={Constants.Ids.locationPickerContainer} {...this.onElementFirstDraw(this.addSrOnlyLocationDiv)}>
-				<div id={Constants.Ids.optionLabel} className="optionLabel">
-					<label htmlFor={Constants.Ids.sectionLocationContainer} aria-label={locationString} className="buttonLabelFont" style={Localization.getFontFamilyAsStyle(Localization.FontFamily.Regular)}>
-						<span aria-hidden="true">{locationString}</span>
-					</label>
+				<div id={Constants.Ids.optionLabel} className="optionLabel" aria-hidden="true">
+					<span className="buttonLabelFont" style={Localization.getFontFamilyAsStyle(Localization.FontFamily.Regular)}>
+						{locationString}
+					</span>
 				</div>
 				<OneNotePicker.OneNotePickerComponent
 					id={Constants.Ids.sectionLocationContainer}


### PR DESCRIPTION
This pull request makes a minor accessibility and markup adjustment to the `SectionPickerClass` component. The change simplifies the label structure and ensures that the option label is correctly hidden from screen readers by moving the `aria-hidden="true"` attribute to the container `div` and removing the unnecessary `label` element.

- Accessibility and markup update:
  * In `src/scripts/clipperUI/components/sectionPicker.tsx`, the option label markup is simplified by removing the `label` element, moving `aria-hidden="true"` to the container `div`, and keeping only the styled `span` for the visible text.Fixes #634

## Summary
- Added `aria-hidden="true"` to hide the Location label from Voice Access
- Changed `<label>` to `<span>` since screen reader accessibility is provided by `addSrOnlyLocationDiv`

## Test Plan
- [ ] Open OneNote Web Clipper dialog
- [ ] Enable Voice Access
- [ ] Say "Click Location" and verify no number appears on the Location text
- [ ] Verify the Location picker still functions correctly
- [ ] Test with screen reader to ensure accessibility is maintained

**Demo after fix**
https://github.com/user-attachments/assets/1cb5adf3-cf8c-4e9e-bb20-ee7d0e340cad




Generated with [Claude Code](https://claude.ai/claude-code)