### PR TITLE
[Version Bump] Bump version to 3.11.2 from 3.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 3.11.2 (July 2026)
+* Improvement : Added system-adaptive dark mode; a11y improvements; enabled Sign out during page capture; and legacy code cleanup.
+
 ## 3.11.1 (May 2026)
 * Improvement : Restored V1 parity for video pages (YouTube, Vimeo) via oEmbed, right-click "Clip Selection" and "Clip Image", article-mode highlighter, and PDF-attach visual indicator.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "webclipper",
-    "version": "3.11.1",
+    "version": "3.11.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "webclipper",
-            "version": "3.11.1",
+            "version": "3.11.2",
             "license": "MIT",
             "dependencies": {
                 "jwt-decode": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.11.1",
+    "version": "3.11.2",
     "name": "webclipper",
     "private": true,
     "description": "The core of the OneNote Web Clipper found at https://www.onenote.com/clipper",

--- a/src/scripts/extensions/chrome/manifest.json
+++ b/src/scripts/extensions/chrome/manifest.json
@@ -4,7 +4,7 @@
     "name": "OneNote Web Clipper",
     "description": "__MSG_appDesc__",
     "default_locale": "en",
-    "version": "3.11.1",
+    "version": "3.11.2",
     "background": {
       "service_worker": "chromeExtension.js",
       "type": "module"

--- a/src/scripts/extensions/edge/manifest.json
+++ b/src/scripts/extensions/edge/manifest.json
@@ -5,7 +5,7 @@
     "name": "OneNote Web Clipper",
     "description": "__MSG_appDesc__",
     "default_locale": "en",
-    "version": "3.11.1",
+    "version": "3.11.2",
     "background": {
         "service_worker": "edgeExtension.js",
         "type": "module"

--- a/src/scripts/extensions/edge/package/AppXManifest.xml
+++ b/src/scripts/extensions/edge/package/AppXManifest.xml
@@ -7,7 +7,7 @@
 	<Identity 
 		Name="Microsoft.OneNoteWebClipper" 
 		Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" 
-		Version="3.11.1.0" />
+		Version="3.11.2.0" />
 
 	<Properties> 
 		<DisplayName>OneNote Web Clipper</DisplayName> 

--- a/src/scripts/extensions/extensionBase.ts
+++ b/src/scripts/extensions/extensionBase.ts
@@ -30,7 +30,7 @@ export abstract class ExtensionBase<TWorker extends ExtensionWorkerBase<TTab, TT
 	protected clipperData: ClipperData;
 	protected auth: AuthenticationHelper;
 	protected clientInfo: SmartValue<ClientInfo>;
-	protected static version = "3.11.1";
+	protected static version = "3.11.2";
 
 	constructor(clipperType: ClientType, clipperData: ClipperData) {
 		this.workers = [];


### PR DESCRIPTION
Bumps the extension version from **3.11.1** to **3.11.2**.

### Changes included since 3.11.1
- #662 — Dark mode for Web Clipper (system-adaptive)
- #667 — Enable Sign out during the initial full-page capture
- #668 — Fix increase/decrease font-size buttons not appearing disabled at min/max bounds in Article mode
- #669 — Announce the actual font-size value on increase/decrease in Article mode
- #661 — Restore collapsed-by-default location dropdown
- #660 — Dependency upgrade and V1 dead-code cleanup

### Files updated
- `package.json`
- `package-lock.json`
- `src/scripts/extensions/chrome/manifest.json`
- `src/scripts/extensions/edge/manifest.json`
- `src/scripts/extensions/edge/package/AppXManifest.xml`
- `src/scripts/extensions/extensionBase.ts`
- `CHANGELOG.md`
