### PR TITLE
Updated version from 3.10.12 to 3.10.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## 3.10.13 (April 2026)
-* 
+* Improvement : Added a11y improvements.
 
 ## 3.10.12 (January 2026)
 * Improvement : Added a11y improvements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 3.10.13 (April 2026)
+* 
+
 ## 3.10.12 (January 2026)
 * Improvement : Added a11y improvements.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "webclipper",
-    "version": "3.10.12",
+    "version": "3.10.13",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "webclipper",
-            "version": "3.10.12",
+            "version": "3.10.13",
             "license": "MIT",
             "dependencies": {
                 "jwt-decode": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.10.12",
+    "version": "3.10.13",
     "name": "webclipper",
     "private": true,
     "description": "The core of the OneNote Web Clipper found at https://www.onenote.com/clipper",

--- a/src/scripts/extensions/chrome/manifest.json
+++ b/src/scripts/extensions/chrome/manifest.json
@@ -3,7 +3,7 @@
     "name": "OneNote Web Clipper",
     "description": "__MSG_appDesc__",
     "default_locale": "en",
-    "version": "3.10.12",
+    "version": "3.10.13",
     "background": {
       "service_worker": "chromeExtension.js",
       "type": "module"

--- a/src/scripts/extensions/edge/manifest.json
+++ b/src/scripts/extensions/edge/manifest.json
@@ -4,7 +4,7 @@
     "name": "OneNote Web Clipper",
     "description": "__MSG_appDesc__",
     "default_locale": "en",
-    "version": "3.10.12",
+    "version": "3.10.13",
     "background": {
         "service_worker": "edgeExtension.js",
         "type": "module"

--- a/src/scripts/extensions/edge/package/AppXManifest.xml
+++ b/src/scripts/extensions/edge/package/AppXManifest.xml
@@ -7,7 +7,7 @@
 	<Identity 
 		Name="Microsoft.OneNoteWebClipper" 
 		Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" 
-		Version="3.10.12.0" />
+		Version="3.10.13.0" />
 
 	<Properties> 
 		<DisplayName>OneNote Web Clipper</DisplayName> 

--- a/src/scripts/extensions/extensionBase.ts
+++ b/src/scripts/extensions/extensionBase.ts
@@ -41,7 +41,7 @@ export abstract class ExtensionBase<TWorker extends ExtensionWorkerBase<TTab, TT
 	protected auth: AuthenticationHelper;
 	protected tooltip: TooltipHelper;
 	protected clientInfo: SmartValue<ClientInfo>;
-	protected static version = "3.10.12";
+	protected static version = "3.10.13";
 
 	constructor(clipperType: ClientType, clipperData: ClipperData) {
 		this.setUnhandledExceptionLogging();


### PR DESCRIPTION
Updated version from 3.10.12 to 3.10.13

This version of OneNote Web Clipper fixes the following A11y bugs-
[Bug 5122289 ](https://dev.azure.com/office/OneNote/_workitems/edit/5122289/?view=edit)
[Bug 6210624](https://dev.azure.com/office/OneNote/_workitems/edit/6210624/?view=edit)
[Bug 6210968](https://dev.azure.com/office/OneNote/_workitems/edit/6210968/?view=edit)
[Bug 6223357](https://dev.azure.com/office/OneNote/_workitems/edit/6223357/?view=edit)
[Bug 8780675](https://dev.azure.com/office/OneNote/_workitems/edit/8780675/?view=edit)
[Bug 8780715](https://dev.azure.com/office/OneNote/_workitems/edit/8780715/?view=edit)
[Bug 9948579](https://dev.azure.com/office/OneNote/_workitems/edit/9948579/?view=edit)
[Bug 10987393](https://dev.azure.com/office/OneNote/_workitems/edit/10987393/?view=edit)
[Bug 8781417](https://dev.azure.com/office/OneNote/_workitems/edit/8781417)