### PR TITLE
A11y Bug 6210968: Keyboard focus gets lost after closing the 'location dropdown' control via esc key.

### DIFF
--- a/src/scripts/clipperUI/components/sectionPicker.tsx
+++ b/src/scripts/clipperUI/components/sectionPicker.tsx
@@ -54,6 +54,13 @@ export class SectionPickerClass extends ComponentBase<SectionPickerState, Sectio
 			// If the user selects a section, onPopupToggle will fire because it closes the popup, even though it wasn't a click
 			// so logging only when they open it is potentially the next best thing
 			Clipper.logger.logClickEvent(Log.Click.Label.sectionPickerLocationContainer);
+		} else {
+			// Restore focus to the dropdown trigger when popup closes (e.g., via Escape key)
+			// This ensures keyboard users don't lose focus after closing the dropdown
+			const locationContainer = document.getElementById(Constants.Ids.sectionLocationContainer);
+			if (locationContainer) {
+				locationContainer.focus();
+			}
 		}
 		this.props.onPopupToggle(shouldNowBeOpen);
 	}

--- a/src/scripts/clipperUI/components/sectionPicker.tsx
+++ b/src/scripts/clipperUI/components/sectionPicker.tsx
@@ -57,10 +57,13 @@ export class SectionPickerClass extends ComponentBase<SectionPickerState, Sectio
 		} else {
 			// Restore focus to the dropdown trigger when popup closes (e.g., via Escape key)
 			// This ensures keyboard users don't lose focus after closing the dropdown
-			const locationContainer = document.getElementById(Constants.Ids.sectionLocationContainer);
-			if (locationContainer) {
-				locationContainer.focus();
-			}
+			// Use setTimeout to defer focus until after the picker's internal DOM updates complete
+			setTimeout(() => {
+				const locationContainer = document.getElementById(Constants.Ids.sectionLocationContainer);
+				if (locationContainer) {
+					locationContainer.focus();
+				}
+			}, 0);
 		}
 		this.props.onPopupToggle(shouldNowBeOpen);
 	}

--- a/src/scripts/clipperUI/components/sectionPicker.tsx
+++ b/src/scripts/clipperUI/components/sectionPicker.tsx
@@ -54,16 +54,6 @@ export class SectionPickerClass extends ComponentBase<SectionPickerState, Sectio
 			// If the user selects a section, onPopupToggle will fire because it closes the popup, even though it wasn't a click
 			// so logging only when they open it is potentially the next best thing
 			Clipper.logger.logClickEvent(Log.Click.Label.sectionPickerLocationContainer);
-		} else {
-			// Restore focus to the dropdown trigger when popup closes (e.g., via Escape key)
-			// This ensures keyboard users don't lose focus after closing the dropdown
-			// Use setTimeout to defer focus until after the picker's internal DOM updates complete
-			setTimeout(() => {
-				const locationContainer = document.getElementById(Constants.Ids.sectionLocationContainer);
-				if (locationContainer) {
-					locationContainer.focus();
-				}
-			}, 0);
 		}
 		this.props.onPopupToggle(shouldNowBeOpen);
 	}
@@ -245,6 +235,32 @@ export class SectionPickerClass extends ComponentBase<SectionPickerState, Sectio
 		};
 	}
 
+	
+	// Attach escape key handler to return focus to the dropdown button when Escape is pressed
+	// This is needed because the OneNotePicker component handles Escape internally without calling onPopupToggle
+	attachEscapeFocusHandler(element: HTMLElement, isInitialized: boolean) {
+		if (!isInitialized) {
+			const escKeyCode = 27;
+			const handleKeyDown = (ev: KeyboardEvent) => {
+				if (ev.keyCode === escKeyCode) {
+					// Check if the dropdown popup is currently visible
+					let sectionPickerPopup = document.querySelector(".SectionPickerPopup");
+					if (sectionPickerPopup) {
+						// The popup is open - schedule focus return after it closes
+						setTimeout(() => {
+							let locationButton = document.getElementById(Constants.Ids.sectionLocationContainer);
+							if (locationButton) {
+								locationButton.focus();
+							}
+						}, 10);
+					}
+				}
+			};
+			// Use capture phase to run before OneNotePicker's handler
+			document.addEventListener("keydown", handleKeyDown, true);
+		}
+	}
+
 	addSrOnlyLocationDiv(element: HTMLElement) {
 		const pickerLinkElement = document.getElementById(Constants.Ids.sectionLocationContainer);
 		if (!pickerLinkElement) {
@@ -256,6 +272,9 @@ export class SectionPickerClass extends ComponentBase<SectionPickerState, Sectio
 		srDiv.setAttribute("class", Constants.Classes.srOnly);
 		// Make srDiv the first child of pickerLinkElement
 		pickerLinkElement.insertBefore(srDiv, pickerLinkElement.firstChild);
+
+		// Attach escape key handler to return focus to the dropdown button
+		this.attachEscapeFocusHandler(element, false);
 	}
 
 	render() {

--- a/src/tests/clipperUI/components/sectionPicker_tests.tsx
+++ b/src/tests/clipperUI/components/sectionPicker_tests.tsx
@@ -272,6 +272,39 @@ export class SectionPickerTests extends TestModule {
 			let actual = SectionPickerClass.formatSectionInfoForStorage([]);
 			strictEqual(actual, undefined, "The section info should be formatted correctly");
 		});
+
+		test("onPopupToggle should restore focus to sectionLocationContainer when popup closes", () => {
+			let clipperState = MockProps.getMockClipperState();
+			let mockNotebooks = MockProps.getMockNotebooks();
+			initializeClipperStorage(JSON.stringify(mockNotebooks), undefined);
+
+			let popupToggleCalled = false;
+			let component = <SectionPicker
+				onPopupToggle={() => { popupToggleCalled = true; }}
+				clipperState={clipperState} />;
+			let controllerInstance = MithrilUtils.mountToFixture(component);
+
+			// Open the popup first
+			MithrilUtils.simulateAction(() => {
+				document.getElementById(TestConstants.Ids.sectionLocationContainer).click();
+			});
+
+			// Focus another element to simulate focus being elsewhere
+			let anotherElement = document.createElement("button");
+			document.body.appendChild(anotherElement);
+			anotherElement.focus();
+
+			// Close the popup by calling onPopupToggle with false
+			controllerInstance.onPopupToggle(false);
+
+			// Verify focus was restored to the location container
+			strictEqual(document.activeElement.id, TestConstants.Ids.sectionLocationContainer,
+				"Focus should be restored to sectionLocationContainer when popup closes");
+			ok(popupToggleCalled, "The parent onPopupToggle callback should have been called");
+
+			// Clean up
+			document.body.removeChild(anotherElement);
+		});
 	}
 }
 

--- a/src/tests/clipperUI/components/sectionPicker_tests.tsx
+++ b/src/tests/clipperUI/components/sectionPicker_tests.tsx
@@ -273,7 +273,8 @@ export class SectionPickerTests extends TestModule {
 			strictEqual(actual, undefined, "The section info should be formatted correctly");
 		});
 
-		test("onPopupToggle should restore focus to sectionLocationContainer when popup closes", () => {
+		test("onPopupToggle should restore focus to sectionLocationContainer when popup closes", (assert: QUnitAssert) => {
+			let done = assert.async();
 			let clipperState = MockProps.getMockClipperState();
 			let mockNotebooks = MockProps.getMockNotebooks();
 			initializeClipperStorage(JSON.stringify(mockNotebooks), undefined);
@@ -297,13 +298,17 @@ export class SectionPickerTests extends TestModule {
 			// Close the popup by calling onPopupToggle with false
 			controllerInstance.onPopupToggle(false);
 
-			// Verify focus was restored to the location container
-			strictEqual(document.activeElement.id, TestConstants.Ids.sectionLocationContainer,
-				"Focus should be restored to sectionLocationContainer when popup closes");
-			ok(popupToggleCalled, "The parent onPopupToggle callback should have been called");
+			// Wait for the deferred focus (setTimeout) to execute
+			setTimeout(() => {
+				// Verify focus was restored to the location container
+				strictEqual(document.activeElement.id, TestConstants.Ids.sectionLocationContainer,
+					"Focus should be restored to sectionLocationContainer when popup closes");
+				ok(popupToggleCalled, "The parent onPopupToggle callback should have been called");
 
-			// Clean up
-			document.body.removeChild(anotherElement);
+				// Clean up
+				document.body.removeChild(anotherElement);
+				done();
+			}, 10);
 		});
 	}
 }


### PR DESCRIPTION
When the location dropdown was closed via the Escape key, keyboard focus was lost, making it difficult for keyboard-only users to continue navigating. This fix ensures focus returns to the dropdown trigger element when the popup closes, improving accessibility for keyboard users.

**Demo**
https://github.com/user-attachments/assets/ac836069-451d-4d8d-a1c5-cd2de19b05b9






Fixes #641