### PR TITLE
fix: Update extension button title for better screen reader accessibi…

### DIFF
--- a/src/scripts/extensions/chrome/manifest.json
+++ b/src/scripts/extensions/chrome/manifest.json
@@ -61,7 +61,7 @@
       "256": "icons/icon-256.png"
     },
     "action": {
-      "default_title": "Clip to OneNote",
+      "default_title": "OneNote Web Clipper",
       "default_icon": {
         "19": "icons/icon-19.png",
         "38": "icons/icon-38.png"

--- a/src/scripts/extensions/edge/manifest.json
+++ b/src/scripts/extensions/edge/manifest.json
@@ -60,7 +60,7 @@
     },
 
     "action": {
-        "default_title": "Clip to OneNote",
+        "default_title": "OneNote Web Clipper",
         "default_icon": {
             "19": "icons/icon-19.png",
             "38": "icons/icon-38.png"

--- a/src/scripts/extensions/firefox/manifest.json
+++ b/src/scripts/extensions/firefox/manifest.json
@@ -40,7 +40,7 @@
     "content_security_policy": "script-src 'self'; object-src 'self'",
 
     "browser_action": {
-        "default_title": "Clip to OneNote",
+        "default_title": "OneNote Web Clipper",
         "default_icon": {
             "19": "icons/icon-19.png",
             "38": "icons/icon-38.png"


### PR DESCRIPTION
…lity

Changed default_title from "Clip to OneNote" to "OneNote Web Clipper" in Chrome, Edge, and Firefox manifest files. This improves accessibility by providing a clearer name for screen reader users.

Closes #646