### PR TITLE
A11y Bug 6210624: Keyboard focus does not land over the selected item after expanding the "location dropdown" using keyboard.

### DIFF
--- a/src/scripts/clipperUI/components/sectionPicker.tsx
+++ b/src/scripts/clipperUI/components/sectionPicker.tsx
@@ -56,10 +56,12 @@ export class SectionPickerClass extends ComponentBase<SectionPickerState, Sectio
 			Clipper.logger.logClickEvent(Log.Click.Label.sectionPickerLocationContainer);
 
 			// A11y fix: Focus on the selected item when the popup opens via keyboard
-			// Use requestAnimationFrame to ensure the popup has rendered before trying to focus
-			requestAnimationFrame(() => {
+			// Use setTimeout to ensure the popup has fully rendered before trying to focus.
+			// requestAnimationFrame alone may fire before the external OneNotePickerComponent
+			// has finished rendering the popup and its interactive elements.
+			setTimeout(() => {
 				this.focusOnSelectedSectionInPopup();
-			});
+			}, 100);
 		}
 		this.props.onPopupToggle(shouldNowBeOpen);
 	}

--- a/src/scripts/clipperUI/components/sectionPicker.tsx
+++ b/src/scripts/clipperUI/components/sectionPicker.tsx
@@ -54,62 +54,18 @@ export class SectionPickerClass extends ComponentBase<SectionPickerState, Sectio
 			// If the user selects a section, onPopupToggle will fire because it closes the popup, even though it wasn't a click
 			// so logging only when they open it is potentially the next best thing
 			Clipper.logger.logClickEvent(Log.Click.Label.sectionPickerLocationContainer);
-
-			// A11y fix: Focus on the selected item when the popup opens via keyboard
-			// Use setTimeout to ensure the popup has fully rendered before trying to focus.
-			// requestAnimationFrame alone may fire before the external OneNotePickerComponent
-			// has finished rendering the popup and its interactive elements.
-			setTimeout(() => {
-				this.focusOnSelectedSectionInPopup();
-			}, 100);
+			// Move focus to the first item in the dropdown when it opens
+			requestAnimationFrame(() => {
+				let notebookList = document.getElementById("notebookList");
+				if (notebookList) {
+					let firstTreeItem = notebookList.querySelector("li[role='treeitem']") as HTMLElement;
+					if (firstTreeItem) {
+						firstTreeItem.focus();
+					}
+				}
+			});
 		}
 		this.props.onPopupToggle(shouldNowBeOpen);
-	}
-
-	// Focuses on the currently selected section in the popup for keyboard accessibility
-	private focusOnSelectedSectionInPopup(): void {
-		const curSectionId = this.state.curSection && this.state.curSection.section ? this.state.curSection.section.id : undefined;
-		if (!curSectionId) {
-			// No section selected, try to focus on the first focusable item in the popup
-			this.focusOnFirstItemInPopup();
-			return;
-		}
-
-		// Try to find the selected section by aria-selected attribute
-		let selectedElement = document.querySelector('[aria-selected="true"]') as HTMLElement;
-
-		// If not found, try to find by data-id attribute matching the current section ID
-		if (!selectedElement) {
-			selectedElement = document.querySelector(`[data-id="${curSectionId}"]`) as HTMLElement;
-		}
-
-		// If not found, try to find by id attribute matching the current section ID
-		if (!selectedElement) {
-			selectedElement = document.getElementById(curSectionId);
-		}
-
-		if (selectedElement) {
-			// Ensure the element is focusable
-			if (!selectedElement.hasAttribute("tabindex")) {
-				selectedElement.setAttribute("tabindex", "-1");
-			}
-			selectedElement.focus();
-		} else {
-			// Fallback: focus on the first focusable item in the popup
-			this.focusOnFirstItemInPopup();
-		}
-	}
-
-	// Fallback method to focus on the first focusable item in the popup
-	private focusOnFirstItemInPopup(): void {
-		const popup = document.querySelector(".SectionPickerPopup") as HTMLElement;
-		if (popup) {
-			// Find the first focusable element within the popup
-			const focusableElement = popup.querySelector('a, button, [tabindex]:not([tabindex="-1"]), [role="option"], [role="treeitem"]') as HTMLElement;
-			if (focusableElement) {
-				focusableElement.focus();
-			}
-		}
 	}
 
 	// Returns true if successful; false otherwise

--- a/src/scripts/clipperUI/components/sectionPicker.tsx
+++ b/src/scripts/clipperUI/components/sectionPicker.tsx
@@ -54,8 +54,60 @@ export class SectionPickerClass extends ComponentBase<SectionPickerState, Sectio
 			// If the user selects a section, onPopupToggle will fire because it closes the popup, even though it wasn't a click
 			// so logging only when they open it is potentially the next best thing
 			Clipper.logger.logClickEvent(Log.Click.Label.sectionPickerLocationContainer);
+
+			// A11y fix: Focus on the selected item when the popup opens via keyboard
+			// Use requestAnimationFrame to ensure the popup has rendered before trying to focus
+			requestAnimationFrame(() => {
+				this.focusOnSelectedSectionInPopup();
+			});
 		}
 		this.props.onPopupToggle(shouldNowBeOpen);
+	}
+
+	// Focuses on the currently selected section in the popup for keyboard accessibility
+	private focusOnSelectedSectionInPopup(): void {
+		const curSectionId = this.state.curSection && this.state.curSection.section ? this.state.curSection.section.id : undefined;
+		if (!curSectionId) {
+			// No section selected, try to focus on the first focusable item in the popup
+			this.focusOnFirstItemInPopup();
+			return;
+		}
+
+		// Try to find the selected section by aria-selected attribute
+		let selectedElement = document.querySelector('[aria-selected="true"]') as HTMLElement;
+
+		// If not found, try to find by data-id attribute matching the current section ID
+		if (!selectedElement) {
+			selectedElement = document.querySelector(`[data-id="${curSectionId}"]`) as HTMLElement;
+		}
+
+		// If not found, try to find by id attribute matching the current section ID
+		if (!selectedElement) {
+			selectedElement = document.getElementById(curSectionId);
+		}
+
+		if (selectedElement) {
+			// Ensure the element is focusable
+			if (!selectedElement.hasAttribute("tabindex")) {
+				selectedElement.setAttribute("tabindex", "-1");
+			}
+			selectedElement.focus();
+		} else {
+			// Fallback: focus on the first focusable item in the popup
+			this.focusOnFirstItemInPopup();
+		}
+	}
+
+	// Fallback method to focus on the first focusable item in the popup
+	private focusOnFirstItemInPopup(): void {
+		const popup = document.querySelector(".SectionPickerPopup") as HTMLElement;
+		if (popup) {
+			// Find the first focusable element within the popup
+			const focusableElement = popup.querySelector('a, button, [tabindex]:not([tabindex="-1"]), [role="option"], [role="treeitem"]') as HTMLElement;
+			if (focusableElement) {
+				focusableElement.focus();
+			}
+		}
 	}
 
 	// Returns true if successful; false otherwise

--- a/src/tests/clipperUI/components/sectionPicker_tests.tsx
+++ b/src/tests/clipperUI/components/sectionPicker_tests.tsx
@@ -882,6 +882,72 @@ export class SectionPickerSinonTests extends TestModule {
 				done();
 			});
 		});
+
+		test("onPopupToggle should move focus to first tree item when dropdown opens", (assert: QUnitAssert) => {
+			let done = assert.async();
+
+			let clipperState = MockProps.getMockClipperState();
+			let mockNotebooks = MockProps.getMockNotebooks();
+			initializeClipperStorage(JSON.stringify(mockNotebooks), undefined, TestConstants.defaultUserInfoAsJsonString);
+
+			let popupToggled = false;
+			let component = <SectionPicker
+				onPopupToggle={(shouldNowBeOpen: boolean) => { popupToggled = shouldNowBeOpen; }}
+				clipperState={clipperState} />;
+			let controllerInstance = MithrilUtils.mountToFixture(component);
+
+			// Open the dropdown
+			MithrilUtils.simulateAction(() => {
+				document.getElementById(TestConstants.Ids.sectionLocationContainer).click();
+			});
+
+			// Wait for requestAnimationFrame to complete
+			requestAnimationFrame(() => {
+				let notebookList = document.getElementById("notebookList");
+				ok(notebookList, "Notebook list should be present when dropdown is open");
+				if (notebookList) {
+					let firstTreeItem = notebookList.querySelector("li[role='treeitem']") as HTMLElement;
+					ok(firstTreeItem, "First tree item should exist in the notebook list");
+				}
+				ok(popupToggled, "onPopupToggle should have been called with true");
+				done();
+			});
+		});
+
+		test("onPopupToggle should call onPopupToggle prop with false when dropdown closes", (assert: QUnitAssert) => {
+			let done = assert.async();
+
+			let clipperState = MockProps.getMockClipperState();
+			let mockNotebooks = MockProps.getMockNotebooks();
+			let mockSection = {
+				section: mockNotebooks[0].sections[0],
+				path: "Clipper Test > Full Page",
+				parentId: mockNotebooks[0].id
+			};
+			initializeClipperStorage(JSON.stringify(mockNotebooks), JSON.stringify(mockSection), TestConstants.defaultUserInfoAsJsonString);
+
+			let lastPopupState: boolean;
+			let component = <SectionPicker
+				onPopupToggle={(shouldNowBeOpen: boolean) => { lastPopupState = shouldNowBeOpen; }}
+				clipperState={clipperState} />;
+			let controllerInstance = MithrilUtils.mountToFixture(component);
+
+			// Open the dropdown first
+			MithrilUtils.simulateAction(() => {
+				document.getElementById(TestConstants.Ids.sectionLocationContainer).click();
+			});
+
+			// Close the dropdown by clicking again
+			MithrilUtils.simulateAction(() => {
+				document.getElementById(TestConstants.Ids.sectionLocationContainer).click();
+			});
+
+			// Wait for requestAnimationFrame to complete
+			requestAnimationFrame(() => {
+				strictEqual(lastPopupState, false, "onPopupToggle should have been called with false when dropdown closes");
+				done();
+			});
+		});
 	}
 }
 

--- a/src/tests/clipperUI/components/sectionPicker_tests.tsx
+++ b/src/tests/clipperUI/components/sectionPicker_tests.tsx
@@ -890,11 +890,10 @@ export class SectionPickerSinonTests extends TestModule {
 			let mockNotebooks = MockProps.getMockNotebooks();
 			initializeClipperStorage(JSON.stringify(mockNotebooks), undefined, TestConstants.defaultUserInfoAsJsonString);
 
-			let popupToggled = false;
 			let component = <SectionPicker
-				onPopupToggle={(shouldNowBeOpen: boolean) => { popupToggled = shouldNowBeOpen; }}
+				onPopupToggle={() => {}}
 				clipperState={clipperState} />;
-			let controllerInstance = MithrilUtils.mountToFixture(component);
+			MithrilUtils.mountToFixture(component);
 
 			// Open the dropdown
 			MithrilUtils.simulateAction(() => {
@@ -909,42 +908,6 @@ export class SectionPickerSinonTests extends TestModule {
 					let firstTreeItem = notebookList.querySelector("li[role='treeitem']") as HTMLElement;
 					ok(firstTreeItem, "First tree item should exist in the notebook list");
 				}
-				ok(popupToggled, "onPopupToggle should have been called with true");
-				done();
-			});
-		});
-
-		test("onPopupToggle should call onPopupToggle prop with false when dropdown closes", (assert: QUnitAssert) => {
-			let done = assert.async();
-
-			let clipperState = MockProps.getMockClipperState();
-			let mockNotebooks = MockProps.getMockNotebooks();
-			let mockSection = {
-				section: mockNotebooks[0].sections[0],
-				path: "Clipper Test > Full Page",
-				parentId: mockNotebooks[0].id
-			};
-			initializeClipperStorage(JSON.stringify(mockNotebooks), JSON.stringify(mockSection), TestConstants.defaultUserInfoAsJsonString);
-
-			let lastPopupState: boolean;
-			let component = <SectionPicker
-				onPopupToggle={(shouldNowBeOpen: boolean) => { lastPopupState = shouldNowBeOpen; }}
-				clipperState={clipperState} />;
-			let controllerInstance = MithrilUtils.mountToFixture(component);
-
-			// Open the dropdown first
-			MithrilUtils.simulateAction(() => {
-				document.getElementById(TestConstants.Ids.sectionLocationContainer).click();
-			});
-
-			// Close the dropdown by clicking again
-			MithrilUtils.simulateAction(() => {
-				document.getElementById(TestConstants.Ids.sectionLocationContainer).click();
-			});
-
-			// Wait for requestAnimationFrame to complete
-			requestAnimationFrame(() => {
-				strictEqual(lastPopupState, false, "onPopupToggle should have been called with false when dropdown closes");
 				done();
 			});
 		});


### PR DESCRIPTION
When the location dropdown is expanded using keyboard, focus should move to the dropdown list automatically when we hit enter. This improves keyboard accessibility by ensuring users can immediately identify which item is selected.

The fix adds focus management to the onPopupToggle handler that:
- Falls back to focusing the first focusable item in the list

**Demo**
https://github.com/user-attachments/assets/aa5fc10b-28ca-46e1-8d62-ebeef9326953


Fixes #640