### PR TITLE
Test PR- Fix keyboard focus in location dropdown for accessibility

### DIFF
--- a/src/scripts/clipperUI/components/sectionPicker.tsx
+++ b/src/scripts/clipperUI/components/sectionPicker.tsx
@@ -54,8 +54,39 @@ export class SectionPickerClass extends ComponentBase<SectionPickerState, Sectio
 			// If the user selects a section, onPopupToggle will fire because it closes the popup, even though it wasn't a click
 			// so logging only when they open it is potentially the next best thing
 			Clipper.logger.logClickEvent(Log.Click.Label.sectionPickerLocationContainer);
+
+			// Set focus on the selected item in the dropdown for keyboard accessibility
+			// Use setTimeout to ensure the popup has rendered before trying to focus
+			setTimeout(() => {
+				this.focusOnSelectedSection();
+			}, 0);
 		}
 		this.props.onPopupToggle(shouldNowBeOpen);
+	}
+
+	focusOnSelectedSection() {
+		// Try to focus on the currently selected section item
+		let selectedElement: HTMLElement = null;
+
+		// First, try to find by section ID if we have a current section
+		if (this.state.curSection && this.state.curSection.section) {
+			selectedElement = document.getElementById(this.state.curSection.section.id) as HTMLElement;
+		}
+
+		// If not found by ID, try to find by aria-selected attribute
+		if (!selectedElement) {
+			selectedElement = document.querySelector('[aria-selected="true"]') as HTMLElement;
+		}
+
+		// If still not found, focus on the first section in the list as a fallback
+		if (!selectedElement) {
+			selectedElement = document.querySelector('.Section') as HTMLElement;
+		}
+
+		// Set focus if we found an element
+		if (selectedElement && typeof selectedElement.focus === 'function') {
+			selectedElement.focus();
+		}
 	}
 
 	// Returns true if successful; false otherwise


### PR DESCRIPTION
Fixes #622

### Summary
When the location dropdown is expanded via keyboard (Tab + Enter), focus now automatically moves to the currently selected section item within the dropdown, improving keyboard navigation and meeting accessibility standards.

### Changes
- Added `focusOnSelectedSection()` method to set focus on the selected section when the dropdown opens
- Method tries to find the selected element by:
   1. Section ID (curSectionId)
   2. aria-selected="true" attribute
   3. First .Section element as fallback
- Integrated into onPopupToggle callback with setTimeout to ensure the popup has rendered before setting focus

### Testing
Manual testing recommended:
1. Install the OneNote Clipper extension with these changes
2. Sign in with a Microsoft work account
3. Navigate to the location dropdown using Tab key
4. Press Enter to expand the dropdown
5. Verify that focus lands on the selected section item

Complies with Microsoft Liquid accessibility guidelines for Focus Order (02.04.03).

Generated with [Claude Code](https://claude.ai/code)