### PR TITLE
Fix broken failure telemetry: restore Clipper.logger assignment

### DIFF
--- a/src/scripts/extensions/extensionBase.ts
+++ b/src/scripts/extensions/extensionBase.ts
@@ -4,6 +4,7 @@ import {Constants} from "../constants";
 import {StringUtils} from "../stringUtils";
 import {UrlUtils} from "../urlUtils";
 
+import {Clipper} from "../clipperUI/frontEndGlobals";
 import {TooltipType} from "../clipperUI/tooltipType";
 
 import {SmartValue} from "../communicator/smartValue";
@@ -48,6 +49,9 @@ export abstract class ExtensionBase<TWorker extends ExtensionWorkerBase<TTab, TT
 
 		this.workers = [];
 		this.logger = new WorkerPassthroughLogger(this.workers);
+		// Module-level callers (Log.ErrorUtils.sendFailureLogRequest, userDataBoundaryHelper)
+		// reach for this static slot since they have no `this` to hold a logger on.
+		Clipper.logger = this.logger;
 		ExtensionBase.extensionId = StringUtils.generateGuid();
 
 		this.clipperData = clipperData;


### PR DESCRIPTION
## Summary

Wires up `Clipper.logger` in `ExtensionBase` — a static slot that two V2 module-level loggers depend on, but that V2 never set up. This is **not** a "normal telemetry is broken" PR: per-worker Aria logging for all user-initiated flows has been working fine. Only specific failure-scenario events were being silently dropped.

## What WAS working (unaffected by this bug)

Per-worker Aria logging via `LogManager.createExtLogger()` → `AriaLoggerDecorator`. All the normal observability:

- `InvokeClipper`, `ClipToOneNoteAction`, `HandleSignInEvent`, `GetNotebooks`
- All context properties (AppInfoId, BrowserLanguage, ClipperType, AuthType, UserInfoId, etc.)
- Session start/end, click events, funnel events, trace events

These flow `worker → Aria` directly; they never touch `Clipper.logger`.

## What was NOT working

Module-level functions that need a logger reference but have no `this` context (no instance to hold a logger on) reach for the static slot `Clipper.logger`. Affected call sites:

- `Log.ErrorUtils.sendFailureLogRequest` — invoked from:
  - `extensionBase.ts:316` → `GetChangeLog` (changelog fetch failure after version update)
  - `extensionBase.ts:380` → `UnhandledExceptionThrown` (SW `self.onerror` — the safety net for any uncaught crash)
  - `webExtensionWorker.ts:151` → `UnclippablePage` (scripting.executeScript probe failure)
- `userDataBoundaryHelper.ts:69` → `JsonParse` (sign-in EUDB endpoint returned malformed JSON)

Each of these called `Clipper.logger.logFailure(...)` on `undefined`, throwing `TypeError: Cannot read properties of undefined (reading 'logFailure')` *inside the error handler itself*. The browser silently swallows exceptions thrown by `self.onerror` (no recursive re-fire), so the failure was invisible — neither the original error nor the telemetry-mechanism error reached observability.

Most impactful loss: `UnhandledExceptionThrown` is the SW safety net for any unanticipated crash. Production telemetry has been blind to novel SW exceptions throughout V2.

## Root cause

V1's `src/scripts/clipperUI/clipper.tsx` contained:
```ts
Clipper.logger = new CommunicatorLoggerPure(Clipper.getExtensionCommunicator());
```
That setter fired when the V1 Mithril sidebar bootstrapped via injection. V2 replaced the whole architecture — worker opens renderer window directly, no sidebar injection — and `clipper.tsx` stopped executing in the V2 flow. The V1 setter was never re-established in V2 and never fired again. The bug has been latent throughout V2 development. Commit 8f0dad5 later deleted the dead V1 source file, but the runtime behavior was already broken before that cleanup.

Why it stayed invisible until now:
1. Affected paths fire only in **error conditions** — rare in normal usage and manual dev testing
2. The `TypeError` thrown inside `self.onerror` is silently swallowed by the browser
3. Telemetry-loss is silent by definition — nothing observable breaks user-facing flows

## Fix

One line in `ExtensionBase` constructor, immediately after `WorkerPassthroughLogger` is created:

```ts
Clipper.logger = this.logger;
```

Routes module-level failure logs through the same per-worker `AriaLoggerDecorator` chain that normal telemetry uses.

## Test plan

- [x] Build clean: `npm run build:prod` → zero errors, tslint passes
- [x] Verified bundle now has the assignment (`grep "Clipper.logger\s*="` finds 1 match in the shipped JS)
- [x] SW DevTools repro: invoke clipper once to create a worker, then run `setTimeout(() => { throw new Error("repro"); }, 0);` in SW console → `WebClipper.Failure.UnhandledExceptionThrown` POST to `browser.pipe.aria.microsoft.com/Collector/3.0/` confirmed with full Aria event payload (FailureType=Unexpected, Id=ExtensionBase, full stack)

## Out of scope

The SW-boot window (errors fired before any per-tab worker exists → `WorkerPassthroughLogger` has zero fan-out targets) is a pre-existing architectural gap shared with V1 — V1's `Clipper.logger` was set inside the sidebar at injection time, so SW errors before sidebar load were also lost in V1. Filed as follow-up; full coverage would require an SW-level `AriaLoggerDecorator` independent of workers.